### PR TITLE
quickfix: config object is supposed to be optional

### DIFF
--- a/.changeset/dull-baboons-kick.md
+++ b/.changeset/dull-baboons-kick.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/idle": patch
+---
+
+Make createIdleTimer options argumnet optional.

--- a/packages/idle/src/createIdleTimer.ts
+++ b/packages/idle/src/createIdleTimer.ts
@@ -46,7 +46,7 @@ export const createIdleTimer = ({
   onIdle,
   onPrompt,
   startManually = false
-}: IdleTimerOptions): IdleTimerReturn => {
+}: IdleTimerOptions = {}): IdleTimerReturn => {
   let listenersAreOn = false;
   const [isPrompted, setIsPrompted] = createSignal(false);
   const [isIdle, setIsIdle] = createSignal(false);


### PR DESCRIPTION
Configuration argument is supposed to be optional, however calling `createIdleTimer()` without any argument would result in error. This shall fix it.