### PR TITLE
Upload: export types

### DIFF
--- a/packages/upload/src/index.ts
+++ b/packages/upload/src/index.ts
@@ -35,3 +35,4 @@ export const fileUploader = (element: HTMLInputElement, options: () => FileUploa
 
 export { createFileUploader } from "./createFileUploader";
 export { createDropzone } from "./createDropzone";
+export * from "./types";


### PR DESCRIPTION
I made the `index.ts` export all the types of `@solid-primitives/upload` from `types.ts`.

I don't know whether all the types should be exported, or some should be left accessible only inside the package, so maybe some changes should be made