### PR TITLE
fetch: manual cache invalidation

### DIFF
--- a/.changeset/chatty-queens-unite.md
+++ b/.changeset/chatty-queens-unite.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/fetch": minor
+---
+
+manual cache invalidation


### PR DESCRIPTION
The invalidate() function was already present, but incorrectly typed and didn't cause a re-fetch on invalidation.