### PR TITLE
rootless: refactor `runWith___` functions (closes #102)

### DIFF
--- a/packages/rootless/README.md
+++ b/packages/rootless/README.md
@@ -7,14 +7,13 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/rootless?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-primitives/rootless)
 [![version](https://img.shields.io/npm/v/@solid-primitives/rootless?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/rootless)
-[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-2.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
-A collection of helpers that aim to simplify using reactive primitives outside of reactive roots, asynchronously after the root initialization, or just working with roots in general.
+A collection of helpers that aim to simplify using reactive primitives outside of reactive roots, and managing disposal of reactive roots.
 
-- [`createSubRoot`](#createSubRoot) - Creates a reactive **sub root**, that will be automatically disposed when it's owner does.
+- [`createBranch`](#createBranch) - Creates a reactive **root branch**, that will be automatically disposed when it's owner does.
 - [`createCallback`](#createCallback) - A wrapper for creating callbacks with `runWithOwner`.
-- [`runWithRoot`](#runWithRoot) - Use reactive primitives outside of reactive roots.
-- [`runWithSubRoot`](#runWithSubRoot) - Like `runWithRoot`, but creates a sub root instead.
+- [`createDisposable`](#createDisposable) - For disposing computations early – before the root cleanup.
 
 ## Installation
 
@@ -24,35 +23,35 @@ npm install @solid-primitives/rootless
 yarn add @solid-primitives/rootless
 ```
 
-## `createSubRoot`
+## `createBranch`
 
-Creates a reactive **sub root**, that will be automatically disposed when it's owner does.
+Creates a reactive **root branch**, that will be automatically disposed when it's owner does.
 
 ### How to use it
 
-Use it for creating roots nested in other roots.
+Use it for nested roots _(literally nested, or provided manually to dependency array)_ that should be disposed before or with their owner.
 
 ```ts
-import { createSubRoot } from "@solid-primitives/rootless";
+import { createBranch } from "@solid-primitives/rootless";
 
 createRoot(dispose => {
+  createBranch(disposeBranch => {
+    // computations will be disposed with branch
+    createEffect(() => {...});
 
-   createSubRoot(disposeSubRoot => {
-      createEffect(...)
+    // disposes only the branch
+    disposeBranch();
+  });
 
-      // disposes only the sub root
-      disposeSubRoot()
-   })
-
-   // disposes the outer root, AND all the nested sub roots
-   dispose()
-})
+  // disposes the outer root, AND all the nested branches
+  dispose();
+});
 ```
 
 ### Definition
 
 ```ts
-function createSubRoot<T>(fn: (dispose: () => void) => T, owner?: Owner | null): T;
+function createBranch<T>(fn: (dispose: VoidFunction) => T, ...owners: (Owner | null)[]): T;
 ```
 
 ## `createCallback`
@@ -82,28 +81,24 @@ const handleClick = createCallback(() => {
 ### Definition
 
 ```ts
-const createCallback = <T extends AnyFunction>(
-  callback: T,
-  owner?: Owner | null
-): T
+function createCallback<T extends AnyFunction>(callback: T, owner?: Owner | null): T;
 ```
 
-## `runWithRoot`
+## `createDisposable`
 
-Helper for simplifying usage of Solid's reactive primitives outside of components (reactive roots).
+For disposing computations early – before the root cleanup.
 
 ### How to use it
 
-```ts
-// when fn doesn't return anything
-const dispose = runWithRoot(() =>
-  createEffect(() => {
-    console.log(count());
-  })
-);
+Executes provided function in a [`createBranch`](#createBranch) _(auto-disposing root)_, and returns a dispose function, to dispose computations used inside before automatic cleanup.
 
-// when fn returns something
-const [double, dispose] = runWithRoot(() => createMemo(() => count() * 2));
+```ts
+const dispose = createDisposable(dispose => {
+   createEffect(() => {...})
+});
+
+// dispose later (if not, will dispose automatically)
+dispose()
 ```
 
 ### Definition
@@ -112,34 +107,7 @@ const [double, dispose] = runWithRoot(() => createMemo(() => count() * 2));
 type runWithRootReturn<T> = T extends void | undefined | null
   ? Dispose
   : [returns: T, dispose: Dispose];
-const runWithRoot = <T>(fn: () => T, detachedOwner?: Owner): runWithRootReturn<T>
-```
-
-## `runWithSubRoot`
-
-Helper for simplifying usage of Solid's reactive primitives outside of components (reactive roots). A **sub root** will be automatically disposed when it's owner does.
-
-### How to use it
-
-```ts
-// when fn doesn't return anything
-const dispose = runWithSubRoot(() =>
-  createEffect(() => {
-    console.log(count());
-  })
-);
-
-// when fn returns something
-const [double, dispose] = runWithSubRoot(() => createMemo(() => count() * 2));
-```
-
-### Definition
-
-```ts
-type runWithRootReturn<T> = T extends void | undefined | null
-  ? Dispose
-  : [returns: T, dispose: Dispose];
-const runWithSubRoot = <T>(fn: () => T, detachedOwner?: Owner): runWithRootReturn<T>
+const createDisposable = <T>(fn: () => T, detachedOwner?: Owner): runWithRootReturn<T>
 ```
 
 ## Changelog
@@ -150,5 +118,10 @@ const runWithSubRoot = <T>(fn: () => T, detachedOwner?: Owner): runWithRootRetur
 0.0.100
 
 Initial release as a Stage-1 primitive.
+
+1.0.0 - **Stage-2**
+
+- Remove `runWithRoot`
+- Rename `createSubRoot` to `createBranch` and `runWithSubRoot` to `createDisposable` (also unify returns to only dispose fn)
 
 </details>

--- a/packages/rootless/package.json
+++ b/packages/rootless/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@solid-primitives/rootless",
-  "version": "0.1.0",
-  "description": "A template primitive example.",
+  "version": "1.0.0",
+  "description": "A collection of helpers that aim to simplify using reactive primitives outside of reactive roots, and managing disposal of reactive roots.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/rootless#readme",
@@ -11,12 +11,11 @@
   },
   "primitive": {
     "name": "rootless",
-    "stage": 1,
+    "stage": 2,
     "list": [
-      "createSubRoot",
+      "createBranch",
       "createCallback",
-      "runWithRoot",
-      "runWithSubRoot"
+      "createDisposable"
     ],
     "category": "Reactivity"
   },
@@ -34,6 +33,7 @@
     "test": "uvu -r solid-register"
   },
   "keywords": [
+    "root",
     "solid",
     "primitives"
   ],

--- a/packages/rootless/src/index.ts
+++ b/packages/rootless/src/index.ts
@@ -1,37 +1,27 @@
 import { AnyFunction, asArray, access } from "@solid-primitives/utils";
-import { createRoot, getOwner, onCleanup, runWithOwner as _runWithOwner } from "solid-js";
+import { createRoot, getOwner, onCleanup, runWithOwner } from "solid-js";
 import type { Owner } from "solid-js/types/reactive/signal";
 
-export type RunWithRootReturn<T> = T extends void | undefined | null
-  ? VoidFunction
-  : [returns: T, dispose: VoidFunction];
-
 /**
- * Solid's `runWithOwner` that allows `null` to be passed as an owner.
- */
-export const runWithOwner = _runWithOwner as <T>(o: Owner | null, fn: () => T) => T;
-
-/**
- * Creates a reactive **sub root**, that will be automatically disposed when it's owner does.
+ * Creates a reactive **root branch**, that will be automatically disposed when it's owner does.
  *
- * @param fn
- * @param owner a root that will trigger the cleanup
- * @returns whatever the "fn" returns
+ * @param fn a function in which the reactive state is scoped
+ * @param owners reactive root dependency list – cleanup of any of them will trigger branch disposal. (Defaults to `getOwner()`)
+ * @returns return values of {@link fn}
  *
  * @example
  * const owner = getOwner()
- * const handleClick = () => createSubRoot(() => {
- *    createEffect(() => {})
- * }, owner);
+ * const [dispose, memo] = createBranch(dispose => {
+ *    const memo = createMemo(() => {...})
+ *    onCleanup(() => {...}) // <- will cleanup when branch/owner disposes
+ *    return [dispose, memo]
+ * }, owner, owner2);
  */
-export function createSubRoot<T>(
-  fn: (dispose: VoidFunction) => T,
-  ...owners: (Owner | null | undefined)[]
-): T {
+export function createBranch<T>(fn: (dispose: VoidFunction) => T, ...owners: (Owner | null)[]): T {
   if (owners.length === 0) owners = [getOwner()];
   return createRoot(dispose => {
     asArray(access(owners)).forEach(
-      owner => owner && runWithOwner(owner, () => onCleanup(dispose))
+      owner => owner && runWithOwner(owner, onCleanup.bind(void 0, dispose))
     );
     return fn(dispose);
   }, owners[0] || undefined);
@@ -41,9 +31,9 @@ export function createSubRoot<T>(
  * A wrapper for creating callbacks with `runWithOwner`.
  * It gives you the option to use reactive primitives after root setup and outside of effects.
  *
- * @param callback
- * @param owner a root that will trigger the cleanup
- * @returns the callback function
+ * @param callback function that will be ran with owner once called
+ * @param owner a root that will trigger the cleanup (Defaults to `getOwner()`)
+ * @returns the {@link callback} function
  *
  * @example
  * const handleClick = createCallback(() => {
@@ -56,57 +46,26 @@ export const createCallback = <T extends AnyFunction>(
 ): T => (owner ? (((...args) => runWithOwner(owner, () => callback(...args))) as T) : callback);
 
 /**
- * Helper for simplifying usage of Solid's reactive primitives outside of components (reactive roots).
+ * Executes {@link fn} in a {@link createBranch} *(auto-disposing root)*, and returns a dispose function, to dispose computations used inside before automatic cleanup.
  *
- * @param fn will be executed immediately in a new synthetic root.
- *
- * @example
- * ```ts
- * // when fn doesn't return anything
- * const dispose = runWithRoot(() => createEffect(() => {
- *    console.log(count())
- * }));
- *
- * // when fn returns something
- * const [double, dispose] = runWithRoot(
- *    () => createMemo(() => count() * 2)
- * );
- * ```
- */
-export const runWithRoot = <T>(fn: () => T, detachedOwner?: Owner): RunWithRootReturn<T> =>
-  createRoot(dispose => {
-    const returns = fn();
-    return returns !== undefined && returns !== null ? [returns, dispose] : dispose;
-  }, detachedOwner) as RunWithRootReturn<T>;
-
-/**
- * Helper for simplifying usage of Solid's reactive primitives outside of components (reactive roots). A **sub root** will be automatically disposed when it's owner does.
- *
- * @param fn will be executed immediately in a new **sub root**.
+ * @param fn a function in which the reactive state is scoped
+ * @returns root dispose function
  *
  * @example
  * ```ts
- * // when fn doesn't return anything
- * const dispose = runWithSubRoot(() => createEffect(() => {
- *    console.log(count())
- * }));
- *
- * // when fn returns something
- * const [double, dispose] = runWithSubRoot(
- *    () => createMemo(() => count() * 2)
- * );
+ * const dispose = createDisposable(dispose => {
+ *    createEffect(() => {...})
+ * });
+ * // dispose later (if not, will dispose automatically)
+ * dispose()
  * ```
  */
-export const runWithSubRoot = <T>(
-  fn: () => T,
-  ...owners: (Owner | null | undefined)[]
-): RunWithRootReturn<T> =>
-  createSubRoot(dispose => {
-    const returns = fn();
-    return returns !== undefined && returns !== null ? [returns, dispose] : dispose;
-  }, ...owners) as RunWithRootReturn<T>;
-
-// import { createEffect, createMemo, createResource } from "solid-js";
-// const [memo, del] = runWithRoot(() => createMemo(() => 123));
-// const dis = runWithRoot(() => createEffect(() => 123));
-// const [[data, { refetch }], dispose] = runWithRoot(() => createResource(() => 123));
+export function createDisposable(
+  fn: (dispose: VoidFunction) => void,
+  ...owners: (Owner | null)[]
+): VoidFunction {
+  return createBranch(dispose => {
+    fn(dispose);
+    return dispose;
+  }, ...owners);
+}

--- a/packages/rootless/test/index.test.ts
+++ b/packages/rootless/test/index.test.ts
@@ -1,12 +1,12 @@
-import { createCallback, createSubRoot, runWithRoot, runWithSubRoot } from "../src";
-import { createComputed, createMemo, createRoot, createSignal, getOwner } from "solid-js";
+import { createCallback, createBranch, createDisposable } from "../src";
+import { createComputed, createRoot, createSignal, getOwner } from "solid-js";
 import { suite } from "uvu";
 import * as assert from "uvu/assert";
 
-const csr = suite("createSubRoot");
+const csr = suite("createBranch");
 
 csr("behaves like a root", () =>
-  createSubRoot(dispose => {
+  createBranch(dispose => {
     const captured: any[] = [];
     const [count, setCount] = createSignal(0);
     createComputed(() => captured.push(count()));
@@ -20,7 +20,7 @@ csr("behaves like a root", () =>
 
 csr("disposes with owner", () =>
   createRoot(dispose => {
-    createSubRoot(() => {
+    createBranch(() => {
       const captured: any[] = [];
       const [count, setCount] = createSignal(0);
       createComputed(() => captured.push(count()));
@@ -42,7 +42,7 @@ csr("many parent owners", () => {
     return [o1, o2, dispose1, dispose2];
   });
 
-  createSubRoot(
+  createBranch(
     () => {
       const captured: any[] = [];
       const [count, setCount] = createSignal(0);
@@ -61,7 +61,7 @@ csr("many parent owners", () => {
 
 csr.run();
 
-const ccwo = suite("createCallbackWithOwner");
+const ccwo = suite("createCallback");
 
 ccwo("owner is available in async trigger", () =>
   createRoot(dispose => {
@@ -83,59 +83,24 @@ ccwo("owner is available in async trigger", () =>
 
 ccwo.run();
 
-const rir = suite("runWithRoot");
-
-rir("working with createComputed", () => {
-  const [count, setCount] = createSignal(0);
-  const captured: any[] = [];
-  const dispose = runWithRoot(() => createComputed(() => captured.push(count())));
-  assert.equal(captured, [0]);
-  setCount(1);
-  assert.equal(captured, [0, 1], "before dispose()");
-  dispose();
-  assert.equal(captured, [0, 1], "after disposing");
-});
-
-rir("working with createMemo", () => {
-  const [count, setCount] = createSignal(0);
-  const [memo, dispose] = runWithRoot(() => createMemo(() => count()));
-  assert.is(memo(), 0);
-  setCount(1);
-  assert.is(memo(), 1, "before dispose()");
-  dispose();
-  assert.is(memo(), 1, "after disposing");
-});
-
-rir.run();
-
-const risr = suite("runWithSubRoot");
+const risr = suite("createDisposable");
 
 risr("working with createComputed", () => {
   const [count, setCount] = createSignal(0);
   const captured: any[] = [];
-  const dispose = runWithSubRoot(() => createComputed(() => captured.push(count())));
+  const dispose = createDisposable(() => createComputed(() => captured.push(count())));
   assert.equal(captured, [0]);
   setCount(1);
   assert.equal(captured, [0, 1], "before dispose()");
   dispose();
   assert.equal(captured, [0, 1], "after disposing");
-});
-
-risr("working with createMemo", () => {
-  const [count, setCount] = createSignal(0);
-  const [memo, dispose] = runWithSubRoot(() => createMemo(() => count()));
-  assert.is(memo(), 0);
-  setCount(1);
-  assert.is(memo(), 1, "before dispose()");
-  dispose();
-  assert.is(memo(), 1, "after disposing");
 });
 
 risr("disposes together with owner", () =>
   createRoot(dispose => {
     const [count, setCount] = createSignal(0);
     const captured: any[] = [];
-    runWithSubRoot(() => createComputed(() => captured.push(count())));
+    createDisposable(() => createComputed(() => captured.push(count())));
     assert.equal(captured, [0]);
     setCount(1);
     assert.equal(captured, [0, 1], "before dispose()");

--- a/packages/rootless/tsconfig.json
+++ b/packages/rootless/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "extends": "../../tsconfig.json",
   "include": [
-    "./src"
+    "./src",
+    "./test",
+    "./dev"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This PR brings the refactor brought up in #102.
This will allow us to push more the pattern of using `createDisposable` or `createBranch` for disposing computations early, and proceed with clean() function refactor mentioned here: #103 
As this is a breaking change I've bumped the version to `1.0.0`, and the package stage to 2.