### PR TITLE
Props: add `filterProps` primitive

### DIFF
--- a/packages/props/README.md
+++ b/packages/props/README.md
@@ -124,7 +124,7 @@ https://codesandbox.io/s/combineprops-demo-ytw247?file=/index.tsx
 
 A helper that creates a new props object with only the property names that match the predicate.
 
-An alternative primitive to Solid's [splitProps](https://www.solidjs.com/docs/latest/api#splitprops) that will split the props eagerly, without letting you change the omitter keys afterwards.
+An alternative primitive to Solid's [splitProps](https://www.solidjs.com/docs/latest/api#splitprops) that will split the props eagerly, without letting you change the omitted keys afterwards.
 
 The `predicate` is run for every property read lazily — any signal accessed within the `predicate` will be tracked, and `predicate` re-executed if changed.
 

--- a/packages/props/README.md
+++ b/packages/props/README.md
@@ -12,6 +12,7 @@
 Library of primitives focused around component props.
 
 - [`combineProps`](#combineProps) - Reactively merges multiple props objects together while smartly combining some of Solid's JSX/DOM attributes.
+- [`filterProps`](#filterProps) - Create a new props object with only the property names that match the predicate.
 - [`createProps`](#createProps) - Provides controllable props signals like knobs/controls for simple component testing.
 
 ## Installation
@@ -119,6 +120,52 @@ styles; // { margin: "2rem", border: "1px solid #121212", padding: "16px" }
 
 https://codesandbox.io/s/combineprops-demo-ytw247?file=/index.tsx
 
+## `filterProps`
+
+A helper that creates a new props object with only the property names that match the predicate.
+
+An alternative primitive to Solid's [splitProps](https://www.solidjs.com/docs/latest/api#splitprops) that will split the props eagerly, without letting you change the omitter keys afterwards.
+
+The `predicate` is run for every property read lazily — any signal accessed within the `predicate` will be tracked, and `predicate` re-executed if changed.
+
+### How to use it
+
+Params:
+
+- `props` — The props object to filter.
+- `predicate` — A function that returns `true` if the property should be included in the filtered object.
+
+Returns A new props object with only the properties that match the predicate.
+
+```tsx
+import { filterProps } from "@solid-primitives/props";
+
+const MyComponent = props => {
+  const dataProps = filterProps(props, key => key.startsWith("data-"));
+
+  return <div {...dataProps} />;
+};
+```
+
+### `createPropsPredicate`
+
+Creates a predicate function that can be used to filter props by the prop name dynamically.
+
+The provided `predicate` function get's wrapped with a cache layer to prevent unnecessary re-evaluation. If one property is requested multiple times, the `predicate` will only be evaluated once.
+
+The cache is only cleared when the keys of the props object change. _(when spreading props from a singal)_ This also means that any signal accessed within the `predicate` won't be tracked.
+
+```tsx
+import { filterProps, createPropsPredicate } from "@solid-primitives/props";
+
+const MyComponent = props => {
+  const predicate = createPropsPredicate(props, key => key.startsWith("data-"));
+  const dataProps = filterProps(props, predicate);
+
+  return <div {...dataProps} />;
+};
+```
+
 ## `createProps`
 
 Primitive that provides controllable props signals like knobs/controls for simple component testing
@@ -212,5 +259,9 @@ Add support for tuple event handlers and de-dupeing to `combineProps`.
 2.1.1
 
 Support for Solid 1.4
+
+2.2.0
+
+Add `filterProps` and `createPropsPredicate` primitives.
 
 </details>

--- a/packages/props/package.json
+++ b/packages/props/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/props",
-  "version": "2.1.8",
+  "version": "2.2.0",
   "description": "Library of primitives focused around component props.",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "contributors": [
@@ -17,6 +17,7 @@
     "stage": 3,
     "list": [
       "combineProps",
+      "filterProps",
       "createControlledProps"
     ],
     "category": "Utilities"
@@ -69,7 +70,8 @@
     "unocss": "^0.39.3",
     "uvu": "^0.5.6",
     "vite": "^2.9.14",
-    "vite-plugin-solid": "2.2.6"
+    "vite-plugin-solid": "2.2.6",
+    "solid-js": "^1.4.7"
   },
   "peerDependencies": {
     "solid-js": "^1.3.0"

--- a/packages/props/src/filterProps.ts
+++ b/packages/props/src/filterProps.ts
@@ -20,10 +20,12 @@ export function filterProps<T>(props: T, predicate: (key: keyof T) => boolean): 
   return new Proxy(
     {
       get(property: string | number | symbol) {
-        return predicate(property as keyof T) ? props[property as keyof T] : undefined;
+        return property in props && predicate(property as keyof T)
+          ? props[property as keyof T]
+          : undefined;
       },
       has(property: string | number | symbol) {
-        return predicate(property as keyof T) ? property in props : false;
+        return property in props && predicate(property as keyof T);
       },
       keys() {
         return Object.keys(props).filter(predicate as (key: string) => boolean);
@@ -65,11 +67,11 @@ export function createPropsPredicate<T>(
     { equals: false }
   );
   return key => {
-    const _cache = cache();
-    const cached = _cache[key];
+    const cacheRef = cache();
+    const cached = cacheRef[key];
     if (cached !== undefined) return cached;
     const v = predicate(key);
-    _cache[key] = v;
+    cacheRef[key] = v;
     return v;
   };
 }

--- a/packages/props/src/filterProps.ts
+++ b/packages/props/src/filterProps.ts
@@ -1,6 +1,21 @@
 import { createMemo } from "solid-js";
 import { propTraps } from "./propTraps";
 
+/**
+ * An alternative primitive to Solid's [splitProps](https://www.solidjs.com/docs/latest/api#splitprops) allowing you to create a new props object with only the property names that match the predicate.
+ *
+ * The predicate is run for every property read lazily, instead of calculated eagerly like the original splitProps. Any signal accessed within the `predicate` will be tracked, and `predicate` re-executed if changed.
+ *
+ * @param props The props object to filter.
+ * @param predicate A function that returns `true` if the property should be included in the filtered object.
+ * @returns A new props object with only the properties that match the predicate.
+ *
+ * @example
+ * ```tsx
+ * const dataProps = filterProps(props, key => key.startsWith("data-"));
+ * <div {...dataProps} />
+ * ```
+ */
 export function filterProps<T>(props: T, predicate: (key: keyof T) => boolean): T {
   return new Proxy(
     {
@@ -18,6 +33,24 @@ export function filterProps<T>(props: T, predicate: (key: keyof T) => boolean): 
   ) as unknown as T;
 }
 
+/**
+ * Creates a predicate function that can be used to filter props by the prop name dynamically.
+ *
+ * The provided {@link predicate} function get's wrapped with a cache layer to prevent unnecessary re-evaluation. If one property is requested multiple times, the predicate function will only be evaluated once.
+ *
+ * The cache is only cleared when the keys of the props object change. *(when spreading props from a singal)*
+ *
+ * @param props The props object to filter.
+ * @param predicate A function that returns `true` if the property should be included in the filtered object.
+ * @returns A cached predicate function that filters the props object.
+ *
+ * @example
+ * ```tsx
+ * const predicate = createPropsPredicate(props, key => key.startsWith("data-"));
+ * const dataProps = filterProps(props, predicate);
+ * <div {...dataProps} />
+ * ```
+ */
 export function createPropsPredicate<T>(
   props: T,
   predicate: (key: keyof T) => boolean

--- a/packages/props/src/filterProps.ts
+++ b/packages/props/src/filterProps.ts
@@ -1,0 +1,42 @@
+import { createMemo } from "solid-js";
+import { propTraps } from "./propTraps";
+
+export function filterProps<T>(props: T, predicate: (key: keyof T) => boolean): T {
+  return new Proxy(
+    {
+      get(property: string | number | symbol) {
+        return predicate(property as keyof T) ? props[property as keyof T] : undefined;
+      },
+      has(property: string | number | symbol) {
+        return predicate(property as keyof T) ? property in props : false;
+      },
+      keys() {
+        return Object.keys(props).filter(predicate as (key: string) => boolean);
+      }
+    },
+    propTraps
+  ) as unknown as T;
+}
+
+export function createPropsPredicate<T>(
+  props: T,
+  predicate: (key: keyof T) => boolean
+): (key: keyof T) => boolean {
+  const cache = createMemo(
+    (): Partial<Record<keyof T, boolean>> => {
+      // track prop names — adding/removing keys to dynamic props will trigger this
+      Object.keys(props);
+      return {};
+    },
+    undefined,
+    { equals: false }
+  );
+  return key => {
+    const _cache = cache();
+    const cached = _cache[key];
+    if (cached !== undefined) return cached;
+    const v = predicate(key);
+    _cache[key] = v;
+    return v;
+  };
+}

--- a/packages/props/src/index.tsx
+++ b/packages/props/src/index.tsx
@@ -1,2 +1,4 @@
+export * from "./propTraps";
 export * from "./controlledProps";
+export * from "./filterProps";
 export * from "./combineProps";

--- a/packages/props/src/propTraps.ts
+++ b/packages/props/src/propTraps.ts
@@ -1,0 +1,35 @@
+import { $PROXY } from "solid-js";
+
+function trueFn() {
+  return true;
+}
+
+export const propTraps: ProxyHandler<{
+  get: (k: string | number | symbol) => any;
+  has: (k: string | number | symbol) => boolean;
+  keys: () => string[];
+}> = {
+  get(_, property, receiver) {
+    if (property === $PROXY) return receiver;
+    return _.get(property);
+  },
+  has(_, property) {
+    return _.has(property);
+  },
+  set: trueFn,
+  deleteProperty: trueFn,
+  getOwnPropertyDescriptor(_, property) {
+    return {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return _.get(property);
+      },
+      set: trueFn,
+      deleteProperty: trueFn
+    };
+  },
+  ownKeys(_) {
+    return _.keys();
+  }
+};

--- a/packages/props/test/filterProps.test.ts
+++ b/packages/props/test/filterProps.test.ts
@@ -40,6 +40,10 @@ test("predicate runs for every read", () => {
   assert.equal(checked, ["a"]);
   checked.length = 0;
 
+  filtered["not-existing"];
+  assert.is(checked.length, 0, "predicate is not run for non-existing keys");
+  checked.length = 0;
+
   filtered.b;
   filtered.a;
   filtered.a;

--- a/packages/props/test/filterProps.test.ts
+++ b/packages/props/test/filterProps.test.ts
@@ -1,0 +1,194 @@
+import { createComputed, createRoot, createSignal, mergeProps } from "solid-js";
+import { suite } from "uvu";
+import * as assert from "uvu/assert";
+import { filterProps, createPropsPredicate } from "../src";
+
+const test = suite("filterProps");
+
+test("filters props", () => {
+  const props = {
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4
+  };
+  const filtered = filterProps(props, key => key !== "b");
+  assert.equal(filtered, {
+    a: 1,
+    c: 3,
+    d: 4
+  });
+  assert.equal(Object.keys(filtered), ["a", "c", "d"]);
+});
+
+test("predicate runs for every read", () => {
+  const checked: string[] = [];
+  const filtered: any = filterProps(
+    {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4
+    },
+    key => {
+      checked.push(key);
+      return true;
+    }
+  );
+  assert.is(checked.length, 0);
+  filtered.a;
+  assert.equal(checked, ["a"]);
+  checked.length = 0;
+
+  filtered.b;
+  filtered.a;
+  filtered.a;
+  assert.equal(checked, ["b", "a", "a"]);
+  checked.length = 0;
+
+  Object.keys(filtered);
+  assert.equal(checked, ["a", "b", "c", "d"]);
+});
+
+test("supports dynamic props", () =>
+  createRoot(dispose => {
+    const [props, setProps] = createSignal<Record<string, number>>({
+      a: 1,
+      b: 2,
+      c: 3
+    });
+    const proxy = mergeProps(props);
+    const filtered = filterProps(proxy, key => key !== "b" && key !== "d");
+    let captured: any;
+    createComputed(() => {
+      captured = { ...filtered };
+    });
+    assert.equal(captured, {
+      a: 1,
+      c: 3
+    });
+
+    setProps({
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      e: 5
+    });
+
+    assert.equal(captured, {
+      a: 1,
+      c: 3,
+      e: 5
+    });
+
+    dispose();
+  }));
+
+test.run();
+
+const testCached = suite("filterProps + createPropsPredicate");
+
+testCached("filters props", () =>
+  createRoot(dispose => {
+    const props = {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4
+    };
+    const filtered = filterProps(
+      props,
+      createPropsPredicate(props, key => key !== "b")
+    );
+    assert.equal(filtered, {
+      a: 1,
+      c: 3,
+      d: 4
+    });
+    assert.equal(Object.keys(filtered), ["a", "c", "d"]);
+
+    dispose();
+  })
+);
+
+testCached("predicate is cached", () =>
+  createRoot(dispose => {
+    const props = {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4
+    };
+    const checked: string[] = [];
+    const filtered: any = filterProps(
+      props,
+      createPropsPredicate(props, key => {
+        checked.push(key);
+        return true;
+      })
+    );
+    assert.is(checked.length, 0);
+
+    filtered.a;
+    assert.equal(checked, ["a"]);
+
+    filtered.b;
+    filtered.a;
+    filtered.a;
+    assert.equal(checked, ["a", "b"]);
+
+    Object.keys(filtered);
+    assert.equal(checked, ["a", "b", "c", "d"]);
+
+    dispose();
+  })
+);
+
+testCached("supports dynamic props", () =>
+  createRoot(dispose => {
+    const checked: string[] = [];
+    const [props, setProps] = createSignal<Record<string, number>>({
+      a: 1,
+      b: 2,
+      c: 3
+    });
+    const proxy = mergeProps(props);
+    const filtered = filterProps(
+      proxy,
+      createPropsPredicate(proxy, key => {
+        checked.push(key);
+        return key !== "b" && key !== "d";
+      })
+    );
+    let captured: any;
+    createComputed(() => {
+      captured = { ...filtered };
+    });
+    assert.equal(captured, {
+      a: 1,
+      c: 3
+    });
+    assert.equal(checked, ["a", "b", "c"]);
+    checked.length = 0;
+
+    setProps({
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      e: 5
+    });
+
+    assert.equal(captured, {
+      a: 1,
+      c: 3,
+      e: 5
+    });
+    assert.equal(checked, ["a", "b", "c", "d", "e"]);
+
+    dispose();
+  })
+);
+
+testCached.run();


### PR DESCRIPTION
Adds `filterProps` and `createPropsPredicate` primitives to the props package.

The idea of `filterProps` comes from the [`filterDOMProps`](https://github.com/solidjs-community/solid-aria/blob/main/packages/utils/src/filterDOMProps.ts#L58) helper in solid-aria, and will be used to update it.

[README](https://github.com/solidjs-community/solid-primitives/tree/filter-props/packages/props#filterprops)