### PR TITLE
Handle exceptions thrown during audio playback

### DIFF
--- a/.changeset/selfish-cycles-serve.md
+++ b/.changeset/selfish-cycles-serve.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/audio": patch
+---
+
+Handle exceptions thrown during audio playback.


### PR DESCRIPTION
This can happen when trying to play audio prior to the user interacting with the page.

Should we be treating this the same as we do any other error or does it warrant a special case which will allow library users to, e.g., show a popup which when dismissed will retry playback?

I've also made this only happen if the exception thrown is named `NotAllowedError`, which is the name of the error thrown when the user agent blocks playback (e.g. because the user didn't interact with the page).
Should this just be a catch-all `catch`?
(Also the current implementation might need to rethrow errors that aren't named `NotAllowedError` but it's a trivial change to make)