### PR TITLE
Document event-listener w.r.t. refs

### DIFF
--- a/packages/event-listener/README.md
+++ b/packages/event-listener/README.md
@@ -46,6 +46,12 @@ const clear = createEventListener(
 // to clear all of the event listeners
 clear();
 
+// when element is not wrapped in an accessor,
+// runs in createEffect so refs are already bound:
+let ref;
+createEventListener(ref, "mousemove", e => {});
+return <div ref={ref}/>;
+
 // target element and event name can be reactive signals
 const [ref, setRef] = createSignal<HTMLElement>();
 const [name, setName] = createSignal("mousemove");

--- a/packages/event-listener/README.md
+++ b/packages/event-listener/README.md
@@ -46,16 +46,17 @@ const clear = createEventListener(
 // to clear all of the event listeners
 clear();
 
-// when element is not wrapped in an accessor,
-// runs in createEffect so refs are already bound:
-let ref;
-createEventListener(ref, "mousemove", e => {});
-return <div ref={ref}/>;
-
 // target element and event name can be reactive signals
 const [ref, setRef] = createSignal<HTMLElement>();
 const [name, setName] = createSignal("mousemove");
 createEventListener(ref, name, e => {}, { passive: true });
+
+// also runs in createEffect so refs are already bound
+// (but variable refs need to be wrapped in functions)
+let ref;
+createEventListener(() => ref, "mousemove", e => {});
+return <div ref={ref}/>;
+
 ```
 
 #### Custom events


### PR DESCRIPTION
I had to read the code to check whether this was the case: `createEventListener` can take standard `let` refs. The current examples use `document.getElementById` and signal refs, but not normal refs.