### PR TITLE
export 2 Actions Type

### DIFF
--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -8,9 +8,11 @@ export type {
   StorageObject,
   StorageSetter,
   AsyncStorage,
+  StorageActions,
   AsyncStorageWithOptions,
   AsyncStorageObject,
   AsyncStorageSetter,
+  AsyncStorageActions,
   StorageSignalProps
 } from "./types";
 


### PR DESCRIPTION
These two types are routinely used for context references, and perhaps they were just neglected