### PR TITLE
[pagination] Prevent wrong pages slice

### DIFF
--- a/.changeset/calm-islands-serve.md
+++ b/.changeset/calm-islands-serve.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/pagination": patch
+---
+
+Prevent wrong pages slice by clamping start to 0.

--- a/.changeset/calm-islands-serve.md
+++ b/.changeset/calm-islands-serve.md
@@ -2,4 +2,4 @@
 "@solid-primitives/pagination": patch
 ---
 
-Prevent wrong pages slice by clamping start to 0.
+Prevent wrong pages slice by internally clamping maxPages to total page count.

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.101",
   "description": "A primitive that creates all the reactive data to manage your pagination.",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
-  "contributors": [],
+  "contributors": [
+    "Martin Pengelly-Phillips <dev@thisbeyond.com>"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/pagination#readme",
   "repository": {

--- a/packages/pagination/src/index.ts
+++ b/packages/pagination/src/index.ts
@@ -180,7 +180,10 @@ export const createPagination = (
   );
 
   const start = createMemo(() =>
-    Math.min(opts().pages - opts().maxPages, Math.max(1, page() - (opts().maxPages >> 1)) - 1)
+    Math.max(
+      0,
+      Math.min(opts().pages - opts().maxPages, Math.max(1, page() - (opts().maxPages >> 1)) - 1)
+    )
   );
   const showFirst = createMemo(() =>
     normalizeOption("showFirst", opts().showFirst, page(), opts().pages)

--- a/packages/pagination/src/index.ts
+++ b/packages/pagination/src/index.ts
@@ -106,6 +106,8 @@ export const createPagination = (
       }[ev.key] || noop
     )());
 
+  const maxPages = createMemo(() => Math.min(opts().maxPages, opts().pages));
+
   const pages: PaginationProps = [...Array(opts().pages)].map((_, i) =>
     ((pageNo: number) =>
       Object.defineProperties(
@@ -180,10 +182,7 @@ export const createPagination = (
   );
 
   const start = createMemo(() =>
-    Math.max(
-      0,
-      Math.min(opts().pages - opts().maxPages, Math.max(1, page() - (opts().maxPages >> 1)) - 1)
-    )
+    Math.min(opts().pages - maxPages(), Math.max(1, page() - (maxPages() >> 1)) - 1)
   );
   const showFirst = createMemo(() =>
     normalizeOption("showFirst", opts().showFirst, page(), opts().pages)
@@ -206,7 +205,7 @@ export const createPagination = (
     if (showPrev()) {
       props.push(back);
     }
-    props.push(...pages.slice(start(), start() + opts().maxPages));
+    props.push(...pages.slice(start(), start() + maxPages()));
     if (showNext()) {
       props.push(next);
     }

--- a/packages/pagination/test/index.test.ts
+++ b/packages/pagination/test/index.test.ts
@@ -36,4 +36,15 @@ describe("createPagination", () => {
       expect(paginationProps().findIndex(({ ["aria-current"]: current }) => current)).toBe(3);
       dispose();
     }));
+
+  test("createPagination clamps start", () =>
+    createRoot(dispose => {
+      const [paginationProps, _page, _setPage] = createPagination({
+        pages: 10,
+        maxPages: 13
+      });
+      const extraProps = 4;
+      expect(paginationProps().length, "pages").toBe(10 + extraProps);
+      dispose();
+    }));
 });


### PR DESCRIPTION
When `maxPages` is greater than `pages`, ensure the min value of the computed start for slicing is 0 (rather than a negative number). A negative number starts indexing from the end of the array causing an incorrect slice to be made. 

E.g. `10 pages - 13 maxPages = pages[-3, 13] = pages[8,9,10]`