### PR TITLE
[RAF] Remove FPS limiting to consider other possible features

### DIFF
--- a/packages/raf/README.md
+++ b/packages/raf/README.md
@@ -48,38 +48,6 @@ function createRAF(
 
 To respect clients refresh rate, timeStamp should be used to calculate how much the animation should progress in a given frame, otherwise the animation will run faster on high refresh rate screens. As an example: A screen refreshing at 300fps will run the animations 5x faster than a screen with 60fps if you use other forms of time keeping that don't consider this. Please see https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame
 
-## `targetFPS`
-
-A primitive for wrapping `window.requestAnimationFrame` callback function to limit the execution of the callback to specified number of FPS.
-
-Keep in mind that limiting FPS is achieved by not executing a callback if the frames are above defined limit. This can lead to not consistant frame duration.
-
-The `targetFPS` primitive takes two arguments:
-
-- `callback` - The callback to run each _allowed_ frame
-- `fps` - The target FPS limit
-
-```ts
-import createRAF, { targetFPS } from "@solid-primitives/raf";
-
-const [running, start, stop] = createRAF(
-  targetFPS(timeStamp => console.log("Time stamp is", timeStamp), 60)
-);
-
-// the target fps value can be a reactive sigmal
-const [fps, setFps] = createSignal(60);
-createRAF(targetFPS((timestamp) => {...}, fps));
-```
-
-#### Definition
-
-```ts
-function targetFPS(
-  callback: FrameRequestCallback,
-  fps: MaybeAccessor<number>
-): FrameRequestCallback;
-```
-
 ## Demo
 
 You may view a working example here: https://codesandbox.io/s/solid-primitives-raf-demo-4xvmjd?file=/src/index.tsx
@@ -112,10 +80,16 @@ Patch by [titoBouzout](https://www.github.com/titoBouzout):
 - allow to limit fps above 60fps
 - remove `runImmediately` – animation loop will have to be initialized manually.
 - respect `requestAnimationFrame` signature and give `timeStamp` back to the callback instead of a `deltaTime`
-- use cancelAnimationFrame instead of !isRunning
+- use `cancelAnimationFrame` instead of `!isRunning`
 
 Patch by [thetarnav](https://www.github.com/thetarnav):
 
 - Move FPS limiting feature into a separate `targetFPS` primitive
+
+  3.0.0
+
+Patch by [titoBouzout](https://www.github.com/titoBouzout):
+
+- Remove FPS limiting feature till consensus can be reached about providing other features, like passing down a `delta` or how many frames have been painted in a given second, options that could be used while limiting frames or not.
 
 </details>

--- a/packages/raf/dev/index.tsx
+++ b/packages/raf/dev/index.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, Show, createEffect } from "solid-js";
+import { Component } from "solid-js";
 import { render } from "solid-js/web";
 import RAF from "./raf";
 
@@ -7,19 +7,6 @@ const App: Component = () => {
     <div>
       <h1>Target FPS Dev Test</h1>
       <hr />
-      <RAF targetFPS={1} />
-      <RAF targetFPS={15} />
-      <RAF targetFPS={24} />
-      <RAF targetFPS={30} />
-      <RAF targetFPS={44} />
-      <RAF targetFPS={60} />
-      <RAF targetFPS={90} />
-      <RAF targetFPS={120} />
-      <RAF targetFPS={130} />
-      <RAF targetFPS={140} />
-      <RAF targetFPS={240} />
-      <RAF targetFPS={300} />
-      <RAF targetFPS={Infinity} />
       <RAF />
     </div>
   );

--- a/packages/raf/dev/raf.tsx
+++ b/packages/raf/dev/raf.tsx
@@ -1,10 +1,10 @@
 import { createSignal, Show } from "solid-js";
 
-import createRAF, { targetFPS } from "../src";
+import createRAF from "../src";
 
 const targetRuns = 500;
 
-export default (props: { targetFPS?: number }) => {
+export default () => {
   const [sum, setSum] = createSignal(0);
   let runs = -1;
   let last = 0;
@@ -19,9 +19,7 @@ export default (props: { targetFPS?: number }) => {
     if (runs === targetRuns) handleStop();
   };
 
-  const [running, start, stop] = createRAF(
-    props.targetFPS ? targetFPS(eachFrame, props.targetFPS) : eachFrame
-  );
+  const [running, start, stop] = createRAF(eachFrame);
 
   const [avgMs, setAvgMs] = createSignal(0);
   const [avgFps, setAvgFps] = createSignal(0);
@@ -47,8 +45,8 @@ export default (props: { targetFPS?: number }) => {
           | Running{" "}
         </Show>
         <span>
-          | Target FPS: {props.targetFPS || "UNCAPPED"}| Runs: {numRuns()}| AVG Ms: {avgMs()}| AVG
-          FPS {avgFps()}| Current FPS: {1000 / (sum() / runs)}
+          UNCAPPED | Runs: {numRuns()}| AVG Ms: {avgMs()}| AVG FPS {avgFps()}| Current FPS:{" "}
+          {1000 / (sum() / runs)}
         </span>
       </span>
     </div>

--- a/packages/raf/package.json
+++ b/packages/raf/package.json
@@ -1,70 +1,69 @@
 {
-  "name": "@solid-primitives/raf",
-  "version": "2.0.0",
-  "description": "Primitive that facilitates RAF functionality",
-  "author": "David Di Biase <dave.dibiase@gmail.com>",
-  "contributors": [
-    "Tito <tito.bouzout@gmail.com>",
-    "Damian Tarnawski <gthetarnav@gmail.com>"
-  ],
-  "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/raf",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/solidjs-community/solid-primitives.git"
-  },
-  "primitive": {
-    "name": "raf",
-    "stage": 3,
-    "list": [
-      "createRAF",
-      "targetFPS"
-    ],
-    "category": "Display & Media"
-  },
-  "files": [
-    "dist"
-  ],
-  "private": false,
-  "sideEffects": false,
-  "type": "module",
-  "main": "./dist/server.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    "node": {
-      "import": "./dist/server.js",
-      "require": "./dist/server.cjs"
-    },
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
-  },
-  "scripts": {
-    "start": "vite serve dev --host",
-    "dev": "yarn start",
-    "build": "tsup"
-  },
-  "keywords": [
-    "raf",
-    "animation",
-    "requestAnimationFrame",
-    "solid",
-    "primitives"
-  ],
-  "devDependencies": {
-    "prettier": "^2.6.1",
-    "tslib": "^2.3.1",
-    "tsup": "^5.12.1",
-    "typescript": "^4.6.3",
-    "unocss": "0.28.1",
-    "vite": "2.8.6",
-    "vite-plugin-solid": "2.2.6",
-    "vitest": "^0.7.11"
-  },
-  "peerDependencies": {
-    "solid-js": "^1.3.0"
-  },
-  "dependencies": {
-    "@solid-primitives/utils": "^0.5.3"
-  }
+	"name": "@solid-primitives/raf",
+	"version": "3.0.0",
+	"description": "Primitive that facilitates RAF functionality",
+	"author": "David Di Biase <dave.dibiase@gmail.com>",
+	"contributors": [
+		"Tito <tito.bouzout@gmail.com>",
+		"Damian Tarnawski <gthetarnav@gmail.com>"
+	],
+	"license": "MIT",
+	"homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/raf",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/solidjs-community/solid-primitives.git"
+	},
+	"primitive": {
+		"name": "raf",
+		"stage": 3,
+		"list": [
+			"createRAF",
+			"targetFPS"
+		],
+		"category": "Display & Media"
+	},
+	"files": [
+		"dist"
+	],
+	"private": false,
+	"sideEffects": false,
+	"type": "module",
+	"main": "./dist/server.cjs",
+	"module": "./dist/index.js",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		"node": {
+			"import": "./dist/server.js",
+			"require": "./dist/server.cjs"
+		},
+		"import": "./dist/index.js",
+		"require": "./dist/index.cjs"
+	},
+	"scripts": {
+		"dev": "vite serve dev --host",
+		"build": "tsup"
+	},
+	"keywords": [
+		"raf",
+		"animation",
+		"requestAnimationFrame",
+		"solid",
+		"primitives"
+	],
+	"devDependencies": {
+		"prettier": "^2.6.1",
+		"tslib": "^2.3.1",
+		"tsup": "^5.12.1",
+		"typescript": "^4.6.3",
+		"unocss": "0.28.1",
+		"vite": "2.8.6",
+		"vite-plugin-solid": "2.2.6",
+		"vitest": "^0.7.11"
+	},
+	"peerDependencies": {
+		"solid-js": "^1.3.0"
+	},
+	"dependencies": {
+		"@solid-primitives/utils": "^0.5.3"
+	}
 }

--- a/packages/raf/src/index.ts
+++ b/packages/raf/src/index.ts
@@ -1,5 +1,5 @@
-import { Fn, isFunction, MaybeAccessor } from "@solid-primitives/utils";
-import { createSignal, createMemo, Accessor, onCleanup } from "solid-js";
+import { Fn } from "@solid-primitives/utils";
+import { createSignal, Accessor, onCleanup } from "solid-js";
 
 /**
  * A primitive creating reactive `window.requestAnimationFrame`, that is automatically disposed onCleanup.
@@ -39,44 +39,4 @@ function createRAF(
   return [running, start, stop];
 }
 
-/**
- * A primitive for wrapping `window.requestAnimationFrame` callback function to limit the execution of the callback to specified number of FPS.
- *
- * Keep in mind that limiting FPS is achieved by not executing a callback if the frames are above defined limit. This can lead to not consistant frame duration.
- *
- * @see https://github.com/solidjs-community/solid-primitives/tree/main/packages/raf#targetFPS
- * @param callback The callback to run each *allowed* frame
- * @param fps The target FPS limit
- * @returns Wrapped RAF callback
- *
- * @example
- * const [running, start, stop] = createRAF(
- *   targetFPS(() => {...}, 60)
- * );
- */
-function targetFPS(
-  callback: FrameRequestCallback,
-  fps: MaybeAccessor<number>
-): FrameRequestCallback {
-  const interval = isFunction(fps)
-    ? createMemo(() => Math.floor(1000 / (fps as Accessor<number>)()))
-    : (() => {
-        const interval = Math.floor(1000 / fps);
-        return () => interval;
-      })();
-
-  let elapsed = 0;
-  let lastRun = 0;
-  let missedBy = 0;
-
-  return timeStamp => {
-    elapsed = timeStamp - lastRun;
-    if (Math.ceil(elapsed + missedBy) >= interval()) {
-      lastRun = timeStamp;
-      missedBy = Math.max(elapsed - interval(), 0);
-      callback(timeStamp);
-    }
-  };
-}
-
-export { createRAF, createRAF as default, targetFPS };
+export { createRAF, createRAF as default };

--- a/packages/raf/src/server.ts
+++ b/packages/raf/src/server.ts
@@ -4,6 +4,5 @@ import * as API from ".";
 const createRAF: typeof API.createRAF = () => {
   return [() => false, noop, noop];
 };
-const targetFPS: typeof API.targetFPS = cb => cb;
 
-export { createRAF, createRAF as default, targetFPS };
+export { createRAF, createRAF as default };


### PR DESCRIPTION
Off the top of my head, I could think that what almost any **fancy** requestAnimationFrame need is:
- `targetFPS`, run at most N FPS
- tell at how many FPS we're running, to provide feedback, maybe only for development, but nice to have
- tell the `delta` value, how much time elapsed since the last run

What most people need is none of the above, but that's not the point. Others would find these values to be passed down useful.

I'm proposing to start over, because this is a fresh and breaking change, and having people to use it, will make them to then have to change the way it's used in the future, and nobody likes that. The proposal made in https://github.com/solidjs-community/solid-primitives/pull/78 considered the above, but what got merged somehow is not considering it.

The `targetFPS` callback that got implemented was very clever, but how do we add additional features that won't get repeated around and won't require changing signatures.