### PR TITLE
Memo: debounced memo improvements

### DIFF
--- a/packages/memo/README.md
+++ b/packages/memo/README.md
@@ -7,7 +7,7 @@
 [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg?style=for-the-badge)](https://lerna.js.org/)
 [![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/memo?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-primitives/memo)
 [![version](https://img.shields.io/npm/v/@solid-primitives/memo?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/memo)
-[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-2.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
 Collection of custom `createMemo` primitives. They extend it's functionality while keeping the usage similar.
 
@@ -16,7 +16,8 @@ Collection of custom `createMemo` primitives. They extend it's functionality whi
 - [`createLazyMemo`](#createLazyMemo) - Lazily evaluated memo. Will run the calculation only if is being listened to.
 - [`createAsyncMemo`](#createAsyncMemo) - Memo that allows for asynchronous calculations.
 - [`createDebouncedMemo`](#createDebouncedMemo) - Memo which returned signal is debounced.
-- [`createThrottledMemo`](#createThrottledMemo) - Memo which returned signal is throttled.
+- [`createDebouncedMemoOn`](#createDebouncedMemoOn) - Memo which callback is debounced.
+- [`createThrottledMemo`](#createThrottledMemo) - Memo which callback is throttled.
 - [`createPureReaction`](#createPureReaction) - A `createReaction` that runs before render _(non-batching)_.
 - [`createMemoCache`](#createMemoCache) - Custom, lazily-evaluated, memo, with caching based on keys.
 
@@ -175,7 +176,7 @@ const [data] = createResource(signal, value => {...})
 
 ## `createDebouncedMemo`
 
-Solid's `createMemo` which returned signal is debounced.
+Solid's `createMemo` which returned signal is debounced. _(The callback is not debounced!)_
 
 ### How to use it
 
@@ -186,17 +187,28 @@ import { createDebouncedMemo } from "@solid-primitives/memo";
 const double = createDebouncedMemo(prev => count() * 2, 200);
 
 // with initial value:
-const double = createDebouncedMemo(prev => count() * 2, 200, { value: 0 });
+const double = createDebouncedMemo(prev => count() * 2, 200, 0);
 ```
 
-Notes:
+> **Note** The callback is not perfectly debounced, it will be fired every time the source changes. It's the updates of the returned signal that are debounced. If you want to debounce the callback, use [`createDebouncedMemoOn`](#createDebouncedMemoOn) instead.
 
-1. the callback is not perfectly debounced, it will be fired twice for each debounce duration, instead of once. _(this shouldn't really matter, because only a pure calculation should be passed as callback)_
-2. the callback is run initially to kickoff tracking and set the signal's value.
+## `createDebouncedMemoOn`
+
+Solid's `createMemo` with explicit sources, and debounced callback execution.
+
+The `deps` and `fn` arguments are the same as in Solid's `on` halper.
+
+### How to use it
+
+```ts
+import { createDebouncedMemoOn } from "@solid-primitives/memo";
+
+const double = createDebouncedMemoOn(count, v => v * 2, 200);
+```
 
 ## `createThrottledMemo`
 
-Solid's `createMemo` which returned signal is throttled.
+Solid's `createMemo` which callback execution is throttled.
 
 ### How to use it
 
@@ -207,10 +219,8 @@ import { createThrottledMemo } from "@solid-primitives/memo";
 const double = createThrottledMemo(prev => count() * 2, 200);
 
 // with initial value:
-const double = createThrottledMemo(prev => count() * 2, 200, { value: 0 });
+const double = createThrottledMemo(prev => count() * 2, 200, 0);
 ```
-
-Note: the callback is run initially to kickoff tracking and set the signal's value.
 
 ## `createPureReaction`
 
@@ -340,5 +350,11 @@ Support for Solid 1.4
 Improve how `createPureReaction`, `createThrottledMemo` and `createDebouncedMemo` work when created during batched effect.
 
 Provida a separate tuntime for server.
+
+1.0.0 - **stage-3**
+
+Add `createDebouncedMemoOn` primitive.
+
+Move the initial value argument from options to a separate argument in `createDebouncedMemo` and `createThrottledMemo` primitives.
 
 </details>

--- a/packages/memo/dev/grouped.tsx
+++ b/packages/memo/dev/grouped.tsx
@@ -1,10 +1,10 @@
-import { createDebouncedMemo, createThrottledMemo } from "../src";
+import { createDebouncedMemo, createDebouncedMemoOn, createThrottledMemo } from "../src";
 import { Component, Show } from "solid-js";
 import { createMousePosition } from "@solid-primitives/mouse";
 
 const Grouped: Component = () => {
   const pos = createMousePosition();
-  const debPos = createDebouncedMemo(() => ({ x: pos.x, y: pos.y }), 200);
+  const debPos = createDebouncedMemoOn([() => pos.x, () => pos.y], ([x, y]) => ({ x, y }), 200);
   const thrPos = createThrottledMemo(() => ({ x: pos.x, y: pos.y }), 200);
 
   return (

--- a/packages/memo/package.json
+++ b/packages/memo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/memo",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Collection of custom memo primitives. They extend Solid's createMemo functionality while keeping the usage similar.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "contributors": [],
@@ -15,13 +15,14 @@
   },
   "primitive": {
     "name": "memo",
-    "stage": 2,
+    "stage": 3,
     "list": [
       "createCurtain",
       "createWritableMemo",
       "createLazyMemo",
       "createAsyncMemo",
       "createDebouncedMemo",
+      "createDebouncedMemoOn",
       "createThrottledMemo",
       "createPureReaction",
       "createMemoCache"

--- a/packages/memo/src/server.ts
+++ b/packages/memo/src/server.ts
@@ -1,5 +1,5 @@
 import { noop } from "@solid-primitives/utils";
-import { Accessor } from "solid-js";
+import { Accessor, createMemo, on } from "solid-js";
 import * as API from "./index";
 
 export const createPureReaction: typeof API.createPureReaction = () => noop;
@@ -8,15 +8,28 @@ export const createCurtain = API.createCurtain;
 
 export const createWritableMemo = API.createWritableMemo;
 
-export const createDebouncedMemo: typeof API.createDebouncedMemo = (calc, timeoutMs, options) => {
-  const value = calc(options?.value as any);
+export const createDebouncedMemo: typeof API.createDebouncedMemo = ((calc, timeoutMs, init) => {
+  const value = calc(init as any);
   return () => value;
-};
+}) as typeof API.createDebouncedMemo;
 
-export const createThrottledMemo: typeof API.createThrottledMemo = (calc, timeoutMs, options) => {
-  const value = calc(options?.value as any);
+export const createDebouncedMemoOn: typeof API.createDebouncedMemoOn = ((
+  deps,
+  calc,
+  timeoutMs,
+  init,
+  options
+) =>
+  createMemo(
+    on(deps, calc as any) as () => any,
+    init,
+    options
+  )) as typeof API.createDebouncedMemoOn;
+
+export const createThrottledMemo: typeof API.createThrottledMemo = ((calc, timeoutMs, init) => {
+  const value = calc(init as any);
   return () => value;
-};
+}) as typeof API.createThrottledMemo;
 
 export const createAsyncMemo: typeof API.createAsyncMemo = (calc, options) => options?.value;
 

--- a/packages/memo/test/exports.test.ts
+++ b/packages/memo/test/exports.test.ts
@@ -1,0 +1,14 @@
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
+import * as API from "../src/index";
+import * as noopAPI from "../src/server";
+
+const test = suite("exports");
+
+test("server have to exports match client exports", () => {
+  (Object.keys(API) as (keyof typeof API)[]).forEach(name => {
+    assert.is(typeof noopAPI[name], typeof API[name]);
+  });
+});
+
+test.run();


### PR DESCRIPTION
- Add `createDebouncedMemoOn` primitive.
- Improves `createDebouncedMemo`
- Moves the initial value argument from options to a separate argument in `createDebouncedMemo` and `createThrottledMemo` primitives.
- Bumps the package stage to 3, and version to 1.0.0, as changing the arguments is a breaking change, and the package has been frequently used and improved upon for a while now.