### PR TITLE
fix: keyup event on useKeyDownList

### DIFF
--- a/.changeset/ten-toes-fly.md
+++ b/.changeset/ten-toes-fly.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/keyboard": patch
+---
+
+fix keyup event on useKeyDownList hook

--- a/packages/keyboard/src/index.ts
+++ b/packages/keyboard/src/index.ts
@@ -62,7 +62,10 @@ export const useKeyDownList = /*#__PURE__*/ createSharedRoot<
   makeEventListener(window, "keyup", e => {
     if (typeof e.key !== "string") return;
     const key = e.key.toUpperCase();
-    setPressedKeys(prev => prev.filter(_key => _key !== key));
+    batch(() => {
+      setEvent(e);
+      setPressedKeys(prev => prev.filter(_key => _key !== key));
+    })
   });
 
   makeEventListener(window, "blur", reset);


### PR DESCRIPTION
keyup event is missing on useKeyDownList hook event signal. It sends keydown instead of keyup on key release.