### PR TITLE
fetch: remove side-effects

### DIFF
--- a/.changeset/large-spoons-heal.md
+++ b/.changeset/large-spoons-heal.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/fetch": minor
+---
+
+remove side effects

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -21,7 +21,7 @@
     "dist"
   ],
   "private": false,
-  "sideEffects": true,
+  "sideEffects": false,
   "type": "module",
   "main": "./dist/server.cjs",
   "module": "./dist/index.js",
@@ -62,7 +62,7 @@
     "vitest": "^0.20.3"
   },
   "peerDependencies": {
-    "node-fetch": ">=2.0.0",
+    "node-fetch": ">=3.2.10",
     "solid-js": ">=1.3.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
The side effect was impacting tree shaking. Thanks to the composable update, we can now easily remove the global polyfill.