### PR TITLE
make node-fetch optional

### DIFF
--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -19,6 +19,18 @@ npm install @solid-primitives/fetch
 yarn add @solid-primitives/fetch
 ```
 
+### Additional requirements
+
+Since nodejs 17.5.0, the fetch API is available in node via the `--experimental-fetch` command line option. From version 18.0.0 upwards, it is supposed to become available out of the box. If you want to use `createFetch` on your server, but your nodejs version does not support the fetch API, you need to install node-fetch alongside this primitive:
+
+```bash
+npm install node-fetch
+# or
+yarn add node-fetch
+```
+
+If you fail to install it, but still run it on the server, you should see a nice error message that asks you to install it in the logs and your requests are all rejected.
+
 ## How to use it
 
 ```ts
@@ -65,5 +77,9 @@ Released CJS and SSR support.
 1.0.6
 
 Added missing server entry compile in TSUP and updated to Solid.
+
+1.0.7
+
+Improve server entry to make node-fetch optional in cases it is not needed.
 
 </details>

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/fetch",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Primitive that wraps fetch requests",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "license": "MIT",
@@ -47,10 +47,8 @@
     "solid",
     "primitives"
   ],
-  "dependencies": {
-    "node-fetch": "^2.6.6"
-  },
   "devDependencies": {
+    "@types/node": "^17.0.23",
     "jsdom": "^19.0.0",
     "prettier": "^2.0.5",
     "solid-register": "^0.1.5",
@@ -60,6 +58,12 @@
     "uvu": "^0.5.2"
   },
   "peerDependencies": {
-    "solid-js": "^1.3.1"
+    "node-fetch": ">=2.0.0",
+    "solid-js": ">=1.3.0"
+  },
+  "peerDependenciesMeta": {
+    "node-fetch": {
+      "optional": true
+    }
   }
 }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -21,7 +21,7 @@
     "dist"
   ],
   "private": false,
-  "sideEffects": false,
+  "sideEffects": true,
   "type": "module",
   "main": "./dist/server.cjs",
   "module": "./dist/index.js",

--- a/packages/fetch/src/server.ts
+++ b/packages/fetch/src/server.ts
@@ -1,7 +1,15 @@
-import fetch from "node-fetch";
-
 if (!globalThis.fetch) {
-  Object.assign(globalThis, { fetch });
+  Object.assign(globalThis, { fetch: (...args: any[]) => {
+    try {
+      const fetch = require("node-fetch");
+      Object.assign(globalThis, { fetch });
+      return fetch(...args);
+    } catch(e) {
+      console.warn('"\x1b[33m⚠️ package missing to run createFetch on the server.\n Please run:\x1b[0m\n\nnpm i node-fetch\n"');
+      Object.assign(globalThis, { fetch: () => Promise.reject() });
+      return Promise.reject();
+    }
+  }});
 }
 
 export * from "./index";

--- a/packages/fetch/tsconfig.json
+++ b/packages/fetch/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "emitDeclarationOnly": false
+    "emitDeclarationOnly": false,
+    "types": ["node"]
   },
-  "include": ["./src"]
+  "include": ["./src"],
 }


### PR DESCRIPTION
To handle issue#88, I changed the server entry so that node-fetch was only required once fetch was called for the first time, with a soft failure function emitting just a nice console message and rejecting every request.

I've used the same pattern in solid-register for optional dependencies and found it very effective.