### PR TITLE
[pagination] Update computed pages when options signal changes.

### DIFF
--- a/.changeset/gentle-tools-wonder.md
+++ b/.changeset/gentle-tools-wonder.md
@@ -1,0 +1,9 @@
+---
+"@solid-primitives/pagination": patch
+---
+
+Update computed pages when options signal changes.
+
+If the passed pagination options are a reactive signal, ensure that the pages
+array is recomputed when it changes. This prevents the pages array getting out
+of sync and the resulting pagination props missing pages.

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.101",
   "description": "A primitive that creates all the reactive data to manage your pagination.",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
-  "contributors": [],
+  "contributors": [
+    "Martin Pengelly-Phillips <dev@thisbeyond.com>"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/pagination#readme",
   "repository": {

--- a/packages/pagination/src/index.ts
+++ b/packages/pagination/src/index.ts
@@ -106,26 +106,29 @@ export const createPagination = (
       }[ev.key] || noop
     )());
 
-  const pages: PaginationProps = [...Array(opts().pages)].map((_, i) =>
-    ((pageNo: number) =>
-      Object.defineProperties(
-        process.env.SSR
-          ? { children: pageNo.toString() }
-          : {
-              children: pageNo.toString(),
-              onClick: [setPage, pageNo] as const,
-              onKeyUp: [onKeyUp, pageNo] as const
+  const pages = createMemo(() =>
+    [...Array(opts().pages)].map((_, i) =>
+      ((pageNo: number) =>
+        Object.defineProperties(
+          process.env.SSR
+            ? { children: pageNo.toString() }
+            : {
+                children: pageNo.toString(),
+                onClick: [setPage, pageNo] as const,
+                onKeyUp: [onKeyUp, pageNo] as const
+              },
+          {
+            "aria-current": {
+              get: () => (page() === pageNo ? "true" : undefined),
+              set: noop,
+              enumerable: true
             },
-        {
-          "aria-current": {
-            get: () => (page() === pageNo ? "true" : undefined),
-            set: noop,
-            enumerable: true
-          },
-          page: { value: pageNo, enumerable: false }
-        }
-      ))(i + 1)
+            page: { value: pageNo, enumerable: false }
+          }
+        ))(i + 1)
+    )
   );
+
   const first = Object.defineProperties(
     process.env.SSR
       ? ({} as PaginationProps[number])
@@ -203,7 +206,7 @@ export const createPagination = (
     if (showPrev()) {
       props.push(back);
     }
-    props.push(...pages.slice(start(), start() + opts().maxPages));
+    props.push(...pages().slice(start(), start() + opts().maxPages));
     if (showNext()) {
       props.push(next);
     }

--- a/packages/pagination/src/index.ts
+++ b/packages/pagination/src/index.ts
@@ -106,27 +106,31 @@ export const createPagination = (
       }[ev.key] || noop
     )());
 
-  const pages = createMemo(() =>
-    [...Array(opts().pages)].map((_, i) =>
-      ((pageNo: number) =>
-        Object.defineProperties(
-          process.env.SSR
-            ? { children: pageNo.toString() }
-            : {
-                children: pageNo.toString(),
-                onClick: [setPage, pageNo] as const,
-                onKeyUp: [onKeyUp, pageNo] as const
-              },
-          {
-            "aria-current": {
-              get: () => (page() === pageNo ? "true" : undefined),
-              set: noop,
-              enumerable: true
-            },
-            page: { value: pageNo, enumerable: false }
-          }
-        ))(i + 1)
-    )
+  const pages = createMemo<PaginationProps[]>(
+    previous =>
+      [...Array(opts().pages)].map(
+        (_, i) =>
+          (previous && previous[i]) ??
+          ((pageNo: number) =>
+            Object.defineProperties(
+              process.env.SSR
+                ? { children: pageNo.toString() }
+                : {
+                    children: pageNo.toString(),
+                    onClick: [setPage, pageNo] as const,
+                    onKeyUp: [onKeyUp, pageNo] as const
+                  },
+              {
+                "aria-current": {
+                  get: () => (page() === pageNo ? "true" : undefined),
+                  set: noop,
+                  enumerable: true
+                },
+                page: { value: pageNo, enumerable: false }
+              }
+            ))(i + 1)
+      ),
+    []
   );
 
   const first = Object.defineProperties(

--- a/packages/pagination/test/index.test.ts
+++ b/packages/pagination/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { createRoot } from "solid-js";
+import { createRoot, createSignal } from "solid-js";
 import { createPagination } from "../src";
 
 describe("createPagination", () => {
@@ -34,6 +34,17 @@ describe("createPagination", () => {
       expect(paginationProps().findIndex(({ ["aria-current"]: current }) => current)).toBe(2);
       setPage(page() + 1);
       expect(paginationProps().findIndex(({ ["aria-current"]: current }) => current)).toBe(3);
+      dispose();
+    }));
+
+  test("createPagination reacts to options update", () =>
+    createRoot(dispose => {
+      const [options, setOptions] = createSignal({ pages: 10, maxPages: 20 });
+      const [paginationProps, _page, _setPage] = createPagination(options);
+      const extraProps = 4;
+      expect(paginationProps().length, "initial pages").toBe(10 + extraProps);
+      setOptions({ pages: 5, maxPages: 10 });
+      expect(paginationProps().length, "pages after change").toBe(5 + extraProps);
       dispose();
     }));
 });

--- a/packages/pagination/test/index.test.ts
+++ b/packages/pagination/test/index.test.ts
@@ -39,12 +39,34 @@ describe("createPagination", () => {
 
   test("createPagination reacts to options update", () =>
     createRoot(dispose => {
-      const [options, setOptions] = createSignal({ pages: 10, maxPages: 20 });
+      const commonOptions = {
+        showFirst: false,
+        showPrev: false,
+        showNext: false,
+        showLast: false
+      };
+      const [options, setOptions] = createSignal({ ...commonOptions, pages: 10, maxPages: 20 });
       const [paginationProps, _page, _setPage] = createPagination(options);
-      const extraProps = 4;
-      expect(paginationProps().length, "initial pages").toBe(10 + extraProps);
-      setOptions({ pages: 5, maxPages: 10 });
-      expect(paginationProps().length, "pages after change").toBe(5 + extraProps);
+      expect(paginationProps().length, "initial pages").toBe(10);
+      setOptions({ ...commonOptions, pages: 5, maxPages: 10 });
+      expect(paginationProps().length, "pages after change").toBe(5);
+      dispose();
+    }));
+
+  test("createPagination pages reused", () =>
+    createRoot(dispose => {
+      const commonOptions = {
+        showFirst: false,
+        showPrev: false,
+        showNext: false,
+        showLast: false
+      };
+      const [options, setOptions] = createSignal({ ...commonOptions, pages: 3 });
+      const [paginationProps, _page, _setPage] = createPagination(options);
+      const initialPages = paginationProps();
+      setOptions({ ...commonOptions, pages: 2 });
+      const updatedPages = paginationProps();
+      expect(updatedPages.every((page, index) => Object.is(page, initialPages[index]))).toBe(true);
       dispose();
     }));
 });


### PR DESCRIPTION
If the passed pagination options are a reactive signal, ensure that the pages array is recomputed when it changes. This prevents the pages array getting out of sync and the resulting pagination props missing pages.