### PR TITLE
Fix vite config path on new-package script

### DIFF
--- a/template/dev/vite.config.ts
+++ b/template/dev/vite.config.ts
@@ -1,2 +1,2 @@
-import { viteConfig } from "../../../vite.config";
+import { viteConfig } from "../../../configs/vite.config";
 export default viteConfig;


### PR DESCRIPTION
Fix vite config path on new-package script. The current path is incorrect and causes dev script on created package to fail.