### PR TITLE
script-loader: Improve API, spread any props on to the script

### DIFF
--- a/.changeset/nasty-camels-roll.md
+++ b/.changeset/nasty-camels-roll.md
@@ -2,4 +2,4 @@
 "@solid-primitives/script-loader": major
 ---
 
-Add `onBeforeAppend` callback option. Rename onload and onerror to onLoad and onError. Do not return the remove script function - should be done with disposing the owner. React to src changes with createRenderEffect.
+Change `createScriptLoader` API to not return the remove script function - should be done with disposing the owner. React to src changes with createRenderEffect. Apply all passed props using solid's `spread` funcion to the script element.

--- a/.changeset/nasty-camels-roll.md
+++ b/.changeset/nasty-camels-roll.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/script-loader": major
+---
+
+Add `onBeforeAppend` callback option. Rename onload and onerror to onLoad and onError. Do not return the remove script function - should be done with disposing the owner. React to src changes with createRenderEffect.

--- a/packages/script-loader/CHANGELOG.md
+++ b/packages/script-loader/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Patch Changes
 
-- b662fe9f: Improve package export contidions for SSR (node, workers, deno)
+- b662fe9f: Improve package export conditions for SSR (node, workers, deno)
 
 ## 1.1.1
 

--- a/packages/script-loader/README.md
+++ b/packages/script-loader/README.md
@@ -48,13 +48,12 @@ createScriptLoader({
 ## Definition
 
 ```ts
-function createScriptLoader(options: {
-  readonly src: string | Accessor<string>; // url or js source
-  readonly type?: string | undefined;
-  readonly onLoad?: (() => void) | undefined;
-  readonly onError?: (() => void) | undefined;
-  readonly onBeforeAppend?: ((script: HTMLScriptElement) => void) | undefined;
-}): HTMLScriptElement | undefined; // script element with be undefined only on the server
+function createScriptLoader(props: ScriptProps): HTMLScriptElement | undefined; // script element with be undefined only on the server
+
+type ScriptProps = Omit<ComponentProps<"script">, "src" | "textContent"> & {
+  /** URL or source of the script to load. */
+  src: string | Accessor<string>;
+};
 ```
 
 ## Demo

--- a/packages/script-loader/README.md
+++ b/packages/script-loader/README.md
@@ -23,6 +23,10 @@ pnpm add @solid-primitives/script-loader
 
 ## How to use it
 
+createScriptLoader expects a props object with a `src` property. All the other props will be spread to the script element.
+
+The `src` prop is required and will be used to set the `src` or `textContent` attribute. It can be a string or an accessor.
+
 ```ts
 import { createScriptLoader } from "@solid-primitives/script-loader";
 

--- a/packages/script-loader/README.md
+++ b/packages/script-loader/README.md
@@ -17,6 +17,8 @@ Creates a primitive to load scripts dynamically, either for external services or
 npm install @solid-primitives/script-loader
 # or
 yarn add @solid-primitives/script-loader
+# or
+pnpm add @solid-primitives/script-loader
 ```
 
 ## How to use it
@@ -24,31 +26,35 @@ yarn add @solid-primitives/script-loader
 ```ts
 import { createScriptLoader } from "@solid-primitives/script-loader";
 
-// ...
-
-const [script: HTMLScriptElement, remove: () => void] = createScriptLoader({
-  src: string | Accessor<string>, // url or js source
-  type?: string,
-  onload?: () => void,
-  onerror?: () => void
-});
-
 // For example, to use recaptcha:
 createScriptLoader({
-  src: 'https://www.google.com/recaptcha/enterprise.js?render=my_token',
-  onload: async () => {
+  src: "https://www.google.com/recaptcha/enterprise.js?render=my_token",
+  async onLoad() {
     await grecaptcha.enterprise.ready();
-    const token = await grecaptcha.enterprise.execute('my_token', {action: 'login'});
+    const token = await grecaptcha.enterprise.execute("my_token", { action: "login" });
     // do your stuff...
   }
 });
 
 // or pinterest embeds:
-const pinterestEmbedScript = '!function(a,b,c){var d,e,f;d="PIN_"+~~((new Date).getTime()/864e5),...';
 createScriptLoader({
-  src: pinterestEmbedScript,
-  onload: () => window?.PinUtils?.build()
+  src: '!function(a,b,c){var d,e,f;d="PIN_"+~~((new Date).getTime()/864e5),...',
+  onLoad() {
+    window?.PinUtils?.build();
+  }
 });
+```
+
+## Definition
+
+```ts
+function createScriptLoader(options: {
+  readonly src: string | Accessor<string>; // url or js source
+  readonly type?: string | undefined;
+  readonly onLoad?: (() => void) | undefined;
+  readonly onError?: (() => void) | undefined;
+  readonly onBeforeAppend?: ((script: HTMLScriptElement) => void) | undefined;
+}): HTMLScriptElement | undefined; // script element with be undefined only on the server
 ```
 
 ## Demo

--- a/packages/script-loader/package.json
+++ b/packages/script-loader/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.3",
   "description": "Primitive to load scripts dynamically",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
+  "contributors": [
+    "Damian Tarnawski <gthetarnav@gmail.com>"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/script",
   "repository": {

--- a/packages/script-loader/src/index.ts
+++ b/packages/script-loader/src/index.ts
@@ -12,7 +12,7 @@ const OMITTED_PROPS = ["src"] as const;
  * Creates a convenient script loader utility
  *
  * @param props The props to spread to the script element.
- * The `src` prop is required and will be used to set the `src` or `textContent` attribute.
+ * The `src` prop is required and will be used to set the `src` or `textContent` attribute. It can be a string or an accessor.
  * @returns The script element that was created. (will be undefined in SSR)
  *
  * @see https://github.com/solidjs-community/solid-primitives/tree/main/packages/script-loader#createScriptLoader

--- a/packages/script-loader/test/index.test.ts
+++ b/packages/script-loader/test/index.test.ts
@@ -1,7 +1,5 @@
+import { createRoot, createSignal } from "solid-js";
 import { describe, expect, it } from "vitest";
-
-import { createEffect, createRoot, createSignal } from "solid-js";
-
 import { createScriptLoader } from "../src";
 
 const dispatchAndWait = (script?: HTMLScriptElement, name: "load" | "error" = "load") =>
@@ -15,53 +13,49 @@ const dispatchAndWait = (script?: HTMLScriptElement, name: "load" | "error" = "l
 describe("createScriptLoader", () => {
   it("will create a script tag with src", () =>
     createRoot(dispose => {
-      const [_, remove] = createRoot(() =>
-        createScriptLoader({ src: "https://localhost:3000/script.js" })
-      );
+      createScriptLoader({ src: "https://localhost:3000/script.js" });
       const script = document.querySelector('script[src="https://localhost:3000/script.js"]');
       expect(script).toBeInstanceOf(window.HTMLScriptElement);
-      remove();
       dispose();
     }));
 
   it("will create a script tag with textContent", () =>
     createRoot(dispose => {
       const src = "!(function(){ window.test = true; })();";
-      const [script, remove] = createRoot(() => createScriptLoader({ src }));
+      const script = createRoot(() => createScriptLoader({ src }));
       expect(script).toBeInstanceOf(window.HTMLScriptElement);
       expect(script?.textContent).toBe(src);
-      remove();
       dispose();
     }));
 
   it("will call the onload handler", async () => {
-    let loadCalled = false;
-    const [script, remove] = createRoot(() =>
-      createScriptLoader({
+    createRoot(dispose => {
+      let loadCalled = false;
+      const script = createScriptLoader({
         src: "https://localhost:3000/script.js",
-        onload: () => {
+        onLoad: () => {
           loadCalled = true;
         }
-      })
-    );
-    dispatchAndWait(script, "load");
-    expect(loadCalled).toBe(true);
-    remove();
+      });
+      dispatchAndWait(script, "load");
+      expect(loadCalled).toBe(true);
+      dispose();
+    });
   });
 
   it("will call the onerror handler", async () => {
-    let errorCalled = false;
-    const [script, remove] = createRoot(() =>
-      createScriptLoader({
+    createRoot(dispose => {
+      let errorCalled = false;
+      const script = createScriptLoader({
         src: "https://localhost:3000/script.js",
-        onerror: () => {
+        onError: () => {
           errorCalled = true;
         }
-      })
-    );
-    dispatchAndWait(script, "error");
-    expect(errorCalled).toBe(true);
-    remove();
+      });
+      dispatchAndWait(script, "error");
+      expect(errorCalled).toBe(true);
+      dispose();
+    });
   });
 
   it("will update the url from an accessor", async () => {
@@ -69,13 +63,13 @@ describe("createScriptLoader", () => {
     await new Promise<void>(resolve =>
       createRoot(async dispose => {
         const [src, setSrc] = createSignal("https://localhost:3000/script.js");
-        const [script] = createScriptLoader({
+        const script = createScriptLoader({
           src: src,
-          onload: () => setSrc("https://localhost:3000/script2.js")
+          onLoad: () => setSrc("https://localhost:3000/script2.js")
         });
         actualSrcUrls.push(script?.src);
         await dispatchAndWait(script, "load");
-        createEffect(() => {
+        queueMicrotask(() => {
           actualSrcUrls.push(script?.src);
           dispose();
           resolve();
@@ -90,7 +84,7 @@ describe("createScriptLoader", () => {
 
   it("will automatically remove the script tag on disposal", async () => {
     const script = createRoot(dispose => {
-      const [script] = createScriptLoader({ src: "https://localhost:3000/script.js" });
+      const script = createScriptLoader({ src: "https://localhost:3000/script.js" });
       dispose();
       return script;
     });

--- a/packages/script-loader/test/server.test.ts
+++ b/packages/script-loader/test/server.test.ts
@@ -1,9 +1,8 @@
 import { describe, expect, it } from "vitest";
-
 import { createScriptLoader } from "../src";
 
 describe("API doesn't break in SSR", () => {
   it("createScriptLoader() - SSR", () => {
-    expect(createScriptLoader({ src: "url" })).toEqual([undefined, expect.any(Function)]);
+    expect(createScriptLoader({ src: "url" })).toEqual(undefined);
   });
 });


### PR DESCRIPTION
Add `onBeforeAppend` callback option. Rename onload and onerror to onLoad and onError. Do not return the remove script function - should be done with disposing the owner. React to src changes with createRenderEffect.