### PR TITLE
Refactor visibility-observer

### DIFF
--- a/packages/visibility-observer/README.md
+++ b/packages/visibility-observer/README.md
@@ -9,7 +9,8 @@
 [![size](https://img.shields.io/npm/v/@solid-primitives/visibility-observer?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/visibility-observer)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
-Provides a reactive page visibility observer.
+- [`createPageVisibility`](#createPageVisibility) - Creates a signal with a boolean value identifying the page visibility state
+- [`usePageVisibility`](#usePageVisibility) - A [shared-root](https://github.com/solidjs-community/solid-primitives/tree/main/packages/rootless#createSharedRoot) alternative.
 
 ## Installation
 
@@ -19,15 +20,36 @@ npm install @solid-primitives/visibility-observer
 yarn add @solid-primitives/visibility-observer
 ```
 
-## How to use it
+## `createPageVisibility`
 
-### createPageVisibilityObserver
+Creates a signal with a boolean value identifying the page visibility state.
 
-Main page visibility observer primitive.
+### How to use it
 
 ```ts
-const visible = createPageVisibilityObserver();
-console.log(visible());
+import { createPageVisibility } from "@solid-primitives/visibility-observer";
+
+const visible = createPageVisibility();
+
+createEffect(() => {
+  visible(); // => boolean
+});
+```
+
+## `usePageVisibility`
+
+`usePageVisibility` is a [shared root](https://github.com/solidjs-community/solid-primitives/tree/main/packages/rootless#createSharedRoot) primitive. It is providing the same signal as `createPageVisibility`, but the event-listener and the signal are shared between dependents, making it more optimized to use in multiple places at once.
+
+### How to use it
+
+```ts
+import { usePageVisibility } from "@solid-primitives/visibility-observer";
+
+const visible = usePageVisibility();
+
+createEffect(() => {
+  visible(); // => boolean
+});
 ```
 
 ## Changelog
@@ -38,5 +60,11 @@ console.log(visible());
 1.0.0
 
 Initial commit of the visibility observer.
+
+2.0.0
+
+Rename `createPageVisibilityObserver` to `createPageVisibility` _(no longer exported as default)_
+
+Add `usePageVisibility`
 
 </details>

--- a/packages/visibility-observer/package.json
+++ b/packages/visibility-observer/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.0",
   "description": "Primitive to track page visibility",
   "author": "David Di Biase",
+  "contributors": [
+    "Damian Tarnawski <gthetarnav@gmail.com>"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/visibility-observer",
   "repository": {
@@ -64,7 +67,6 @@
     "solid-js": "^1.4.3"
   },
   "dependencies": {
-    "@solid-primitives/event-listener": "^2.1.0",
     "@solid-primitives/rootless": "^1.1.0"
   }
 }

--- a/packages/visibility-observer/package.json
+++ b/packages/visibility-observer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/visibility-observer",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Primitive to track page visibility",
   "author": "David Di Biase",
   "license": "MIT",
@@ -13,7 +13,7 @@
     "name": "visibility-observer",
     "stage": 3,
     "list": [
-      "createPageVisibilityObserver"
+      "createPageVisibility"
     ],
     "category": "Display & Media"
   },
@@ -35,7 +35,11 @@
     "require": "./dist/index.cjs"
   },
   "scripts": {
-    "build": "tsup"
+    "start": "vite serve dev --host",
+    "dev": "npm run start",
+    "build": "tsup",
+    "test": "uvu -r solid-register",
+    "test:watch": "watchlist src test -- npm test"
   },
   "keywords": [
     "page",
@@ -44,19 +48,23 @@
     "primitives"
   ],
   "devDependencies": {
-    "@types/jest": "^27.0.0",
-    "prettier": "^2.0.5",
-    "solid-testing-library": "^0.2.0",
-    "tslib": "^2.0.1",
-    "tsup": "^5.10.1",
-    "typescript": "^4.0.2"
+    "jsdom": "^19.0.0",
+    "prettier": "^2.6.2",
+    "solid-register": "^0.2.5",
+    "tslib": "^2.4.0",
+    "tsup": "^5.12.8",
+    "typescript": "^4.6.4",
+    "unocss": "0.34.0",
+    "uvu": "^0.5.3",
+    "vite": "2.9.9",
+    "vite-plugin-solid": "2.2.6",
+    "watchlist": "^0.3.1"
   },
   "peerDependencies": {
-    "solid-js": "^1.3.0"
+    "solid-js": "^1.4.3"
   },
-  "jest": {
-    "setupFiles": [
-      "./test/setup.ts"
-    ]
+  "dependencies": {
+    "@solid-primitives/event-listener": "^2.1.0",
+    "@solid-primitives/rootless": "^1.1.0"
   }
 }

--- a/packages/visibility-observer/src/index.ts
+++ b/packages/visibility-observer/src/index.ts
@@ -1,20 +1,38 @@
-import { onMount, createSignal, onCleanup, Accessor } from "solid-js";
+import { createSignal, Accessor } from "solid-js";
+import { makeEventListener } from "@solid-primitives/event-listener";
+import { createSharedRoot } from "@solid-primitives/rootless";
 
 /**
- * Create a visibility observer is a helper primitive for tracking when the page is visible.
+ * Creates a signal with a boolean value identifying the page visibility state.
  *
- * @return Returns a signel with a boolean value identifying the visibility state.
+ * @example
+ * ```ts
+ * const visible = createPageVisibility();
  *
+ * createEffect(() => {
+ *    visible() // => boolean
+ * })
+ * ```
  */
-const createPageVisibilityObserver = (): Accessor<boolean> => {
-  const visible = () => (document ? document.visibilityState === "visible" : true);
-  const [state, setState] = createSignal(visible());
-  const cb = () => setState(visible());
-  onMount(() => {
-    document.addEventListener("visibilitychange", cb);
-    onCleanup(() => document.removeEventListener("visibilitychange", cb));
-  });
+export const createPageVisibility = (): Accessor<boolean> => {
+  const [state, setState] = createSignal(document.visibilityState === "visible");
+  const cb = () => setState(document.visibilityState === "visible");
+  makeEventListener(document, "visibilitychange", cb);
   return state;
 };
 
-export default createPageVisibilityObserver;
+/**
+ * Returns a signal with a boolean value identifying the page visibility state.
+ *
+ * This is a [shared root](https://github.com/solidjs-community/solid-primitives/tree/main/packages/rootless#createSharedRoot) primitive.
+ *
+ * @example
+ * ```ts
+ * const visible = usePageVisibility();
+ *
+ * createEffect(() => {
+ *    visible() // => boolean
+ * })
+ * ```
+ */
+export const usePageVisibility = createSharedRoot(createPageVisibility);

--- a/packages/visibility-observer/src/index.ts
+++ b/packages/visibility-observer/src/index.ts
@@ -1,5 +1,4 @@
-import { createSignal, Accessor } from "solid-js";
-import { makeEventListener } from "@solid-primitives/event-listener";
+import { createSignal, Accessor, onCleanup } from "solid-js";
 import { createSharedRoot } from "@solid-primitives/rootless";
 
 /**
@@ -17,7 +16,8 @@ import { createSharedRoot } from "@solid-primitives/rootless";
 export const createPageVisibility = (): Accessor<boolean> => {
   const [state, setState] = createSignal(document.visibilityState === "visible");
   const cb = () => setState(document.visibilityState === "visible");
-  makeEventListener(document, "visibilitychange", cb);
+  document.addEventListener("visibilitychange", cb);
+  onCleanup(() => document.removeEventListener("visibilitychange", cb));
   return state;
 };
 

--- a/packages/visibility-observer/src/server.ts
+++ b/packages/visibility-observer/src/server.ts
@@ -1,13 +1,5 @@
-import { Accessor } from "solid-js";
+import * as API from "./index";
 
-/**
- * Create a visibility observer is a helper primitive for tracking when the page is visible.
- *
- * @return Returns a signel with a boolean value identifying the visibility state.
- *
- */
-const createPageVisibilityObserver = (): Accessor<boolean> => {
-  return () => true;
-};
+export const createPageVisibility: typeof API.createPageVisibility = () => () => true;
 
-export default createPageVisibilityObserver;
+export const usePageVisibility: typeof API.usePageVisibility = () => () => true;

--- a/packages/visibility-observer/test/index.test.ts
+++ b/packages/visibility-observer/test/index.test.ts
@@ -1,4 +1,35 @@
-import { render } from "solid-testing-library";
-import createPageVisibilityObserver from "../src/index";
+import * as assert from "uvu/assert";
+import { suite } from "uvu";
+import { createRoot } from "solid-js";
+import { createPageVisibility } from "../src";
 
-describe("createPageVisibilityObserver", (): void => {});
+const test = suite("createPageVisibility");
+
+test("observes visibilitychange events", () =>
+  createRoot(dispose => {
+    let doc_visibility = "prerender";
+    Object.defineProperty(document, "visibilityState", {
+      get() {
+        return doc_visibility;
+      }
+    });
+
+    const visibility = createPageVisibility();
+    assert.is(visibility(), false, "jsdom defaults to false");
+
+    doc_visibility = "visible";
+    document.dispatchEvent(new Event("visibilitychange"));
+    assert.is(visibility(), true);
+
+    doc_visibility = "hidden";
+    document.dispatchEvent(new Event("visibilitychange"));
+    assert.is(visibility(), false);
+
+    dispose();
+
+    doc_visibility = "visible";
+    document.dispatchEvent(new Event("visibilitychange"));
+    assert.is(visibility(), false, "doesn't listen after dispose");
+  }));
+
+test.run();

--- a/packages/visibility-observer/tsconfig.json
+++ b/packages/visibility-observer/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "./dist",
-    "emitDeclarationOnly": false
-  },
-  "include": ["./src"]
+  "include": ["./src", "./test", "./dev"],
+  "exclude": ["node_modules", "./dist"]
 }


### PR DESCRIPTION
- Rename `createPageVisibilityObserver` to `createPageVisibility` _(no longer exported as default)_

- Add `usePageVisibility`

- Add tests

[README](https://github.com/solidjs-community/solid-primitives/tree/visibility-observer-refactor/packages/visibility-observer#readme)