### PR TITLE
Add new `onDispose` primitive

### DIFF
--- a/.changeset/pretty-games-vanish.md
+++ b/.changeset/pretty-games-vanish.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/rootless": minor
+---
+
+Add new `onDispose` primitive.

--- a/packages/rootless/README.md
+++ b/packages/rootless/README.md
@@ -15,6 +15,7 @@ A collection of helpers that aim to simplify using reactive primitives outside o
 - [`createCallback`](#createCallback) - A wrapper for creating callbacks with `runWithOwner`.
 - [`createDisposable`](#createDisposable) - For disposing computations early – before the root cleanup.
 - [`createSharedRoot`](#createSharedRoot) - Share "global primitives" across multiple reactive scopes.
+- [`onDispose`](#onDispose) - Run an effect when the reactive owner gets disposed.
 
 ## Installation
 
@@ -157,6 +158,42 @@ function createSharedRoot<T>(factory: (dispose: Fn) => T): () => T;
 ### Demo
 
 Usage of combining `createSharedRoot` with `createMousePosition`: https://codesandbox.io/s/shared-root-demo-fjl1l9?file=/index.tsx
+
+## `onDispose`
+
+Run an effect when the reactive owner gets disposed.
+
+Same api as [onCleanup](https://www.solidjs.com/docs/latest/api#oncleanup), but if called inside a computation,
+the `fn` callback won't be called each time the computtion is re-evaluated,
+but only when the computation is fully disposed.
+
+### How to use it
+
+`onDispose` takes only one parameter - `fn` an effect that should run only once on cleanup - which also will be returned from it.
+
+```ts
+import { onDispose } from "@solid-primitives/rootless";
+
+createRoot(dispose => {
+  const [count, setCount] = createSignal(0);
+
+  createEffect(() => {
+    count();
+
+    onCleanup(() => {
+      console.log("cleanup");
+    });
+
+    onDispose(() => {
+      console.log("disposed");
+    });
+  });
+
+  setCount(1); // cleanup
+
+  dispose(); // cleanup + dispose (twice)
+});
+```
 
 ## Changelog
 

--- a/packages/rootless/package.json
+++ b/packages/rootless/package.json
@@ -16,7 +16,8 @@
       "createSubRoot",
       "createCallback",
       "createDisposable",
-      "createSharedRoot"
+      "createSharedRoot",
+      "onDispose"
     ],
     "category": "Reactivity"
   },
@@ -31,6 +32,13 @@
   "types": "./dist/index.d.ts",
   "browser": {},
   "exports": {
+    "development": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/dev.js"
+      },
+      "require": "./dist/dev.cjs"
+    },
     "import": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
@@ -38,7 +46,7 @@
     "require": "./dist/index.cjs"
   },
   "scripts": {
-    "build": "jiti ../../scripts/build.ts",
+    "build": "jiti ../../scripts/build.ts --dev",
     "test": "vitest -c ../../configs/vitest.config.ts",
     "test:ssr": "pnpm run test --mode ssr"
   },


### PR DESCRIPTION
Adds new `onDispose` primitive to the `rootless` package.

It's a variant of `onCleanup` that only runs if the owner actually gets disposed of - not just rerun.
Similar to the returned function of `useEffect` from React.
The implementation gets into solids internals to do it, but normally to do it from within an effect, you'd need access to parent owner to which then you could attach cleanup with `runWithOwner` and `onCleanup`. This way you don't need to pass down the owner.

```ts
import { onDispose } from "@solid-primitives/rootless";

createRoot(dispose => {
  const [count, setCount] = createSignal(0);

  createEffect(() => {
    count();

    onCleanup(() => {
      console.log("cleanup");
    });

    onDispose(() => {
      console.log("disposed");
    });
  });

  setCount(1); // cleanup

  dispose(); // cleanup + dispose (twice)
});
```

@bigmistqke this is what I've mentioned in https://github.com/solidjs-community/solid-primitives/pull/289