### PR TITLE
jsx-parser: set returnType createToken from JSX.Element to TokenComponent<Token>

### DIFF
--- a/.changeset/many-buckets-grin.md
+++ b/.changeset/many-buckets-grin.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/jsx-parser": patch
+---
+
+set returnType createToken from JSX.Element to TokenComponent<Token>

--- a/packages/jsx-parser/src/index.ts
+++ b/packages/jsx-parser/src/index.ts
@@ -41,7 +41,7 @@ export function createJSXParser<Tokens extends {}>(options?: { name: string }) {
   function createToken<Props extends { [key: string]: any }, Token extends Tokens>(
     tokenCallback: (props: Props) => Token,
     component?: (props: Props) => JSX.Element
-  ): (props: Props) => JSX.Element {
+  ): (props: Props) => TokenComponent<Token> {
     return (props: Props) =>
       Object.assign(
         component


### PR DESCRIPTION
[as discussed here](https://github.com/solidjs-community/solid-primitives/pull/276#issuecomment-1407043412)