### PR TITLE
input-mask: support regex-replace masks

### DIFF
--- a/packages/input-mask/README.md
+++ b/packages/input-mask/README.md
@@ -21,11 +21,12 @@ yarn add @solid-primitives/input-mask
 
 ## Usage
 
-For convenience reasons, the handler returns the current value, which allows you to use it to fill a signal or assign a let variable. The masks come in 3 different formats: function, array and string. There are tools to convert string masks to array masks and array masks to function masks.
+For convenience reasons, the handler returns the current value, which allows you to use it to fill a signal or assign a let variable. The masks come in 4 different formats: function, regex-replacer, array and string. There are tools to convert string masks to array masks and regex-replacer and array masks to function masks.
 
 ```ts
 import {
   stringMaskToArray,
+  regexMaskToFn,
   arrayMaskToFn,
   anyMaskToFn,
   createInputMask
@@ -37,18 +38,22 @@ import {
 // any other letter becomes a fixed placeholder
 const isodate = "9999-99-99";
 // array mask: RegExp to match variable parts, strings for fixed placeholders
-const meetingId = [/\d/, /\d/, /\d/, "-", /\d/, /\d/, /\d/, "-", /\d/, /\d/, /\d/];
+const meetingId = [/\d/, /\d/, /\d/, "-", /\d/, /\d/, /\d/, "-", /\d/, /\d/, /\d/]);
+// regex replacer mask: a RegExp to match parts and a function to replace them
+const meetingName = [/[^0-9a-zäöüß\-_/]|^(https?:\/\/|)(meet\.goto\.com|gotomeet\.me|)\/?/gi, () => ''];
 // function mask: (value, [start, end]) => [value, [start, end]]
 const meetingIdOrName = (value, selection) =>
-  (/^\D/.test(value) ? arrayMaskToFn([/\w+/, /\S*/]) : anyMaskToFn("999-999-999"))(
-    value,
-    selection
-  );
+  (/^\d{1,3}$|^\d{2,4}-?\d{0,3}$|^\d{2,4}-?\d{2,4}-?\d{0,3}$/.test(value)
+    ? anyMaskToFn(meetingId)
+    : anyMaskToFn(meetingName)
+  )(value, selection);
 
 // converting string mask to array:
 const maskArrayFromString = stringMaskToArray(maskString);
+// converting other formats to function:
 const maskFuncFromArray = arrayMaskToFn(maskArray);
-const maskFuncFromStringOrArray = anyMaskToFn(mask);
+const maskFuncFromRegexReplacer = regexMaskToFn(regexMask, replacerFn);
+const maskFuncFromAny = anyMaskToFn(mask);
 
 // use let variable, store, mutable or signal to get value in event:
 let changeMaskValue = "";
@@ -83,9 +88,9 @@ In most cases you'll want to use `onInput` and `onPaste`.
 
 ## FAQ
 
-- **Why not support contenteditable?**<br> Getting accessible cross-browser support for contenteditable elements is difficult and results in bloated code, so it was decided to skip it for now. If there is enough demand, a later version might introduce it. You could use the exposed mask compilation to roll your own; if you do, please share it with us.
+- **Why not support contenteditable?**<br> In most cases, you ain't gonna need it and a lower bundle size is always good. In those rare cases you do need it, check the [selection](../selection/README.md) package, it shows you how to employ the mask filter functions together with a selection that supports contenteditable.
 - **Why `oninput`/`onchange` instead of e.g. `onkeyup`?**<br> There are a few things happening after keydown, -press and -up, which would result in flickering. Generally, you could use `onblur`, but then you'd attempt to apply the mask even if nothing changed, which just seems unnecessarily wasteful.
-- **Will it work with actual events?**<br> Yes, it will work with composed as well as native events. Solid's composed events are more performant, though.
+- **Will it work with actual events?**<br> Yes, it will work with composed as well as native events, even with React's synthetic events; `createInputMask` has an optional generic that you can use to type the output events. Solid's composed events are more performant than DOM events, so it is best practice to use them.
 - **Is there a server version?**<br> No, since it only creates an event handler that will solely run on the client; it makes no sense to create a server version.
 - **Does this provide any error handling?**<br> There is no error handling, but it should work well together with any form handling library.
 - **Can I limit the events this uses?**<br> If you want to limit the events this uses e.g. as part of a library or to use this with another framework's events while you port your app to solid, we got you covered, you can just call `createInputMask<EventTypeUnion>(mask)` in order to do exactly that.
@@ -123,5 +128,9 @@ Document onPaste event.
 Expose string replacements.
 
 Optional generic to type events.
+
+0.1.2
+
+New regexMaskToFn helper.
 
 </details>

--- a/packages/input-mask/dev/index.tsx
+++ b/packages/input-mask/dev/index.tsx
@@ -5,25 +5,18 @@ import 'uno.css';
 
 const App: Component = () => {
   const isoDateHandler = createInputMask('9999-99-99');
-  const cardExpiryHandler = createInputMask('99/9999');
+  const cardExpiryHandler = createInputMask([/\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]);
   const ibanMask = anyMaskToFn('aa99999999999999999999');
   const ibanHandler = createInputMask((value, selection) => {
     const maskOutput = ibanMask(value, selection)
     maskOutput[0] = maskOutput[0].toUpperCase();
     return maskOutput;
   })
+  const potentialNumericId = /^\d{1,3}$|^\d{2,4}-?\d{0,3}$|^\d{2,4}-?\d{2,4}-?\d{0,3}$/;
   const meetingIdMask = anyMaskToFn('999-999-999');
-  const gotoURLs = /^(https?:\/\/|)(meet\.goto\.com|gotomeet\.me|)\/?/;
-  const removeGotoURLMask = (value: string, selection: Selection): [string, Selection] => {
-    const cleanedValue = value.replace(gotoURLs, '');
-    const removed = value.length - cleanedValue.length;    
-    return cleanedValue === value
-      ? [value, selection]
-      : [cleanedValue, [Math.max(selection[0] - removed, 0), Math.max(selection[1] - removed, 0)]]
-  }
-  const meetingMask = (value: string, selection: Selection): [string, Selection] => /^\D/.test(value)
-    ? removeGotoURLMask(value, selection)
-    : meetingIdMask(value, selection)
+  const meetingNameMask = anyMaskToFn([/[^0-9a-zäöüß\-_/]|^(https?:\/\/|)(meet\.goto\.com|gotomeet\.me|)\/?/gi, () => '']);
+  const meetingMask = (value: string, selection: Selection): [string, Selection] => 
+    potentialNumericId.test(value) ? meetingIdMask(value, selection) : meetingNameMask(value, selection)
   const meetingInputHandler = createInputMask(meetingMask)
 
   return (

--- a/packages/input-mask/src/index.ts
+++ b/packages/input-mask/src/index.ts
@@ -7,7 +7,11 @@ export type InputMaskFn = (
 
 export type InputMaskArray = (string | RegExp)[];
 
-export type InputMask = InputMaskFn | InputMaskArray | string;
+export type ReplaceArgs = [substring: string, ...args: any[]];
+
+export type InputMaskRegex = [regex: RegExp, replacer: (...args: ReplaceArgs) => string];
+
+export type InputMask = InputMaskFn | InputMaskArray | InputMaskRegex | string;
 
 export const stringMaskRegExp: Record<string, RegExp> = {
   9: /\d/,
@@ -16,7 +20,31 @@ export const stringMaskRegExp: Record<string, RegExp> = {
 };
 
 /** Convert a string mask to an array mask */
-export const stringMaskToArray = (mask: string, regexps = stringMaskRegExp) => [...mask].map(c => regexps[c] || c);
+export const stringMaskToArray = (mask: string, regexps = stringMaskRegExp) =>
+  [...mask].map(c => regexps[c] || c);
+
+/** Convert a regex mask to a mask function */
+export const regexMaskToFn =
+  (regex: RegExp, replacer: (...args: ReplaceArgs) => string): InputMaskFn =>
+  (value: string, selection: Selection) =>
+    [
+      value.replace(regex, (...args) => {
+        const replacement = replacer(...args);
+        const index = args[args.length - 2];
+        selection[0] +=
+          index < selection[0]
+            ? 0
+            : ((replacement.length - args[0].length) / args[0].length) *
+              Math.max(selection[0] - index, args[0].length);
+        selection[1] +=
+          index < selection[1]
+            ? 0
+            : ((replacement.length - args[0].length) / args[0].length) *
+              Math.max(selection[1] - index, args[0].length);
+        return replacement;
+      }),
+      selection
+    ];
 
 /** Convert an array mask to a mask function */
 export const maskArrayToFn =
@@ -24,18 +52,17 @@ export const maskArrayToFn =
   (value: string, selection: Selection) => {
     let pos = 0;
     maskArray.forEach(maskItem => {
-      if (value.length < pos + 1) {
-        return;
-      }
-      if (typeof maskItem === "string") {
-        const index = value.slice(pos).indexOf(maskItem);
-        if (index !== 0) {
-          value = value.slice(0, pos) + maskItem + value.slice(pos);
-          selection[0] > pos && (selection[0] += maskItem.length);
-          selection[1] > pos && (selection[1] += maskItem.length);
+      if (value.length >= pos + 1) {
+        if (typeof maskItem === "string") {
+          const index = value.slice(pos).indexOf(maskItem);
+          if (index !== 0) {
+            value = value.slice(0, pos) + maskItem + value.slice(pos);
+            selection[0] += ((selection[0] > pos) as unknown as number) * maskItem.length;
+            selection[1] += ((selection[1] > pos) as unknown as number) * maskItem.length;
+          }
+          pos += maskItem.length;
+          return;
         }
-        pos += maskItem.length;
-      } else if (maskItem instanceof RegExp) {
         const match = value.slice(pos).match(maskItem);
         if (!match || match.index === undefined) {
           value = value.slice(0, pos);
@@ -43,8 +70,8 @@ export const maskArrayToFn =
         } else if (match.index > 0) {
           value = value.slice(0, pos) + value.slice(pos + match.index);
           pos -= match.index - 1;
-          selection[0] > pos && (selection[0] -= match.index);
-          selection[1] > pos && (selection[1] -= match.index);
+          selection[0] -= ((selection[0] > pos) as unknown as number) * match.index;
+          selection[1] -= ((selection[1] > pos) as unknown as number) * match.index;
         }
         pos += match[0].length;
       }
@@ -56,7 +83,11 @@ export const maskArrayToFn =
 export const anyMaskToFn = (mask: InputMask, regexps?: Record<string, RegExp>) =>
   typeof mask === "function"
     ? mask
-    : maskArrayToFn(Array.isArray(mask) ? mask : stringMaskToArray(mask, regexps));
+    : typeof mask[1] === "function" && mask[0] instanceof RegExp
+    ? regexMaskToFn(mask[0], mask[1])
+    : maskArrayToFn(
+        Array.isArray(mask) ? (mask as InputMaskArray) : stringMaskToArray(mask, regexps)
+      );
 
 export interface EventLike {
   target: EventTarget | null;

--- a/packages/input-mask/test/index.test.tsx
+++ b/packages/input-mask/test/index.test.tsx
@@ -42,7 +42,7 @@ test("adds placeholder (e.g. to an iso date)", async ({ container }) => {
   unmount();
 });
 
-test('removes wrongful input (e.g. from iso-date)', async ({ container }) => {
+test("removes wrongful input (e.g. from iso-date)", async ({ container }) => {
   const unmount = render(() => <input onInput={createInputMask("9999-99-99")} />, container);
   const input = container.querySelector("input") as HTMLInputElement;
   input.value = "a";
@@ -54,4 +54,15 @@ test('removes wrongful input (e.g. from iso-date)', async ({ container }) => {
   unmount();
 });
 
-test.run();
+test("works with regex mask", async ({ container }) => {
+  const unmount = render(() => <input onInput={createInputMask([
+    /[^0-9a-zäöüß\-_/]|^(https?:\/\/|)(meet\.goto\.com|gotomeet\.me|)\/?/gi,
+    () => ''
+  ])} />, container);
+  const input = container.querySelector("input") as HTMLInputElement;
+  input.value = "https://meet.goto.com/test";
+  await dispatchInputEvent(input);
+  assert.is(input.value, "test");
+  unmount();
+});
+'re


### PR DESCRIPTION
I found an even more more elegant solutions to masks that replace parts using string.replace(regex, fn). Also, I implemented a few byte-saving techniques to further reduce the bundle size so that we still remain close to 0.5kb even with the added functionality.