### PR TITLE
storage: Set options default type to {}

### DIFF
--- a/packages/storage/src/storage.ts
+++ b/packages/storage/src/storage.ts
@@ -446,7 +446,7 @@ export function createAsyncStorage<O, T>(
  * ]
  * ```
  */
-export function createStorageSignal<T extends any, O extends any>(
+export function createStorageSignal<T, O = {}>(
   key: string,
   initialValue?: T,
   props?: StorageSignalProps<T, Storage | StorageWithOptions<O>, O>
@@ -543,5 +543,5 @@ export function createStorageSignal<T extends any, O extends any>(
 
 export const createLocalStorage = createStorage;
 
-export const createSessionStorage = <T, O>(props: StorageProps<T, Storage, O>) =>
+export const createSessionStorage = <T, O = {}>(props: StorageProps<T, Storage, O>) =>
   createStorage({ ...props, api: globalThis.sessionStorage } as any);

--- a/packages/storage/test/storage.test.ts
+++ b/packages/storage/test/storage.test.ts
@@ -160,7 +160,7 @@ testCreateStorageSignal.before(context => {
 });
 
 testCreateStorageSignal("creates a signal", ({ mockStorage }) => {
-  const [storageItem, setStorageItem] = createStorageSignal<string | null, undefined>(
+  const [storageItem, setStorageItem] = createStorageSignal<string | null>(
     "test",
     null,
     { api: mockStorage }


### PR DESCRIPTION
Before you had to do:
```ts
const [getValue] = createStorageSignal<string, {}>("value");
```
Now you can do:
```ts
const [getValue] = createStorageSignal<string>("value");
```