### PR TITLE
Added official primitives graphics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://raw.githubusercontent.com/solidjs-community/solid-primitives/main/assets/banner.png" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=%20" alt="Solid Primitives">
 </p>
 
 # Solid Primitives

--- a/packages/active-element/README.md
+++ b/packages/active-element/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Active%20Element" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Active%20Element" alt="Solid Primitives Active Element">
 </p>
 
 # @solid-primitives/active-element

--- a/packages/active-element/README.md
+++ b/packages/active-element/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Active%20Element" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/active-element
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -5,6 +5,9 @@ Package: "@solid-primitives/analytics"
 Primitives: createAnalytics
 Category: Utilities
 ---
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Analytics" alt="Solid Primitives">
+</p>
 
 # @solid-primitives/analytics
 

--- a/packages/analytics/README.md
+++ b/packages/analytics/README.md
@@ -6,7 +6,7 @@ Primitives: createAnalytics
 Category: Utilities
 ---
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Analytics" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Analytics" alt="Solid Primitives Analytics">
 </p>
 
 # @solid-primitives/analytics

--- a/packages/audio/README.md
+++ b/packages/audio/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Audio" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/audio
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/audio/README.md
+++ b/packages/audio/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Audio" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Audio" alt="Solid Primitives Audio">
 </p>
 
 # @solid-primitives/audio

--- a/packages/clipboard/README.md
+++ b/packages/clipboard/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Clipboard" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Clipboard" alt="Solid Primitives Clipboard">
 </p>
 
 # @solid-primitives/clipboard

--- a/packages/clipboard/README.md
+++ b/packages/clipboard/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Clipboard" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/clipboard
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/composites/README.md
+++ b/packages/composites/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Composites" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/composites
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/composites/README.md
+++ b/packages/composites/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Composites" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Composites" alt="Solid Primitives Composites">
 </p>
 
 # @solid-primitives/composites

--- a/packages/connectivity/README.md
+++ b/packages/connectivity/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Connectivity" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Connectivity" alt="Solid Primitives Connectivity">
 </p>
 
 # @solid-primitives/connectivity

--- a/packages/connectivity/README.md
+++ b/packages/connectivity/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Connectivity" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/connectivity
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Context" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Context" alt="Solid Primitives Context">
 </p>
 
 # @solid-primitives/context

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Context" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/context
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Date" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Date" alt="Solid Primitives Date">
 </p>
 
 # @solid-primitives/date

--- a/packages/date/README.md
+++ b/packages/date/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Date" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/date
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/debounce/README.md
+++ b/packages/debounce/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Debounce" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Debounce" alt="Solid Primitives Debounce">
 </p>
 
 # @solid-primitives/debounce

--- a/packages/debounce/README.md
+++ b/packages/debounce/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Debounce" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/debounce
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/destructure/README.md
+++ b/packages/destructure/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Destructure" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Destructure" alt="Solid Primitives Destructure">
 </p>
 
 # @solid-primitives/destructure

--- a/packages/destructure/README.md
+++ b/packages/destructure/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Destructure" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/destructure
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/devices/README.md
+++ b/packages/devices/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Devices" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Devices" alt="Solid Primitives Devices">
 </p>
 
 # @solid-primitives/devices

--- a/packages/devices/README.md
+++ b/packages/devices/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Devices" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/devices
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Event%20Bus" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Event%20Bus" alt="Solid Primitives Event Bus">
 </p>
 
 # @solid-primitives/event-bus

--- a/packages/event-bus/README.md
+++ b/packages/event-bus/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Event%20Bus" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/event-bus
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/event-listener/README.md
+++ b/packages/event-listener/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Event%20Listener" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Event%20Listener" alt="Solid Primitives Event Listener">
 </p>
 
 # @solid-primitives/event-listener

--- a/packages/event-listener/README.md
+++ b/packages/event-listener/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Event%20Listener" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/event-listener
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/event-props/README.md
+++ b/packages/event-props/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Event%20Props" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/event-props
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/event-props/README.md
+++ b/packages/event-props/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Event%20Props" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Event%20Props" alt="Solid Primitives Event Props">
 </p>
 
 # @solid-primitives/event-props

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Fetch" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/fetch
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Fetch" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Fetch" alt="Solid Primitives Fetch">
 </p>
 
 # @solid-primitives/fetch

--- a/packages/fullscreen/README.md
+++ b/packages/fullscreen/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Fullscreen" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/fullscreen
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/fullscreen/README.md
+++ b/packages/fullscreen/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Fullscreen" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Fullscreen" alt="Solid Primitives Fullscreen">
 </p>
 
 # @solid-primitives/fullscreen

--- a/packages/geolocation/README.md
+++ b/packages/geolocation/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Geolocation" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Geolocation" alt="Solid Primitives Geolocation">
 </p>
 
 # @solid-primitives/geolocation

--- a/packages/geolocation/README.md
+++ b/packages/geolocation/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Geolocation" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/geolocation
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/gestures/README.md
+++ b/packages/gestures/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Gestures" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/gestures
 
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)

--- a/packages/gestures/README.md
+++ b/packages/gestures/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Gestures" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Gestures" alt="Solid Primitives Gestures">
 </p>
 
 # @solid-primitives/gestures

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Graphql" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Graphql" alt="Solid Primitives Graphql">
 </p>
 
 # @solid-primitives/graphql

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Graphql" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/graphql
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=I18n" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/i18n
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=I18n" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=I18n" alt="Solid Primitives I18n">
 </p>
 
 # @solid-primitives/i18n

--- a/packages/immutable/README.md
+++ b/packages/immutable/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Immutable" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/immutable
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/immutable/README.md
+++ b/packages/immutable/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Immutable" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Immutable" alt="Solid Primitives Immutable">
 </p>
 
 # @solid-primitives/immutable

--- a/packages/input-mask/README.md
+++ b/packages/input-mask/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Input%20Mask" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Input%20Mask" alt="Solid Primitives Input Mask">
 </p>
 
 # @solid-primitives/input-mask

--- a/packages/input-mask/README.md
+++ b/packages/input-mask/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Input%20Mask" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/input-mask
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/intersection-observer/README.md
+++ b/packages/intersection-observer/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Intersection%20Observer" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/intersection-observer
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/intersection-observer/README.md
+++ b/packages/intersection-observer/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Intersection%20Observer" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Intersection%20Observer" alt="Solid Primitives Intersection Observer">
 </p>
 
 # @solid-primitives/intersection-observer

--- a/packages/keyed/README.md
+++ b/packages/keyed/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Keyed" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Keyed" alt="Solid Primitives Keyed">
 </p>
 
 # @solid-primitives/keyed

--- a/packages/keyed/README.md
+++ b/packages/keyed/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Keyed" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/keyed
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/map/README.md
+++ b/packages/map/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Map" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/map
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/map/README.md
+++ b/packages/map/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Map" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Map" alt="Solid Primitives Map">
 </p>
 
 # @solid-primitives/map

--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Media" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/media
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Media" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Media" alt="Solid Primitives Media">
 </p>
 
 # @solid-primitives/media

--- a/packages/memo/README.md
+++ b/packages/memo/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Memo" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Memo" alt="Solid Primitives Memo">
 </p>
 
 # @solid-primitives/memo

--- a/packages/memo/README.md
+++ b/packages/memo/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Memo" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/memo
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/mouse/README.md
+++ b/packages/mouse/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Mouse" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/mouse
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/mouse/README.md
+++ b/packages/mouse/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Mouse" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Mouse" alt="Solid Primitives Mouse">
 </p>
 
 # @solid-primitives/mouse

--- a/packages/mutation-observer/README.md
+++ b/packages/mutation-observer/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Mutation%20Observer" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/mutation-observer
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/mutation-observer/README.md
+++ b/packages/mutation-observer/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Mutation%20Observer" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Mutation%20Observer" alt="Solid Primitives Mutation Observer">
 </p>
 
 # @solid-primitives/mutation-observer

--- a/packages/permission/README.md
+++ b/packages/permission/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Permission" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/permission
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/permission/README.md
+++ b/packages/permission/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Permission" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Permission" alt="Solid Primitives Permission">
 </p>
 
 # @solid-primitives/permission

--- a/packages/pointer/README.md
+++ b/packages/pointer/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Pointer" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Pointer" alt="Solid Primitives Pointer">
 </p>
 
 # @solid-primitives/pointer

--- a/packages/pointer/README.md
+++ b/packages/pointer/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Pointer" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/pointer
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/props/README.md
+++ b/packages/props/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Props" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/props
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/props/README.md
+++ b/packages/props/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Props" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Props" alt="Solid Primitives Props">
 </p>
 
 # @solid-primitives/props

--- a/packages/raf/README.md
+++ b/packages/raf/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Ref" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/raf
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/raf/README.md
+++ b/packages/raf/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Ref" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Ref" alt="Solid Primitives Ref">
 </p>
 
 # @solid-primitives/raf

--- a/packages/refs/README.md
+++ b/packages/refs/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Refs" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Refs" alt="Solid Primitives Refs">
 </p>
 
 # @solid-primitives/refs

--- a/packages/refs/README.md
+++ b/packages/refs/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Refs" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/refs
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/resize-observer/README.md
+++ b/packages/resize-observer/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Resize%20Observer" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/resize-observer
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/resize-observer/README.md
+++ b/packages/resize-observer/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Resize%20Observer" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Resize%20Observer" alt="Solid Primitives Resize Observer">
 </p>
 
 # @solid-primitives/resize-observer

--- a/packages/rootless/README.md
+++ b/packages/rootless/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Rootless" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Rootless" alt="Solid Primitives Rootless">
 </p>
 
 # @solid-primitives/rootless

--- a/packages/rootless/README.md
+++ b/packages/rootless/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Rootless" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/rootless
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/script-loader/README.md
+++ b/packages/script-loader/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Script%20Loader" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Script%20Loader" alt="Solid Primitives Script Loader">
 </p>
 
 # @solid-primitives/script-loader

--- a/packages/script-loader/README.md
+++ b/packages/script-loader/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Script%20Loader" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/script-loader
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/scroll/README.md
+++ b/packages/scroll/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Scroll" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Scroll" alt="Solid Primitives Scroll">
 </p>
 
 # @solid-primitives/scroll

--- a/packages/scroll/README.md
+++ b/packages/scroll/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Scroll" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/scroll
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/set/README.md
+++ b/packages/set/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Set" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/set
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/set/README.md
+++ b/packages/set/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Set" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Set" alt="Solid Primitives Set">
 </p>
 
 # @solid-primitives/set

--- a/packages/share/README.md
+++ b/packages/share/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Share" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Share" alt="Solid Primitives Share">
 </p>
 
 # @solid-primitives/share

--- a/packages/share/README.md
+++ b/packages/share/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Share" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/share
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/signal-builders/README.md
+++ b/packages/signal-builders/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Signal%20Builders" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/signal-builders
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/signal-builders/README.md
+++ b/packages/signal-builders/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Signal%20Builders" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Signal%20Builders" alt="Solid Primitives Signal Builders">
 </p>
 
 # @solid-primitives/signal-builders

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Storage" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/storage
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Storage" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Storage" alt="Solid Primitives Storage">
 </p>
 
 # @solid-primitives/storage

--- a/packages/stream/README.md
+++ b/packages/stream/README.md
@@ -1,3 +1,8 @@
+
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Stream" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/stream
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/stream/README.md
+++ b/packages/stream/README.md
@@ -1,6 +1,6 @@
 
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Stream" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Stream" alt="Solid Primitives Stream">
 </p>
 
 # @solid-primitives/stream

--- a/packages/throttle/README.md
+++ b/packages/throttle/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Throttle" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Throttle" alt="Solid Primitives Throttle">
 </p>
 
 # @solid-primitives/throttle

--- a/packages/throttle/README.md
+++ b/packages/throttle/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Throttle" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/throttle
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/timer/README.md
+++ b/packages/timer/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Timer" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/timer
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/timer/README.md
+++ b/packages/timer/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Timer" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Timer" alt="Solid Primitives Timer">
 </p>
 
 # @solid-primitives/timer

--- a/packages/tween/README.md
+++ b/packages/tween/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Tween" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/tween
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/tween/README.md
+++ b/packages/tween/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Tween" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Tween" alt="Solid Primitives Tween">
 </p>
 
 # @solid-primitives/tween

--- a/packages/until/README.md
+++ b/packages/until/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Until" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Until" alt="Solid Primitives Until">
 </p>
 
 # @solid-primitives/until

--- a/packages/until/README.md
+++ b/packages/until/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Until" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/until
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Utils" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Utils" alt="Solid Primitives Utils">
 </p>
 
 # @solid-primitives/utils

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Utils" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/utils
 
 Solid Primitives Utilities is a support and helper package for a number of primitives in our library. Please free to augment or centralize useful utilities and methods in this package for sharing.

--- a/packages/visibility-observer/README.md
+++ b/packages/visibility-observer/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Visibility%20Observer" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/visibility-observer
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/visibility-observer/README.md
+++ b/packages/visibility-observer/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Visibility%20Observer" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Visibility%20Observer" alt="Solid Primitives Visibility Observer">
 </p>
 
 # @solid-primitives/visibility-observer

--- a/packages/websocket/README.md
+++ b/packages/websocket/README.md
@@ -6,6 +6,10 @@ Primitives: createWebsocket
 Category: Network
 ---
 
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Websocket" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/websocket
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)

--- a/packages/websocket/README.md
+++ b/packages/websocket/README.md
@@ -7,7 +7,7 @@ Category: Network
 ---
 
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Websocket" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Websocket" alt="Solid Primitives Websocket">
 </p>
 
 # @solid-primitives/websocket

--- a/packages/workers/README.md
+++ b/packages/workers/README.md
@@ -1,5 +1,5 @@
 <p>
-  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Workers" alt="Solid Primitives">
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Workers" alt="Solid Primitives Workers">
 </p>
 
 # @solid-primitives/workers

--- a/packages/workers/README.md
+++ b/packages/workers/README.md
@@ -1,3 +1,7 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=Workers" alt="Solid Primitives">
+</p>
+
 # @solid-primitives/workers
 
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)


### PR DESCRIPTION
Since the release of the official [Solid Assets](https://github.com/solidjs/solid-assets), I thought it would be nice to apply the graphics to all the primitives in the repository.

This pull request applies graphics to every `README.md` in the repository and updated graphics for the root `README.md`