### PR TITLE
fix: specify createTween return type

### DIFF
--- a/.changeset/witty-buses-hug.md
+++ b/.changeset/witty-buses-hug.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/tween": patch
+---
+
+fix: specify createTween return type

--- a/packages/tween/src/index.ts
+++ b/packages/tween/src/index.ts
@@ -15,7 +15,7 @@ import { createSignal, createEffect, onCleanup, on } from "solid-js";
 export default function createTween<T extends number>(
   target: () => T,
   { ease = (t: T) => t, duration = 100 }
-) {
+): (() => T) | (() => void) {
   if (process.env.SSR) {
     return () => {
       /*noop*/

--- a/packages/tween/src/index.ts
+++ b/packages/tween/src/index.ts
@@ -15,11 +15,9 @@ import { createSignal, createEffect, onCleanup, on } from "solid-js";
 export default function createTween<T extends number>(
   target: () => T,
   { ease = (t: T) => t, duration = 100 }
-): (() => T) | (() => void) {
+): () => T {
   if (process.env.SSR) {
-    return () => {
-      /*noop*/
-    };
+    return target;
   }
   const [start, setStart] = createSignal(document.timeline.currentTime);
   const [current, setCurrent] = createSignal<T>(target());


### PR DESCRIPTION
Type declaration file in build had incorrect type:

@solid-primitives/tween/dist/index.d.ts
```
declare function createTween<T extends number>(target: () => T, { ease, duration }: {
    ease?: ((t: T) => T) | undefined;
    duration?: number | undefined;
}): () => void;
```