### PR TITLE
chore(fetch): add defer stream to FetchOptions

### DIFF
--- a/packages/fetch/src/index.ts
+++ b/packages/fetch/src/index.ts
@@ -10,6 +10,7 @@ type FetchOptions<I> = I extends undefined
       fetch?: typeof fetch;
       responseHandler?: (response: Response) => any;
       disable?: boolean;
+      deferStream?: boolean;
     }
   : {
       initialValue: I;
@@ -17,6 +18,7 @@ type FetchOptions<I> = I extends undefined
       fetch?: typeof fetch;
       responseHandler?: (response: Response) => any;
       disable?: boolean;
+      deferStream?: boolean;
     };
 
 export type FetchReturn<T, I> = [


### PR DESCRIPTION
# Summary
Since v1.4.0 you can use deferStream so Solid waits for resource before flushing to stream, however this package doesn't support this with its types.