### PR TITLE
New package: Cursor

### DIFF
--- a/packages/cursor/LICENSE
+++ b/packages/cursor/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Solid Primitives Working Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/cursor/README.md
+++ b/packages/cursor/README.md
@@ -1,0 +1,38 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=cursor" alt="Solid Primitives cursor">
+</p>
+
+# @solid-primitives/cursor
+
+[![turborepo](https://img.shields.io/badge/built%20with-turborepo-cc00ff.svg?style=for-the-badge&logo=turborepo)](https://turborepo.org/)
+[![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/cursor?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-primitives/cursor)
+[![version](https://img.shields.io/npm/v/@solid-primitives/cursor?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/cursor)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
+
+A sample primitive that is made up for templating with the following options:
+
+`createPrimitiveTemplate` - Provides a getter and setter for the primitive.
+
+## Installation
+
+```bash
+npm install @solid-primitives/cursor
+# or
+yarn add @solid-primitives/cursor
+# or
+pnpm add @solid-primitives/cursor
+```
+
+## How to use it
+
+```ts
+const [value, setValue] = createPrimitiveTemplate(false);
+```
+
+## Demo
+
+You can use this template for publishing your demo on CodeSandbox: https://codesandbox.io/s/solid-primitives-demo-template-sz95h
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md)

--- a/packages/cursor/README.md
+++ b/packages/cursor/README.md
@@ -9,9 +9,10 @@
 [![version](https://img.shields.io/npm/v/@solid-primitives/cursor?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/cursor)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
-A sample primitive that is made up for templating with the following options:
+Two simple primitives for setting cursor css property reactively.
 
-`createPrimitiveTemplate` - Provides a getter and setter for the primitive.
+- [`createElementCursor`](#createElementCursor) - Set provided cursor to given HTML Element styles reactively.
+- [`createBodyCursor`](#createBodyCursor) - Set selected cursor to body element styles reactively.
 
 ## Installation
 
@@ -23,15 +24,45 @@ yarn add @solid-primitives/cursor
 pnpm add @solid-primitives/cursor
 ```
 
-## How to use it
+## `createElementCursor`
+
+Set provided cursor to given HTML Element styles reactively.
+
+It takes two arguments:
+
+- `element` - HTMLElement or a reactive signal returning one. Returning falsy value will unset the cursor.
+- `cursor` - Cursor css property. E.g. "pointer", "grab", "zoom-in", "wait", etc.
 
 ```ts
-const [value, setValue] = createPrimitiveTemplate(false);
+import { createElementCursor } from "@solid-primitives/cursor";
+
+const target = document.querySelector("#element");
+const [cursor, setCursor] = createSignal("pointer");
+const [enabled, setEnabled] = createSignal(true);
+
+createElementCursor(() => enabled() && target, cursor);
+
+setCursor("help");
 ```
 
-## Demo
+## `createBodyCursor`
 
-You can use this template for publishing your demo on CodeSandbox: https://codesandbox.io/s/solid-primitives-demo-template-sz95h
+Set selected cursor to body element styles reactively.
+
+It takes only one argument:
+
+- `cursor` - Signal returing a cursor css property. E.g. "pointer", "grab", "zoom-in", "wait", etc. Returning falsy value will unset the cursor.
+
+```ts
+import { createBodyCursor } from "@solid-primitives/cursor";
+
+const [cursor, setCursor] = createSignal("pointer");
+const [enabled, setEnabled] = createSignal(true);
+
+createBodyCursor(() => enabled() && cursor());
+
+setCursor("help");
+```
 
 ## Changelog
 

--- a/packages/cursor/dev/App.tsx
+++ b/packages/cursor/dev/App.tsx
@@ -1,0 +1,115 @@
+import { Component, createSignal } from "solid-js";
+import { CursorProperty, createBodyCursor, createElementCursor } from "../src";
+
+const CURSORS = [
+  "alias",
+  "all-scroll",
+  "cell",
+  "col-resize",
+  "context-menu",
+  "copy",
+  "crosshair",
+  "default",
+  "e-resize",
+  "ew-resize",
+  "grab",
+  "grabbing",
+  "help",
+  "move",
+  "n-resize",
+  "ne-resize",
+  "nesw-resize",
+  "no-drop",
+  "none",
+  "not-allowed",
+  "ns-resize",
+  "nw-resize",
+  "nwse-resize",
+  "pointer",
+  "progress",
+  "row-resize",
+  "s-resize",
+  "se-resize",
+  "sw-resize",
+  "text",
+  "vertical-text",
+  "w-resize",
+  "wait",
+  "zoom-in",
+  "zoom-out"
+] as const;
+
+const BodyCursorTest: Component = () => {
+  const [bodyCursor, setBodyCursor] = createSignal<CursorProperty>("pointer");
+  const [enableBodyCursor, setEnableBodyCursor] = createSignal(true);
+
+  createBodyCursor(() => enableBodyCursor() && bodyCursor());
+
+  return (
+    <div class="wrapper-v">
+      <h4>Toggle Body cursor</h4>
+      <div class="flex">
+        <button
+          class="btn"
+          onClick={() => setBodyCursor(() => CURSORS[(Math.random() * CURSORS.length) | 0])}
+        >
+          {bodyCursor()}
+        </button>
+        <button class="btn" onClick={() => setEnableBodyCursor(p => !p)}>
+          {enableBodyCursor() ? "Disable" : "Enable"}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+const ElementCursorTest: Component = () => {
+  const [cursor, setCursor] = createSignal<CursorProperty>("pointer");
+  const [enable, setEnable] = createSignal(true);
+  const [target, setTarget] = createSignal(null as HTMLElement | null);
+
+  createElementCursor(() => enable() && target(), cursor);
+
+  return (
+    <div class="wrapper-v">
+      <h4>Toggle Element cursor</h4>
+      <div class="flex">
+        <button
+          class="btn"
+          onClick={() => setCursor(() => CURSORS[(Math.random() * CURSORS.length) | 0])}
+        >
+          {cursor()}
+        </button>
+        <button class="btn" onClick={() => setEnable(p => !p)}>
+          {enable() ? "Disable" : "Enable"}
+        </button>
+      </div>
+      <div class="flex sapce-x-2">
+        {Array.from({ length: 4 }).map((_, i) => {
+          let ref: HTMLDivElement | undefined;
+          return (
+            <div
+              ref={ref}
+              class="node"
+              onClick={() => setTarget(ref!)}
+              classList={{
+                "bg-red-700": ref === target()
+              }}
+            >
+              {i + 1}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export const App: Component = () => {
+  return (
+    <div class="p-24 box-border w-full min-h-screen flex flex-col justify-center items-center space-y-4 bg-gray-800 text-white">
+      <BodyCursorTest />
+      <ElementCursorTest />
+    </div>
+  );
+};

--- a/packages/cursor/dev/index.html
+++ b/packages/cursor/dev/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <title>Solid App</title>
+  <style>
+    html {
+      font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+    }
+
+    body {
+      padding: 0;
+      margin: 0;
+    }
+
+    a,
+    button {
+      cursor: pointer;
+    }
+
+    * {
+      margin: 0;
+    }
+  </style>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="root"></div>
+
+  <script src="./index.tsx" type="module"></script>
+</body>
+
+</html>

--- a/packages/cursor/dev/index.tsx
+++ b/packages/cursor/dev/index.tsx
@@ -1,0 +1,22 @@
+import { Component, createSignal } from "solid-js";
+import { render } from "solid-js/web";
+import "uno.css";
+
+const App: Component = () => {
+  const [count, setCount] = createSignal(0);
+  const increment = () => setCount(count() + 1);
+
+  return (
+    <div class="p-24 box-border w-full min-h-screen flex flex-col justify-center items-center space-y-4 bg-gray-800 text-white">
+      <div class="wrapper-v">
+        <h4>Counter component</h4>
+        <p class="caption">it's very important...</p>
+        <button class="btn" onClick={increment}>
+          {count()}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+render(() => <App />, document.getElementById("root")!);

--- a/packages/cursor/dev/index.tsx
+++ b/packages/cursor/dev/index.tsx
@@ -1,22 +1,6 @@
-import { Component, createSignal } from "solid-js";
 import { render } from "solid-js/web";
 import "uno.css";
-
-const App: Component = () => {
-  const [count, setCount] = createSignal(0);
-  const increment = () => setCount(count() + 1);
-
-  return (
-    <div class="p-24 box-border w-full min-h-screen flex flex-col justify-center items-center space-y-4 bg-gray-800 text-white">
-      <div class="wrapper-v">
-        <h4>Counter component</h4>
-        <p class="caption">it's very important...</p>
-        <button class="btn" onClick={increment}>
-          {count()}
-        </button>
-      </div>
-    </div>
-  );
-};
+import "solid-devtools";
+import { App } from "./App";
 
 render(() => <App />, document.getElementById("root")!);

--- a/packages/cursor/dev/vite.config.ts
+++ b/packages/cursor/dev/vite.config.ts
@@ -1,0 +1,2 @@
+import { viteConfig } from "../../../vite.config";
+export default viteConfig;

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "@solid-primitives/cursor",
+  "version": "0.0.100",
+  "description": "A template primitive example.",
+  "author": "Damian Tarnawski <gthetarnav@gmail.com>",
+  "contributors": [],
+  "license": "MIT",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/cursor#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solidjs-community/solid-primitives.git"
+  },
+  "bugs": {
+    "url": "https://github.com/solidjs-community/solid-primitives/issues"
+  },
+  "primitive": {
+    "name": "cursor",
+    "stage": 0,
+    "list": [
+      "createElementCursor",
+      "createBodyCursor"
+    ],
+    "category": "Utilities"
+  },
+  "private": false,
+  "sideEffects": false,
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/server.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "node": {
+      "import": "./dist/server.js",
+      "require": "./dist/server.cjs"
+    },
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
+  "scripts": {
+    "start": "vite serve dev --host",
+    "dev": "npm run start",
+    "build": "tsup",
+    "test": "vitest"
+  },
+  "keywords": [
+    "solid",
+    "primitives"
+  ],
+  "devDependencies": {
+    "jsdom": "^20.0.0",
+    "prettier": "^2.7.1",
+    "solid-js": "^1.4.8",
+    "tslib": "^2.4.0",
+    "tsup": "^6.2.2",
+    "typescript": "^4.7.4",
+    "unocss": "^0.44.7",
+    "vite": "^3.0.7",
+    "vite-plugin-solid": "^2.3.0",
+    "vitest": "^0.20.3"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.4.0"
+  },
+  "dependencies": {
+    "@solid-primitives/utils": "^3.0.1"
+  }
+}

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@solid-primitives/cursor",
   "version": "0.0.100",
-  "description": "A template primitive example.",
+  "description": "Two simple primitives for setting cursor css property reactively.",
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
@@ -47,7 +47,9 @@
   },
   "keywords": [
     "solid",
-    "primitives"
+    "primitives",
+    "style",
+    "cursor"
   ],
   "devDependencies": {
     "jsdom": "^20.0.0",

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "jsdom": "^20.0.0",
     "prettier": "^2.7.1",
+    "solid-devtools": "^0.12.0",
     "solid-js": "^1.4.8",
     "tslib": "^2.4.0",
     "tsup": "^6.2.2",

--- a/packages/cursor/src/index.ts
+++ b/packages/cursor/src/index.ts
@@ -50,8 +50,6 @@ export type CursorProperty =
  *
  * @example
  * ```ts
- * import { createElementCursor } from "@solid-primitives/cursor";
- *
  * const target = document.querySelector("#element");
  * const [cursor, setCursor] = createSignal("pointer");
  * const [enabled, setEnabled] = createSignal(true);
@@ -82,8 +80,6 @@ export function createElementCursor(
  *
  * @example
  * ```ts
- * import { createBodyCursor } from "@solid-primitives/cursor";
- *
  * const [cursor, setCursor] = createSignal("pointer");
  * const [enabled, setEnabled] = createSignal(true);
  *

--- a/packages/cursor/src/index.ts
+++ b/packages/cursor/src/index.ts
@@ -1,0 +1,85 @@
+import { Accessor, createEffect } from "solid-js";
+import { access, FalsyValue, MaybeAccessor } from "@solid-primitives/utils";
+
+export type CursorProperty =
+  | "-moz-grab"
+  | "-webkit-grab"
+  | "alias"
+  | "all-scroll"
+  | "auto"
+  | "cell"
+  | "col-resize"
+  | "context-menu"
+  | "copy"
+  | "crosshair"
+  | "default"
+  | "e-resize"
+  | "ew-resize"
+  | "grab"
+  | "grabbing"
+  | "help"
+  | "move"
+  | "n-resize"
+  | "ne-resize"
+  | "nesw-resize"
+  | "no-drop"
+  | "none"
+  | "not-allowed"
+  | "ns-resize"
+  | "nw-resize"
+  | "nwse-resize"
+  | "pointer"
+  | "progress"
+  | "row-resize"
+  | "s-resize"
+  | "se-resize"
+  | "sw-resize"
+  | "text"
+  | "vertical-text"
+  | "w-resize"
+  | "wait"
+  | "zoom-in"
+  | "zoom-out"
+  | (string & {});
+
+/**
+ * Set selected {@link cursor} to {@link target} styles.
+ *
+ * @param target
+ * @param cursor
+ */
+export function createElementCursor(
+  target: Accessor<HTMLElement | FalsyValue> | HTMLElement,
+  cursor: MaybeAccessor<CursorProperty>
+): void {
+  createEffect<{ el: HTMLElement | FalsyValue; cursor: CursorProperty }>(
+    prev => {
+      const el = access(target);
+      const cursorValue = access(cursor);
+      if (prev.el === el && prev.cursor === cursorValue) return prev;
+      if (prev.el) prev.el.style.cursor = prev.cursor;
+      if (el) {
+        const newPrevCursor = el.style.cursor;
+        el.style.cursor = cursorValue;
+        return { el, cursor: newPrevCursor };
+      }
+      return { el, cursor: "" };
+    },
+    { el: undefined, cursor: "" }
+  );
+}
+
+export function createBodyCursor(cursor: Accessor<CursorProperty | FalsyValue>): void {
+  let overwritten: string;
+  createEffect((prev: CursorProperty | FalsyValue) => {
+    const cursorValue = cursor();
+    if (prev === cursorValue) return prev;
+    if (cursorValue) {
+      overwritten = document.body.style.cursor;
+      document.body.style.cursor = cursorValue;
+    } else {
+      document.body.style.cursor = overwritten;
+    }
+    return cursorValue;
+  });
+}

--- a/packages/cursor/src/server.ts
+++ b/packages/cursor/src/server.ts
@@ -1,0 +1,4 @@
+import * as API from ".";
+
+export const createElementCursor: typeof API.createElementCursor = () => {};
+export const createBodyCursor: typeof API.createBodyCursor = () => {};

--- a/packages/cursor/test/exports.test.ts
+++ b/packages/cursor/test/exports.test.ts
@@ -1,0 +1,9 @@
+import { test, expect } from "vitest";
+import * as API from "../src";
+import * as Server from "../src/server";
+
+test("exports match between server and index", () => {
+  (Object.keys(API) as (keyof typeof API)[]).forEach(key => {
+    expect(typeof API[key]).toBe(typeof Server[key]);
+  });
+});

--- a/packages/cursor/test/index.test.ts
+++ b/packages/cursor/test/index.test.ts
@@ -1,14 +1,73 @@
-import { createPrimitiveTemplate } from "../src";
-import { createRoot } from "solid-js";
+import { createBodyCursor, createElementCursor, CursorProperty } from "../src";
+import { createRoot, createSignal } from "solid-js";
 import { describe, test, expect } from "vitest";
 
-describe("createPrimitiveTemplate", () => {
-  test("createPrimitiveTemplate return values", () =>
-    createRoot(dispose => {
-      const [value, setValue] = createPrimitiveTemplate(true);
-      expect(value(), "initial value should be true")(true);
-      setValue(false);
-      expect(value(), "value after change should be false")(false);
+const sleep = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+describe("createBodyCursor", () => {
+  test("switches previous cursor to provided one", async () =>
+    await createRoot(async dispose => {
+      const [cursor, setCursor] = createSignal<CursorProperty>("pointer");
+      const [enabled, setEnabled] = createSignal(true);
+      createBodyCursor(() => enabled() && cursor());
+      await sleep(0);
+      expect(document.body.style.cursor).toBe("pointer");
+      setCursor("help");
+      expect(document.body.style.cursor).toBe("help");
+      setEnabled(false);
+      expect(document.body.style.cursor, "unsets cursor").toBe("");
+      setEnabled(true);
+      expect(document.body.style.cursor).toBe("help");
       dispose();
+      expect(document.body.style.cursor).toBe("");
+    }));
+});
+
+describe("createElementCursor", () => {
+  test("switches previous cursor to provided one", async () =>
+    await createRoot(async dispose => {
+      const div = document.createElement("div");
+      const [cursor, setCursor] = createSignal<CursorProperty>("pointer");
+      const [enabled, setEnabled] = createSignal(true);
+      createElementCursor(() => enabled() && div, cursor);
+      await sleep(0);
+      expect(div.style.cursor).toBe("pointer");
+      setCursor("help");
+      expect(div.style.cursor).toBe("help");
+      setEnabled(false);
+      expect(div.style.cursor, "unsets cursor").toBe("");
+      setEnabled(true);
+      expect(div.style.cursor).toBe("help");
+      dispose();
+      expect(div.style.cursor).toBe("");
+    }));
+  test("multiple targets", async () =>
+    await createRoot(async dispose => {
+      const div1 = document.createElement("div");
+      const div2 = document.createElement("div");
+      const [target, setTarget] = createSignal(div1);
+      const [cursor, setCursor] = createSignal<CursorProperty>("pointer");
+      const [enabled, setEnabled] = createSignal(true);
+      createElementCursor(() => enabled() && target(), cursor);
+      await sleep(0);
+      expect(div1.style.cursor).toBe("pointer");
+      setCursor("help");
+      expect(div1.style.cursor).toBe("help");
+      setTarget(div2);
+      expect(div1.style.cursor).toBe("");
+      expect(div2.style.cursor).toBe("help");
+      setEnabled(false);
+      expect(div2.style.cursor).toBe("");
+      setTarget(div1);
+      expect(div1.style.cursor).toBe("");
+      expect(div2.style.cursor).toBe("");
+      setCursor("pointer");
+      expect(div1.style.cursor).toBe("");
+      expect(div2.style.cursor).toBe("");
+      setEnabled(true);
+      expect(div1.style.cursor).toBe("pointer");
+      expect(div2.style.cursor).toBe("");
+      dispose();
+      expect(div1.style.cursor).toBe("");
     }));
 });

--- a/packages/cursor/test/index.test.ts
+++ b/packages/cursor/test/index.test.ts
@@ -1,0 +1,14 @@
+import { createPrimitiveTemplate } from "../src";
+import { createRoot } from "solid-js";
+import { describe, test, expect } from "vitest";
+
+describe("createPrimitiveTemplate", () => {
+  test("createPrimitiveTemplate return values", () =>
+    createRoot(dispose => {
+      const [value, setValue] = createPrimitiveTemplate(true);
+      expect(value(), "initial value should be true")(true);
+      setValue(false);
+      expect(value(), "value after change should be false")(false);
+      dispose();
+    }));
+});

--- a/packages/cursor/tsconfig.json
+++ b/packages/cursor/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": ["./src", "./test", "./dev"],
+  "exclude": ["node_modules", "./dist"]
+}

--- a/packages/cursor/tsup.config.ts
+++ b/packages/cursor/tsup.config.ts
@@ -1,0 +1,2 @@
+import { doubleEntryConfig } from "../../tsup.config";
+export default doubleEntryConfig;

--- a/packages/cursor/vite.config.ts
+++ b/packages/cursor/vite.config.ts
@@ -1,0 +1,2 @@
+import { vitestConfig } from "../../vite.config";
+export default vitestConfig;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,9 @@ import solidPlugin from "vite-plugin-solid";
 import Unocss from "unocss/vite";
 
 export const viteConfig = defineConfig({
+  server: {
+    port: 3000
+  },
   plugins: [
     solidPlugin(),
     Unocss({


### PR DESCRIPTION
Adds two simple primitives for setting the cursor CSS property reactively to document body, or selected HTML Element.

```ts
import { createElementCursor } from "@solid-primitives/cursor";

const target = document.querySelector("#element");
const [cursor, setCursor] = createSignal("pointer");
const [enabled, setEnabled] = createSignal(true);

createElementCursor(() => enabled() && target, cursor);

setCursor("help");
```

[README](https://github.com/solidjs-community/solid-primitives/tree/cursor/packages/cursor#readme)

TODO:
- [x] add dev playground