### PR TITLE
fix keyboard useKeyDownList bug caused by Meta key

### DIFF
--- a/packages/keyboard/src/index.ts
+++ b/packages/keyboard/src/index.ts
@@ -62,7 +62,11 @@ export const useKeyDownList = /*#__PURE__*/ createSharedRoot<
   makeEventListener(window, "keyup", e => {
     if (typeof e.key !== "string") return;
     const key = e.key.toUpperCase();
-    setPressedKeys(prev => prev.filter(_key => _key !== key));
+    if (key === "META") {
+      setPressedKeys([]);
+    } else {
+      setPressedKeys(prev => prev.filter(_key => _key !== key));
+    }
   });
 
   makeEventListener(window, "blur", reset);


### PR DESCRIPTION
When Meta(CMD or ⌘) key is pressed and held and then press different key, for example "Meta+K", the keyup for "K" does not fire, so the `pressedKeys` list doesn't get cleaned up properly causing issues. 

One issue would be if you use `createShortcut(["META", "K"])` to fire on "Meta+K", it will only work the first time. It won't work again until window blurs (document page loses focus) which clears `pressedKeys`.


You can see another issue where on [demo site](https://solidjs-community.github.io/solid-primitives/keyboard/), if you press "Meta+K", on KeyPress element the "K" persists after not pressing keyboard.

<img width="259" alt="Screen Shot 2023-01-08 at 3 16 22 AM" src="https://user-images.githubusercontent.com/29286430/211193159-1c2b409e-9253-46a7-9986-f2d1c930350a.png">

This PR fixes those issues