### PR TITLE
improve input mask

### DIFF
--- a/packages/input-mask/dev/index.html
+++ b/packages/input-mask/dev/index.html
@@ -9,6 +9,7 @@
   <style>
     html {
       font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+      font-size: 20px;
     }
 
     body {
@@ -23,6 +24,22 @@
 
     * {
       margin: 0;
+    }
+
+    #root {
+      padding: 1em;
+    }
+
+    label {
+      display: inline-block;
+      min-width: 6em;
+      text-align: right;
+    }
+
+    input {
+      font: inherit;
+      margin: 0.5em;
+      width: 15em;
     }
   </style>
 </head>

--- a/packages/input-mask/dev/index.tsx
+++ b/packages/input-mask/dev/index.tsx
@@ -1,14 +1,23 @@
 import { Component } from "solid-js";
 import { render } from "solid-js/web";
-import { createInputMask } from '../src';
+import { anyMaskToFn, createInputMask } from '../src';
 
 const App: Component = () => {
+  const ibanMask = anyMaskToFn('aa99999999999999999999');
   return (
     <div class="p-24 box-border w-full min-h-screen flex flex-col justify-center items-center space-y-4 bg-gray-800 text-white">
       <div class="wrapper-v">
         <h4>Input Mask</h4>
         <label for="isodate">ISO Date:</label>
-        <input type="text" id="isodate" placeholder="YYYY-MM-DD" onInput={createInputMask('9999-99-99')} />
+        <input type="text" id="isodate" placeholder="YYYY-MM-DD" onInput={createInputMask('9999-99-99')} /><br />
+        <label for="cardexpiry">Card Expiry:</label>
+        <input type="text" id="cardexpiry" placeholder="MM/YYYY" onInput={createInputMask('99/9999')} /><br />
+        <label for="iban" title="International Banking Accound Number">IBAN:</label>
+        <input type="text" id="iban" placeholder="XX0000000000000000000000" onInput={createInputMask((value, selection) => {
+          const maskOutput = ibanMask(value, selection)
+          maskOutput[0] = maskOutput[0].toUpperCase();
+          return maskOutput;
+        })} /><br />
       </div>
     </div>
   );

--- a/packages/input-mask/src/index.ts
+++ b/packages/input-mask/src/index.ts
@@ -14,8 +14,8 @@ export const stringMaskToArray = (mask: string) =>
     c =>
       ({
         9: /\d/,
-        a: /\w/,
-        "*": /[\d\w]/
+        a: /[a-z]/i,
+        "*": /\w/
       }[c] || c)
   );
 


### PR DESCRIPTION
Small fix (for "a" in string masks not to match numbers) and improvements for the demo page when running `yarn dev`.