### PR TITLE
add `keyboard` package with `makeKeyHoldListener`

### DIFF
--- a/packages/keyboard/LICENSE
+++ b/packages/keyboard/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Solid Primitives Working Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/keyboard/README.md
+++ b/packages/keyboard/README.md
@@ -11,7 +11,7 @@
 
 A library of reactive promitives helping handling user's keyboard input.
 
-- [`makeHoldKeyListener`](#makeHoldKeyListener) - Attaches keyboard event-listeners, and triggers callback whenever user holds or stops holding specified key.
+- [`makeKeyHoldListener`](#makeKeyHoldListener) - Attaches keyboard event-listeners, and triggers callback whenever user holds or stops holding specified key.
 
 ## Installation
 
@@ -21,7 +21,7 @@ npm install @solid-primitives/keyboard
 yarn add @solid-primitives/keyboard
 ```
 
-## `makeHoldKeyListener`
+## `makeKeyHoldListener`
 
 Attaches keyboard event-listeners to `window`, and calls provided callback whenever user holds or stops holding specified key.
 
@@ -29,7 +29,7 @@ Event listeners are automatically cleaned on root dispose.
 
 ### How to use it
 
-`makeHoldKeyListener` takes three arguments:
+`makeKeyHoldListener` takes three arguments:
 
 - `key` keyboard key or modifier to listen for
 - `onHoldChange` callback fired when the hold state changes
@@ -38,11 +38,11 @@ Event listeners are automatically cleaned on root dispose.
   - `allowOtherKeys` — Should the user be allowed to press other keys while holding the specified one _(Defaults to `false`)_
 
 ```tsx
-import { makeHoldKeyListener } from "@solid-primitives/keyboard";
+import { makeKeyHoldListener } from "@solid-primitives/keyboard";
 
 const [pressing, setPressing] = createSignal(false);
 
-makeHoldKeyListener("altKey", setPressing, {
+makeKeyHoldListener("altKey", setPressing, {
   preventDefault: true
 });
 

--- a/packages/keyboard/README.md
+++ b/packages/keyboard/README.md
@@ -1,0 +1,61 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=keyboard" alt="Solid Primitives keyboard">
+</p>
+
+# @solid-primitives/keyboard
+
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
+[![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/keyboard?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-primitives/keyboard)
+[![version](https://img.shields.io/npm/v/@solid-primitives/keyboard?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/keyboard)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
+
+A library of reactive promitives helping handling user's keyboard input.
+
+- [`makeHoldKeyListener`](#makeHoldKeyListener) - Attaches keyboard event-listeners, and triggers callback whenever user holds or stops holding specified key.
+
+## Installation
+
+```bash
+npm install @solid-primitives/keyboard
+# or
+yarn add @solid-primitives/keyboard
+```
+
+## `makeHoldKeyListener`
+
+Attaches keyboard event-listeners to `window`, and calls provided callback whenever user holds or stops holding specified key.
+
+Event listeners are automatically cleaned on root dispose.
+
+### How to use it
+
+`makeHoldKeyListener` takes three arguments:
+
+- `key` keyboard key or modifier to listen for
+- `onHoldChange` callback fired when the hold state changes
+- `options` additional configuration:
+  - `preventDefault` — call `e.preventDefault()` on the keyboard event, when the specified key is pressed. _(Defaults to `false`)_
+  - `allowOtherKeys` — Should the user be allowed to press other keys while holding the specified one _(Defaults to `false`)_
+
+```tsx
+import { makeHoldKeyListener } from "@solid-primitives/keyboard";
+
+const [pressing, setPressing] = createSignal(false);
+
+makeHoldKeyListener("altKey", setPressing, {
+  preventDefault: true
+});
+
+<p>Is pressing Alt? {pressing() ? "YES" : "NO"}</p>;
+```
+
+## Changelog
+
+<details>
+<summary><b>Expand Changelog</b></summary>
+
+0.0.100
+
+Initial release as a Stage-0 primitive.
+
+</details>

--- a/packages/keyboard/dev/index.html
+++ b/packages/keyboard/dev/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <title>Solid App</title>
+  <style>
+    html {
+      font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+    }
+
+    body {
+      padding: 0;
+      margin: 0;
+    }
+
+    a,
+    button {
+      cursor: pointer;
+    }
+
+    * {
+      margin: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+
+  <script src="./index.tsx" type="module"></script>
+</body>
+
+</html>

--- a/packages/keyboard/dev/index.tsx
+++ b/packages/keyboard/dev/index.tsx
@@ -2,12 +2,12 @@
 import { Component, createSignal } from "solid-js";
 import { render } from "solid-js/web";
 import "uno.css";
-import { makeHoldKeyListener } from "../src";
+import { makeKeyHoldListener } from "../src";
 
 const App: Component = () => {
   const [pressing, setPressing] = createSignal(false);
 
-  makeHoldKeyListener("altKey", setPressing, {
+  makeKeyHoldListener("altKey", setPressing, {
     preventDefault: true
   });
 

--- a/packages/keyboard/dev/index.tsx
+++ b/packages/keyboard/dev/index.tsx
@@ -1,0 +1,24 @@
+/* @refresh reload */
+import { Component, createSignal } from "solid-js";
+import { render } from "solid-js/web";
+import "uno.css";
+import { makeHoldKeyListener } from "../src";
+
+const App: Component = () => {
+  const [pressing, setPressing] = createSignal(false);
+
+  makeHoldKeyListener("altKey", setPressing, {
+    preventDefault: true
+  });
+
+  return (
+    <div class="p-24 box-border w-full min-h-screen flex flex-col justify-center items-center space-y-4 bg-gray-800 text-white">
+      <div class="wrapper-v">
+        <h4>Is pressing Alt?</h4>
+        <p>{pressing() ? "YES" : "NO"}</p>
+      </div>
+    </div>
+  );
+};
+
+render(() => <App />, document.getElementById("root")!);

--- a/packages/keyboard/dev/vite.config.ts
+++ b/packages/keyboard/dev/vite.config.ts
@@ -1,0 +1,2 @@
+import { viteConfig } from "../../../vite.config";
+export default viteConfig;

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@solid-primitives/keyboard",
+  "version": "0.0.100",
+  "description": "A library of reactive promitives helping handling user's keyboard input.",
+  "author": "Damian Tarnwski <gthetarnav@gmail.com>",
+  "contributors": [],
+  "license": "MIT",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/keyboard#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solidjs-community/solid-primitives.git"
+  },
+  "bugs": {
+    "url": "https://github.com/solidjs-community/solid-primitives/issues"
+  },
+  "primitive": {
+    "name": "keyboard",
+    "stage": 0,
+    "list": [
+      "makeHoldKeyListener"
+    ],
+    "category": "Inputs"
+  },
+  "private": false,
+  "sideEffects": false,
+  "type": "module",
+  "main": "./dist/server.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "node": {
+      "import": "./dist/server.js",
+      "require": "./dist/server.cjs"
+    },
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "start": "vite serve dev --host",
+    "dev": "npm run start",
+    "build": "tsup",
+    "test": "uvu -r solid-register",
+    "test:watch": "watchlist src test -- npm test"
+  },
+  "keywords": [
+    "solid",
+    "primitives",
+    "keyboard",
+    "keystroke",
+    "hotkey"
+  ],
+  "devDependencies": {
+    "jsdom": "^19.0.0",
+    "prettier": "^2.7.1",
+    "solid-register": "^0.2.5",
+    "tslib": "^2.4.0",
+    "tsup": "^6.1.2",
+    "typescript": "^4.7.3",
+    "unocss": "0.39.0",
+    "uvu": "^0.5.3",
+    "vite": "2.9.12",
+    "vite-plugin-solid": "2.2.6",
+    "watchlist": "^0.3.1",
+    "solid-js": "^1.4.4"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.4.0"
+  },
+  "dependencies": {
+    "@solid-primitives/event-listener": "^2.2.0"
+  }
+}

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -17,7 +17,7 @@
     "name": "keyboard",
     "stage": 0,
     "list": [
-      "makeHoldKeyListener"
+      "makeKeyHoldListener"
     ],
     "category": "Inputs"
   },

--- a/packages/keyboard/src/env.d.ts
+++ b/packages/keyboard/src/env.d.ts
@@ -1,0 +1,10 @@
+export {};
+
+declare global {
+  interface Array<T> {
+    includes(searchElement: unknown, fromIndex?: number): boolean;
+  }
+  interface ReadonlyArray<T> {
+    includes(searchElement: unknown, fromIndex?: number): boolean;
+  }
+}

--- a/packages/keyboard/src/holdKeyListener.ts
+++ b/packages/keyboard/src/holdKeyListener.ts
@@ -1,8 +1,10 @@
 import { makeEventListener } from "@solid-primitives/event-listener";
 
-export type HoldKeySetting = "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | (string & {});
+export type KeyModifier = "altKey" | "ctrlKey" | "metaKey" | "shiftKey";
 
-const keyModifierProperties = ["altKey", "ctrlKey", "metaKey", "shiftKey"] as const;
+export type KeyToHold = KeyModifier | (string & {});
+
+const keyModifiers: readonly KeyModifier[] = ["altKey", "ctrlKey", "metaKey", "shiftKey"];
 
 /**
  * Attaches keyboard event-listeners to `window`, and calls {@link onHoldChange} callback whenever user holds or stops holding specified {@link key}.
@@ -15,8 +17,8 @@ const keyModifierProperties = ["altKey", "ctrlKey", "metaKey", "shiftKey"] as co
  * - `options.preventDefault` — call `e.preventDefault()` on the keyboard event, when the specified {@link key} is pressed. *(Defaults to `false`)*
  * - `options.allowOtherKeys` — Should the user be allowed to press other keys while holding the specified one *(Defaults to `false`)*
  */
-export function makeHoldKeyListener(
-  key: HoldKeySetting,
+export function makeKeyHoldListener(
+  key: KeyToHold,
   onHoldChange: (isHolding: boolean) => void,
   options: {
     preventDefault?: boolean;
@@ -25,9 +27,7 @@ export function makeHoldKeyListener(
 ): void {
   const { preventDefault, allowOtherKeys } = options;
 
-  const modifier = keyModifierProperties.includes(key)
-    ? (key as "altKey" | "ctrlKey" | "metaKey" | "shiftKey")
-    : undefined;
+  const modifier = keyModifiers.includes(key) ? (key as KeyModifier) : undefined;
 
   let state = false;
   let actualPressed = false;

--- a/packages/keyboard/src/holdKeyListener.ts
+++ b/packages/keyboard/src/holdKeyListener.ts
@@ -1,0 +1,79 @@
+import { makeEventListener } from "@solid-primitives/event-listener";
+
+export type HoldKeySetting = "altKey" | "ctrlKey" | "metaKey" | "shiftKey" | (string & {});
+
+const keyModifierProperties = ["altKey", "ctrlKey", "metaKey", "shiftKey"] as const;
+
+/**
+ * Attaches keyboard event-listeners to `window`, and calls {@link onHoldChange} callback whenever user holds or stops holding specified {@link key}.
+ *
+ * Event listeners are automatically cleaned on root dispose.
+ *
+ * @param key keyboard key or modifier to listen for
+ * @param onHoldChange callback fired when the hold state changes
+ * @param options additional configuration
+ * - `options.preventDefault` — call `e.preventDefault()` on the keyboard event, when the specified {@link key} is pressed. *(Defaults to `false`)*
+ * - `options.allowOtherKeys` — Should the user be allowed to press other keys while holding the specified one *(Defaults to `false`)*
+ */
+export function makeHoldKeyListener(
+  key: HoldKeySetting,
+  onHoldChange: (isHolding: boolean) => void,
+  options: {
+    preventDefault?: boolean;
+    allowOtherKeys?: boolean;
+  } = {}
+): void {
+  const { preventDefault, allowOtherKeys } = options;
+
+  const modifier = keyModifierProperties.includes(key)
+    ? (key as "altKey" | "ctrlKey" | "metaKey" | "shiftKey")
+    : undefined;
+
+  let state = false;
+  let actualPressed = false;
+
+  const updateState = (newState: boolean) => {
+    newState !== state && onHoldChange((state = newState));
+  };
+
+  makeEventListener(
+    window,
+    "keydown",
+    modifier
+      ? e => {
+          if (e.repeat) return;
+          if (e[modifier]) {
+            if (!state && !actualPressed) {
+              preventDefault && e.preventDefault();
+              onHoldChange((state = actualPressed = true));
+            } else if (!allowOtherKeys) updateState(false);
+          } else updateState((actualPressed = false));
+        }
+      : e => {
+          if (e.key !== key) {
+            allowOtherKeys || updateState(false);
+            return;
+          }
+          if (e.repeat) return;
+          updateState(true);
+        }
+  );
+  makeEventListener(
+    window,
+    "keyup",
+    modifier
+      ? e => {
+          if (e[modifier]) allowOtherKeys || updateState(false);
+          else updateState((actualPressed = false));
+        }
+      : e => {
+          if (e.key !== key) allowOtherKeys || updateState(false);
+          else updateState(false);
+        }
+  );
+  makeEventListener(
+    document,
+    "visibilitychange",
+    () => document.visibilityState !== "visible" && updateState(false)
+  );
+}

--- a/packages/keyboard/src/index.ts
+++ b/packages/keyboard/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./holdKeyListener";

--- a/packages/keyboard/src/server.ts
+++ b/packages/keyboard/src/server.ts
@@ -1,3 +1,3 @@
 import type * as API from "./index";
 
-export const makeHoldKeyListener: typeof API.makeHoldKeyListener = () => {};
+export const makeKeyHoldListener: typeof API.makeKeyHoldListener = () => {};

--- a/packages/keyboard/src/server.ts
+++ b/packages/keyboard/src/server.ts
@@ -1,0 +1,3 @@
+import type * as API from "./index";
+
+export const makeHoldKeyListener: typeof API.makeHoldKeyListener = () => {};

--- a/packages/keyboard/test/index.test.ts
+++ b/packages/keyboard/test/index.test.ts
@@ -1,0 +1,152 @@
+import { makeHoldKeyListener } from "../src";
+import { createRoot } from "solid-js";
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
+
+const testMHKL = suite("makeHoldKeyListener");
+
+testMHKL("calls callback in a simple key scenario", () =>
+  createRoot(dispose => {
+    const captured: boolean[] = [];
+
+    makeHoldKeyListener("a", e => captured.push(e));
+    assert.equal(captured, []);
+
+    let ev = new Event("keydown") as any;
+    ev.key = "a";
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true]);
+
+    ev = new Event("keyup") as any;
+    ev.key = "a";
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true, false]);
+
+    dispose();
+  })
+);
+
+testMHKL("calls callback in a simple modifier scenario", () =>
+  createRoot(dispose => {
+    const captured: boolean[] = [];
+
+    makeHoldKeyListener("altKey", e => captured.push(e));
+    assert.equal(captured, []);
+
+    let ev = new Event("keydown") as any;
+    ev.altKey = true;
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true]);
+
+    ev = new Event("keyup") as any;
+    ev.altKey = false;
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true, false]);
+
+    dispose();
+  })
+);
+
+testMHKL("don't allowOtherKeys — key", () =>
+  createRoot(dispose => {
+    const captured: boolean[] = [];
+
+    makeHoldKeyListener("a", e => captured.push(e));
+    assert.equal(captured, []);
+
+    let ev = new Event("keydown") as any;
+    ev.key = "a";
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true]);
+
+    ev = new Event("keydown") as any;
+    ev.key = "b";
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true, false]);
+
+    dispose();
+  })
+);
+
+testMHKL("don't allowOtherKeys — modifier", () =>
+  createRoot(dispose => {
+    const captured: boolean[] = [];
+
+    makeHoldKeyListener("altKey", e => captured.push(e));
+    assert.equal(captured, []);
+
+    let ev = new Event("keydown") as any;
+    ev.altKey = true;
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true]);
+
+    ev = new Event("keydown") as any;
+    ev.altKey = true;
+    ev.key = "b";
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true, false]);
+
+    dispose();
+  })
+);
+
+testMHKL("allowOtherKeys — key", () =>
+  createRoot(dispose => {
+    const captured: boolean[] = [];
+
+    makeHoldKeyListener("a", e => captured.push(e), {
+      allowOtherKeys: true
+    });
+    assert.equal(captured, []);
+
+    let ev = new Event("keydown") as any;
+    ev.key = "a";
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true]);
+
+    ev = new Event("keydown") as any;
+    ev.key = "b";
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true]);
+
+    dispose();
+  })
+);
+
+testMHKL("allowOtherKeys — modifier", () =>
+  createRoot(dispose => {
+    const captured: boolean[] = [];
+
+    makeHoldKeyListener("altKey", e => captured.push(e), {
+      allowOtherKeys: true
+    });
+    assert.equal(captured, []);
+
+    let ev = new Event("keydown") as any;
+    ev.altKey = true;
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true]);
+
+    ev = new Event("keydown") as any;
+    ev.altKey = true;
+    ev.key = "b";
+    window.dispatchEvent(ev);
+
+    assert.equal(captured, [true]);
+
+    dispose();
+  })
+);
+
+testMHKL.run();

--- a/packages/keyboard/test/index.test.ts
+++ b/packages/keyboard/test/index.test.ts
@@ -1,15 +1,15 @@
-import { makeHoldKeyListener } from "../src";
+import { makeKeyHoldListener } from "../src";
 import { createRoot } from "solid-js";
 import { suite } from "uvu";
 import * as assert from "uvu/assert";
 
-const testMHKL = suite("makeHoldKeyListener");
+const testMHKL = suite("makeKeyHoldListener");
 
 testMHKL("calls callback in a simple key scenario", () =>
   createRoot(dispose => {
     const captured: boolean[] = [];
 
-    makeHoldKeyListener("a", e => captured.push(e));
+    makeKeyHoldListener("a", e => captured.push(e));
     assert.equal(captured, []);
 
     let ev = new Event("keydown") as any;
@@ -32,7 +32,7 @@ testMHKL("calls callback in a simple modifier scenario", () =>
   createRoot(dispose => {
     const captured: boolean[] = [];
 
-    makeHoldKeyListener("altKey", e => captured.push(e));
+    makeKeyHoldListener("altKey", e => captured.push(e));
     assert.equal(captured, []);
 
     let ev = new Event("keydown") as any;
@@ -55,7 +55,7 @@ testMHKL("don't allowOtherKeys — key", () =>
   createRoot(dispose => {
     const captured: boolean[] = [];
 
-    makeHoldKeyListener("a", e => captured.push(e));
+    makeKeyHoldListener("a", e => captured.push(e));
     assert.equal(captured, []);
 
     let ev = new Event("keydown") as any;
@@ -78,7 +78,7 @@ testMHKL("don't allowOtherKeys — modifier", () =>
   createRoot(dispose => {
     const captured: boolean[] = [];
 
-    makeHoldKeyListener("altKey", e => captured.push(e));
+    makeKeyHoldListener("altKey", e => captured.push(e));
     assert.equal(captured, []);
 
     let ev = new Event("keydown") as any;
@@ -102,7 +102,7 @@ testMHKL("allowOtherKeys — key", () =>
   createRoot(dispose => {
     const captured: boolean[] = [];
 
-    makeHoldKeyListener("a", e => captured.push(e), {
+    makeKeyHoldListener("a", e => captured.push(e), {
       allowOtherKeys: true
     });
     assert.equal(captured, []);
@@ -127,7 +127,7 @@ testMHKL("allowOtherKeys — modifier", () =>
   createRoot(dispose => {
     const captured: boolean[] = [];
 
-    makeHoldKeyListener("altKey", e => captured.push(e), {
+    makeKeyHoldListener("altKey", e => captured.push(e), {
       allowOtherKeys: true
     });
     assert.equal(captured, []);

--- a/packages/keyboard/tsconfig.json
+++ b/packages/keyboard/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src", "./test", "./dev"],
+  "exclude": ["node_modules", "./dist"]
+}

--- a/packages/keyboard/tsup.config.ts
+++ b/packages/keyboard/tsup.config.ts
@@ -1,0 +1,2 @@
+import { doubleEntryConfig } from "../../tsup.config";
+export default doubleEntryConfig;


### PR DESCRIPTION
This adds a new package: **keyboard**

There is much more that can be added here, but for now, I'm just adding what I need.
And what I need is: `makeHoldKeyListener`

```tsx
const [pressing, setPressing] = createSignal(false);

makeKeyHoldListener("altKey", setPressing, {
  preventDefault: true
});

<p>Is pressing <kbd>Alt/Option</kdb>? {pressing() ? "YES" : "NO"}</p>;
```

[README](https://github.com/solidjs-community/solid-primitives/tree/keyboard/packages/keyboard#readme)