### PR TITLE
input-mask: exposed string regexps and generics

### DIFF
--- a/packages/input-mask/README.md
+++ b/packages/input-mask/README.md
@@ -89,7 +89,7 @@ In most cases you'll want to use `onInput` and `onPaste`.
 - **Is there a server version?**<br> No, since it only creates an event handler that will solely run on the client; it makes no sense to create a server version.
 - **Does this provide any error handling?**<br> There is no error handling, but it should work well together with any form handling library.
 - **Can I limit the events this uses?**<br> If you want to limit the events this uses e.g. as part of a library or to use this with another framework's events while you port your app to solid, we got you covered, you can just call `createInputMask<EventTypeUnion>(mask)` in order to do exactly that.
-- **Can I change the string mask handling?**<br> As a matter of fact, you can! Just `import { stringMaskRegExp } from "@solid-primitives/input-mask"` and change it to your liking.
+- **Can I change the string mask handling?**<br> As a matter of fact, you can! Either use the second optional parameter of `stringMaskToArray(mask[, regexps])` or `anyMaskToFn(mask[, regexps])` or `import { stringMaskRegExp } from "@solid-primitives/input-mask"` and change it to your liking.
 - **Can I turn this off and on again?**<br> You can still wrap the output handler in your own handler to turn it off and on again:
 
 ```jsx

--- a/packages/input-mask/README.md
+++ b/packages/input-mask/README.md
@@ -88,6 +88,8 @@ In most cases you'll want to use `onInput` and `onPaste`.
 - **Will it work with actual events?**<br> Yes, it will work with composed as well as native events. Solid's composed events are more performant, though.
 - **Is there a server version?**<br> No, since it only creates an event handler that will solely run on the client; it makes no sense to create a server version.
 - **Does this provide any error handling?**<br> There is no error handling, but it should work well together with any form handling library.
+- **Can I limit the events this uses?**<br> If you want to limit the events this uses e.g. as part of a library or to use this with another framework's events while you port your app to solid, we got you covered, you can just call `createInputMask<EventTypeUnion>(mask)` in order to do exactly that.
+- **Can I change the string mask handling?**<br> As a matter of fact, you can! Just `import { stringMaskRegExp } from "@solid-primitives/input-mask"` and change it to your liking.
 - **Can I turn this off and on again?**<br> You can still wrap the output handler in your own handler to turn it off and on again:
 
 ```jsx
@@ -115,5 +117,11 @@ Initial release as a Stage-0 primitive.
 0.0.101
 
 Document onPaste event.
+
+0.1.1
+
+Expose string replacements.
+
+Optional generic to type events.
 
 </details>

--- a/packages/input-mask/package.json
+++ b/packages/input-mask/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/input-mask",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "input masking event primitive.",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "contributors": [],
@@ -41,17 +41,22 @@
   ],
   "devDependencies": {
     "jsdom": "^19.0.0",
-    "prettier": "^2.6.0",
-    "solid-register": "^0.1.5",
+    "prettier": "^2.6.2",
+    "solid-register": "^0.2.3",
     "tslib": "^2.3.1",
-    "tsup": "^5.12.1",
-    "typescript": "^4.6.2",
-    "unocss": "0.28.1",
+    "tsup": "^5.12.5",
+    "typescript": "^4.6.3",
+    "unocss": "0.31.8",
     "uvu": "^0.5.3",
-    "vite": "2.8.6",
+    "vite": "2.9.5",
     "vite-plugin-solid": "2.2.6"
   },
   "peerDependencies": {
     "solid-js": ">=1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "solid-js": {
+      "optional": true
+    }
   }
 }

--- a/packages/input-mask/src/index.ts
+++ b/packages/input-mask/src/index.ts
@@ -15,8 +15,10 @@ export const stringMaskRegExp: Record<string, RegExp> = {
   "*": /\w/
 };
 
-export const stringMaskToArray = (mask: string) => [...mask].map(c => stringMaskRegExp[c] || c);
+/** Convert a string mask to an array mask */
+export const stringMaskToArray = (mask: string, regexps = stringMaskRegExp) => [...mask].map(c => regexps[c] || c);
 
+/** Convert an array mask to a mask function */
 export const maskArrayToFn =
   (maskArray: InputMaskArray): InputMaskFn =>
   (value: string, selection: Selection) => {
@@ -50,22 +52,30 @@ export const maskArrayToFn =
     return [value.slice(0, pos), selection];
   };
 
-export const anyMaskToFn = (mask: InputMask) =>
+/** Convert an array or string mask to a mask function */
+export const anyMaskToFn = (mask: InputMask, regexps?: Record<string, RegExp>) =>
   typeof mask === "function"
     ? mask
-    : maskArrayToFn(Array.isArray(mask) ? mask : stringMaskToArray(mask));
+    : maskArrayToFn(Array.isArray(mask) ? mask : stringMaskToArray(mask, regexps));
 
 export interface EventLike {
   target: EventTarget | null;
   currentTarget: EventTarget | null;
 }
 
+/**
+ * Create input mask handler
+ * @param mask string or array or function mask
+ * @param regexps optional object with regexps for string replacements used for string masks
+ * @returns event handler to effectuate the input mask
+ */
 export const createInputMask = <
   MaskEvent extends EventLike = KeyboardEvent | InputEvent | ClipboardEvent
 >(
-  mask: InputMask
+  mask: InputMask,
+  regexps?: Record<string, RegExp>
 ): ((ev: MaskEvent) => string) => {
-  const maskFn = anyMaskToFn(mask);
+  const maskFn = anyMaskToFn(mask, regexps);
   const handler = (ev: MaskEvent) => {
     const ref = (ev.currentTarget || ev.target) as HTMLInputElement | HTMLTextAreaElement;
     const [value, selection] = maskFn(ref.value, [


### PR DESCRIPTION
A few minor improvments for input-mask, documented in the README.