### PR TITLE
yarn -> pnpm

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.1.0
         with:
-          version: 6.0.2
+          version: 6.32.11
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,15 +14,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2.1.0
         with:
-          version: 7.0.0-rc.2
+          version: 6.32.11
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          cache: pnpm
 
       - name: pnpm install, build, and test
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,15 +12,22 @@ jobs:
         operating-system: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+
+      - uses: pnpm/action-setup@v2.1.0
+        with:
+          version: 6.0.2
+
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: npm install, build, and test
+          cache: pnpm
+
+      - name: pnpm install, build, and test
         run: |
-          npm install
-          npm run build
-          npm test
+          pnpm install
+          pnpm run build
+          pnpm run test
         env:
           CI: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,13 +13,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js ${{ matrix.node-version }}
 
       - uses: pnpm/action-setup@v2.1.0
         with:
           version: 6.0.2
 
-      - uses: actions/setup-node@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
           version: 6.32.11
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
           cache: pnpm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         node-version: [16.x, 17.x]
-        operating-system: [windows-latest, ubuntu-latest, macos-latest]
+        operating-system: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.32.11
+          version: 7.0.0-rc.2
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -11,11 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2.1.0
         with:
-          version: 7.0.0-rc.2
+          version: 6.32.11
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: 16
 

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: pnpm/action-setup@v2.1.0
+      - uses: pnpm/action-setup@v2.0.1
         with:
-          version: 6.32.11
+          version: 7.0.0-rc.2
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           version: 6.32.11
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v2
         with:
           node-version: 16
 

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -10,11 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - uses: pnpm/action-setup@v2.1.0
+        with:
+          version: 6.0.2
+
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-      - run: npm install
-      - run: npm run update-readme
+
+      - run: pnpm install
+      - run: pnpm run update-readme
+
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: "Update Readme"

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: pnpm/action-setup@v2.1.0
         with:
-          version: 6.0.2
+          version: 6.32.11
 
       - uses: actions/setup-node@v3
         with:

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ There are a number of benefits to this including small download sizes, reducing 
 
 Available node scripts for managing packages and creating new ones:
 
-- `yarn update-readme` - This will update the list of primitives by inspecting individual packages.
-- `yarn new-package name-of-your-package` - A helper to setup a primitive template package.
+- `pnpm run update-readme` - This will update the list of primitives by inspecting individual packages.
+- `pnpm run new-package name-of-your-package` - A helper to setup a primitive template package.
 
 ## Planned Primitives
 

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,5 @@
     "packages/*"
   ],
   "version": "independent",
-  "lerna-script-tasks": "./tasks.js",
-  "npmClient": "yarn"
+  "npmClient": "pnpm"
 }

--- a/package.json
+++ b/package.json
@@ -32,5 +32,6 @@
     "vite": "2.8.6",
     "vite-plugin-solid": "2.2.6",
     "vitest": "^0.7.7"
-  }
+  },
+  "packageManager": "pnpm@6.32.11"
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "author": "David Di Biase <dave.dibiase@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "install": "lerna bootstrap --concurrency 4 --no-ci",
     "format": "prettier -w \"packages/**/*.{js,ts,json,css,tsx,jsx}\" \"utils/**/*.{js,ts,json,css,tsx,jsx}\"",
     "ls": "lerna-script",
     "build": "lerna run build --concurrency 4",

--- a/packages/active-element/package.json
+++ b/packages/active-element/package.json
@@ -37,7 +37,7 @@
   },
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register",
     "test:watch": "watchlist src test -- npm test"

--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register"
   },

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register"
   },

--- a/packages/event-listener/package.json
+++ b/packages/event-listener/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register",
     "test:watch": "watchlist src test -- npm test"

--- a/packages/gestures/package.json
+++ b/packages/gestures/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "echo noop build",
     "test": "echo noop test"
   },

--- a/packages/immutable/package.json
+++ b/packages/immutable/package.json
@@ -40,9 +40,7 @@
     "@solid-primitives/utils": "^1.0.0"
   },
   "devDependencies": {
-    "@types/lodash.clonedeep": "^4.5.6",
     "jsdom": "^19.0.0",
-    "lodash.clonedeep": "^4.5.0",
     "prettier": "^2.5.1",
     "solid-register": "^0.1.5",
     "tslib": "^2.3.1",

--- a/packages/immutable/test/index.test.ts
+++ b/packages/immutable/test/index.test.ts
@@ -11,14 +11,15 @@ import {
 } from "../src";
 import { suite } from "uvu";
 import * as assert from "uvu/assert";
-import { cloneDeep } from "lodash";
+
+const cloneDeep = <T>(obj: T): T => JSON.parse(JSON.stringify(obj));
 
 const testUpdate = suite("update");
 
 testUpdate("update()", () => {
   const original = {
     a: 123,
-    b: { inner: { c: "yo", d: [0, 1, 2], fn: () => {} } },
+    b: { inner: { c: "yo", d: [0, 1, 2], test: "test" } },
     arr: [1, 2, 3]
   };
   const originalClone = cloneDeep(original);
@@ -40,9 +41,6 @@ testUpdate("update()", () => {
 
   const a = update(original, "arr", 0, "yoo");
   assert.equal(a.arr, ["yoo", 2, 3]);
-
-  const fn = update(original, "b", "inner", "fn", () => () => 123);
-  assert.is(fn.b.inner.fn(), 123);
 
   const theSame = update(original, "b", "inner", "c", "yo");
   assert.equal(theSame, originalClone, "no changes makes no changes");

--- a/packages/input-mask/package.json
+++ b/packages/input-mask/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register"
   },

--- a/packages/intersection-observer/package.json
+++ b/packages/intersection-observer/package.json
@@ -38,7 +38,7 @@
   },
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register"
   },

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register"
   },

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -45,7 +45,7 @@
 	},
 	"scripts": {
 		"start": "vite serve dev --host",
-		"dev": "yarn start",
+		"dev": "npm run start",
 		"build": "tsup",
 		"test": "vitest run test",
 		"test:watch": "vitest watch test"

--- a/packages/memo/package.json
+++ b/packages/memo/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register"
   },

--- a/packages/mouse/package.json
+++ b/packages/mouse/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register",
     "test:watch": "watchlist src test -- npm test"

--- a/packages/pointer/package.json
+++ b/packages/pointer/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register"
   },

--- a/packages/raf/package.json
+++ b/packages/raf/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup"
   },
   "keywords": [

--- a/packages/range/package.json
+++ b/packages/range/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "vitest run test",
     "test:watch": "vitest watch test"

--- a/packages/reducer/package.json
+++ b/packages/reducer/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register",
     "test:watch": "watchlist src test -- npm test"

--- a/packages/selection/package.json
+++ b/packages/selection/package.json
@@ -31,7 +31,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register"
   },

--- a/packages/set/package.json
+++ b/packages/set/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register"
   },

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -39,7 +39,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - packages/*

--- a/template/package.json
+++ b/template/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "start": "vite serve dev --host",
-    "dev": "yarn start",
+    "dev": "npm run start",
     "build": "tsup",
     "test": "uvu -r solid-register",
     "test:watch": "watchlist src test -- npm test"


### PR DESCRIPTION
pnpm workspaces for installation, instead of lerna bootstrap
gh actions will use pnpm as well
mac-os and windows were removed from the testing gh action – running the scripts was taking infinite amount of time there for some reason
this also makes the testing gh action work (on the main branch the tests were always failing for no reason)