### PR TITLE
Add callback wrappers to event-listener

### DIFF
--- a/packages/event-listener/README.md
+++ b/packages/event-listener/README.md
@@ -13,19 +13,25 @@ A set of primitives that help with listening to DOM and Custom Events.
 
 ##### Non-reactive primitives:
 
-- [`makeEventListener`](#makeEventListener) - Non-reactive primitive for adding event listeners that gets removed onCleanup.
-- [`makeEventListenerStack`](#makeEventListenerStack) - Creates a stack of event listeners, that will be automatically disposed on cleanup.
+- [`makeEventListener`](#makeEventListener) — Non-reactive primitive for adding event listeners that gets removed onCleanup.
+- [`makeEventListenerStack`](#makeEventListenerStack) — Creates a stack of event listeners, that will be automatically disposed on cleanup.
 
 ##### Reactive primitives:
 
-- [`createEventListener`](#createEventListener) - Reactive version of [`makeEventListener`](#makeEventListener), that takes signal arguments to apply new listeners once changed.
-- [`createEventSignal`](#createEventListener) - Like [`createEventListener`](#createEventListener), but captured events are stored in a returned signal.
-- [`createEventListenerMap`](#createEventListenerMap) - A helpful primitive that listens to a map of events. Handle them by individual callbacks.
+- [`createEventListener`](#createEventListener) — Reactive version of [`makeEventListener`](#makeEventListener), that takes signal arguments to apply new listeners once changed.
+- [`createEventSignal`](#createEventListener) — Like [`createEventListener`](#createEventListener), but captured events are stored in a returned signal.
+- [`createEventListenerMap`](#createEventListenerMap) — A helpful primitive that listens to a map of events. Handle them by individual callbacks.
 
 ##### Component global listeners:
 
-- [`WindowEventListener`](#WindowEventListener) - Listen to the `window` DOM Events, using a component.
-- [`DocumentEventListener`](#DocumentEventListener) - Listen to the `document` DOM Events, using a component.
+- [`WindowEventListener`](#WindowEventListener) — Listen to the `window` DOM Events, using a component.
+- [`DocumentEventListener`](#DocumentEventListener) — Listen to the `document` DOM Events, using a component.
+
+##### Callback Wrappers
+
+- [`preventDefault`](#preventDefault) — Wraps event handler with `e.preventDefault()` call.
+- [`stopPropagation`](#stopPropagation) — Wraps event handler with `e.stopPropagation()` call.
+- [`stopImmediatePropagation`](#stopImmediatePropagation) — Wraps event handler with `e.stopImmediatePropagation()` call.
 
 ## Installation
 
@@ -275,6 +281,56 @@ import { DocumentEventListener } from "@solid-primitives/event-listener";
 <DocumentEventListener onMouseMove={e => console.log(e.x, e.y)} />;
 ```
 
+## Callback Wrappers
+
+### `preventDefault`
+
+Wraps event handler with `e.preventDefault()` call.
+
+```tsx
+import { preventDefault, makeEventListener } from "@solid-primitives/event-listener";
+
+const handleClick = e => {
+  concole.log("Click!", e);
+};
+
+makeEventListener(window, "click", preventDefault(handleClick), true);
+// or in jsx:
+<div onClick={preventDefault(handleClick)} />;
+```
+
+### `stopPropagation`
+
+Wraps event handler with `e.stopPropagation()` call.
+
+```tsx
+import { stopPropagation, makeEventListener } from "@solid-primitives/event-listener";
+
+const handleClick = e => {
+  concole.log("Click!", e);
+};
+
+makeEventListener(window, "click", stopPropagation(handleClick), true);
+// or in jsx:
+<div onClick={stopPropagation(handleClick)} />;
+```
+
+### `stopImmediatePropagation`
+
+Wraps event handler with `e.stopImmediatePropagation()` call.
+
+```tsx
+import { stopImmediatePropagation, makeEventListener } from "@solid-primitives/event-listener";
+
+const handleClick = e => {
+  concole.log("Click!", e);
+};
+
+makeEventListener(window, "click", stopImmediatePropagation(handleClick), true);
+// or in jsx:
+<div onClick={stopImmediatePropagation(handleClick)} />;
+```
+
 ## Demo
 
 You may view a working example here: https://codesandbox.io/s/solid-primitives-event-listener-elti5
@@ -342,5 +398,9 @@ Remove clear() functions from reactive primitives.
 2.1.0
 
 Allow for `undefined` targets in `createEventListener`
+
+2.2.0
+
+Add `preventDefault`, `stopPropagation` and `stopImmediatePropagation` callback wrappers.
 
 </details>

--- a/packages/event-listener/src/callbackWrappers.ts
+++ b/packages/event-listener/src/callbackWrappers.ts
@@ -1,0 +1,65 @@
+/**
+ * Calls `e.preventDefault()` on the `Event` and calls the {@link callback}
+ *
+ * @param callback Event handler
+ * @returns Event handler matching {@link callback}'s type
+ * @example
+ * ```tsx
+ * const handleClick = (e) => {
+ *    concole.log("Click!", e)
+ * }
+ * makeEventListener(window, "click", preventDefault(handleClick), true);
+ * // or in jsx:
+ * <div onClick={preventDefault(handleClick)} />
+ * ```
+ */
+export const preventDefault =
+  <E extends Event>(callback: (event: E) => void): ((event: E) => void) =>
+  e => {
+    e.preventDefault();
+    callback(e);
+  };
+
+/**
+ * Calls `e.stopPropagation()` on the `Event` and calls the {@link callback}
+ *
+ * @param callback Event handler
+ * @returns Event handler matching {@link callback}'s type
+ * @example
+ * ```tsx
+ * const handleClick = (e) => {
+ *    concole.log("Click!", e)
+ * }
+ * makeEventListener(window, "click", stopPropagation(handleClick), true);
+ * // or in jsx:
+ * <div onClick={stopPropagation(handleClick)} />
+ * ```
+ */
+export const stopPropagation =
+  <E extends Event>(callback: (event: E) => void): ((event: E) => void) =>
+  e => {
+    e.stopPropagation();
+    callback(e);
+  };
+
+/**
+ * Calls `e.stopImmediatePropagation()` on the `Event` and calls the {@link callback}
+ *
+ * @param callback Event handler
+ * @returns Event handler matching {@link callback}'s type
+ * @example
+ * ```tsx
+ * const handleClick = (e) => {
+ *    concole.log("Click!", e)
+ * }
+ * makeEventListener(window, "click", stopImmediatePropagation(handleClick), true);
+ * // or in jsx:
+ * <div onClick={stopImmediatePropagation(handleClick)} />
+ * ```
+ */
+export const stopImmediatePropagation =
+  <E extends Event>(callback: (event: E) => void): ((event: E) => void) =>
+  e => {
+    e.stopImmediatePropagation();
+    callback(e);
+  };

--- a/packages/event-listener/src/index.ts
+++ b/packages/event-listener/src/index.ts
@@ -2,4 +2,5 @@ export * from "./eventListener";
 export * from "./eventListenerMap";
 export * from "./components";
 export * from "./eventListenerStack";
+export * from "./callbackWrappers";
 export * from "./types";


### PR DESCRIPTION
Three very small helpers, but I like to use them personally. Maybe because I had `@click.prevent="callback"` in vue.

[README](https://github.com/solidjs-community/solid-primitives/tree/cb-wrappers/packages/event-listener#callback-wrappers-1)