### PR TITLE
jsx-parser: Add the data to the `data` property

### DIFF
--- a/.changeset/great-moons-explain.md
+++ b/.changeset/great-moons-explain.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/utils": minor
+---
+
+Add Narrow type utility.

--- a/.changeset/light-wolves-remember.md
+++ b/.changeset/light-wolves-remember.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/jsx-parser": minor
+---
+
+Add the token object to the `data` property of the token element, instead of spreading it with `Object.assign`.

--- a/.changeset/light-wolves-remember.md
+++ b/.changeset/light-wolves-remember.md
@@ -3,3 +3,5 @@
 ---
 
 Add the token object to the `data` property of the token element, instead of spreading it with `Object.assign`.
+
+Separates available functions into own exports, `parser` is now required to be passed to the functions.

--- a/packages/jsx-parser/README.md
+++ b/packages/jsx-parser/README.md
@@ -52,6 +52,8 @@ Creates a token component associated with the corresponding jsx-parser.
 - `render` function that returns the fallback JSX Element to render _(if one isn't passed, nothing will get rendred)_
 
 ```tsx
+import { createToken } from "@solid-primitives/jsx-parser";
+
 const TokenExample = createToken(
   parser,
   // function that returns the data of the token - called when the token is resolved by `resolveTokens`

--- a/packages/jsx-parser/README.md
+++ b/packages/jsx-parser/README.md
@@ -94,6 +94,12 @@ A function similar to Solid's [`children()`](https://www.solidjs.com/docs/latest
 
 ```tsx
 const tokens = childrenTokens(() => props.children);
+
+createEffect(() => {
+  tokens().forEach(token => {
+    console.log(token.data);
+  });
+});
 ```
 
 ## `isToken`

--- a/packages/jsx-parser/dev/index.tsx
+++ b/packages/jsx-parser/dev/index.tsx
@@ -68,20 +68,18 @@ const Subtract = createToken(
 
 const App: Component = () => {
   return (
-    <div
-      style={{
-        display: "flex",
-        "align-items": "center",
-        "justify-content": "center",
-        height: "100vh"
-      }}
-    >
-      <Calculator>
-        <h1>This is a calculator</h1>
-        <Value value={1} />
-        <Add value={4} />
-        <Subtract value={2} />
-      </Calculator>
+    <div class="p-24 box-border w-full min-h-screen flex flex-col justify-center items-center space-y-4 bg-gray-800 text-white">
+      <div class="wrapper-v">
+        <h4>This is a calculator</h4>
+        <div class="flex">
+          <Calculator>
+            <div>Invalid element (not token)</div>
+            <Value value={1} />
+            <Add value={4} />
+            <Subtract value={2} />
+          </Calculator>
+        </div>
+      </div>
     </div>
   );
 };

--- a/packages/jsx-parser/dev/index.tsx
+++ b/packages/jsx-parser/dev/index.tsx
@@ -18,14 +18,14 @@ const Calculator: ParentComponent = props => {
 
   const calculation = () => {
     let result = 0;
-    tokens().forEach(token => {
-      console.info("token is ", token);
-      if (token.id === "Value") {
-        result = token.props.value;
-      } else if (token.id === "Add") {
-        result += token.props.value;
-      } else if (token.id === "Subtract") {
-        result -= token.props.value;
+    tokens().forEach(({ data }) => {
+      console.info("token is ", data);
+      if (data.id === "Value") {
+        result = data.props.value;
+      } else if (data.id === "Add") {
+        result += data.props.value;
+      } else if (data.id === "Subtract") {
+        result -= data.props.value;
       }
       console.info("result is", result);
     });

--- a/packages/jsx-parser/dev/index.tsx
+++ b/packages/jsx-parser/dev/index.tsx
@@ -1,20 +1,20 @@
 import { Component, JSX, ParentComponent } from "solid-js";
 import { render } from "solid-js/web";
 import "uno.css";
-import { createJSXParser } from "../src";
+import { createJSXParser, createToken, resolveTokens } from "../src";
 
 type Props = {
   value: number;
   children?: JSX.Element | JSX.Element[];
 };
 
-const { createToken, childrenTokens } = createJSXParser<{
+const parser = createJSXParser<{
   id: "Value" | "Add" | "Subtract";
   props: Props;
 }>({ name: "calculator" });
 
 const Calculator: ParentComponent = props => {
-  const tokens = childrenTokens(() => props.children);
+  const tokens = resolveTokens(parser, () => props.children);
 
   const calculation = () => {
     let result = 0;
@@ -40,6 +40,7 @@ const Calculator: ParentComponent = props => {
 };
 
 const Value = createToken(
+  parser,
   (props: Props) => ({
     props,
     id: "Value"
@@ -48,6 +49,7 @@ const Value = createToken(
 );
 
 const Add = createToken(
+  parser,
   (props: Props) => ({
     props,
     id: "Add"
@@ -56,6 +58,7 @@ const Add = createToken(
 );
 
 const Subtract = createToken(
+  parser,
   (props: Props) => ({
     props,
     id: "Subtract"

--- a/packages/jsx-parser/package.json
+++ b/packages/jsx-parser/package.json
@@ -19,7 +19,10 @@
     "name": "jsx-parser",
     "stage": 0,
     "list": [
-      "createJSXParser"
+      "createJSXParser",
+      "createToken",
+      "resolveTokens",
+      "isToken"
     ],
     "category": "Utilities"
   },

--- a/packages/jsx-parser/package.json
+++ b/packages/jsx-parser/package.json
@@ -59,7 +59,9 @@
     "test": "vitest -c ../../configs/vitest.config.ts",
     "test:ssr": "pnpm run test --mode ssr"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@solid-primitives/utils": "workspace:^5.0.0"
+  },
   "peerDependencies": {
     "solid-js": "^1.6.0"
   }

--- a/packages/jsx-parser/package.json
+++ b/packages/jsx-parser/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.2",
   "description": "A primitive to tokenize your solid-components to enable custom parsing.",
   "author": "Vincent Van Dijck <vandijckv@gmail.com>",
-  "contributors": [],
+  "contributors": [
+    "Damian Tarnawski <gthetarnav@gmail.com>"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/parser#readme",
   "repository": {

--- a/packages/jsx-parser/src/index.ts
+++ b/packages/jsx-parser/src/index.ts
@@ -6,7 +6,7 @@ export type TokenElement<T> = (() => JSX.Element) & { data: T };
 // this is only for type inference
 declare const TYPE: unique symbol;
 
-export type JSXParser<T> = { readonly id: symbol } & { [k in typeof TYPE]: T };
+export type JSXParser<T> = { readonly id: symbol; [TYPE]: T };
 
 export type JSXParserData<T extends JSXParser<any>> = T[typeof TYPE];
 

--- a/packages/jsx-parser/src/index.ts
+++ b/packages/jsx-parser/src/index.ts
@@ -3,7 +3,7 @@ import { type Narrow } from "@solid-primitives/utils";
 
 export type TokenElement<T> = (() => JSX.Element) & { data: T };
 
-// this is only for type checking
+// this is only for type inference
 declare const TYPE: unique symbol;
 
 export type JSXParser<T> = { readonly id: symbol } & { [k in typeof TYPE]: T };
@@ -68,7 +68,9 @@ export function createToken<T>(
         : () => {
             process.env.DEV &&
               // eslint-disable-next-line no-console
-              console.warn(`tokens can only be rendered inside a Parser with id '${name}'`);
+              console.warn(
+                `Tokens can only be rendered inside a Parser "${parser.id.description}"`
+              );
             return "";
           }
     ) as TokenElement<T>;
@@ -82,9 +84,11 @@ function resolveChildren(resolved: unknown[], children: unknown, symbol: symbol)
   if (typeof children === "function" && !children.length) {
     if (symbol in children) resolved.push(children);
     else resolveChildren(resolved, children(), symbol);
-  }
-  if (Array.isArray(children))
+  } else if (Array.isArray(children))
     for (let i = 0; i < children.length; i++) resolveChildren(resolved, children[i], symbol);
+  else if (process.env.DEV)
+    // eslint-disable-next-line no-console
+    console.warn(`Invalid JSX Element passed to Parser "${symbol.description}":`, children);
   return resolved;
 }
 

--- a/packages/jsx-parser/test/index.test.tsx
+++ b/packages/jsx-parser/test/index.test.tsx
@@ -1,6 +1,6 @@
 import { children, createRoot, createSignal, Show } from "solid-js";
 import { describe, expect, it } from "vitest";
-import { createJSXParser } from "../src";
+import { createJSXParser, createToken, resolveTokens } from "../src";
 
 describe("jsx-parser", () => {
   const parser1 = createJSXParser<{
@@ -8,14 +8,14 @@ describe("jsx-parser", () => {
     props: { text: string };
   }>();
 
-  const MyToken1 = parser1.createToken((props: { text: string }) => ({
+  const MyToken1 = createToken(parser1, (props: { text: string }) => ({
     type: "my-token",
     props
   }));
 
   it("should work", () => {
     createRoot(() => {
-      const tokens = parser1.childrenTokens(() => (
+      const tokens = resolveTokens(parser1, () => (
         <>
           <MyToken1 text="foo" />
           <MyToken1 text="bar" />
@@ -36,7 +36,7 @@ describe("jsx-parser", () => {
     createRoot(() => {
       const [show, setShow] = createSignal(true);
 
-      const tokens = parser1.childrenTokens(() => (
+      const tokens = resolveTokens(parser1, () => (
         <>
           <Show when={show()}>
             <MyToken1 text="foo" />
@@ -57,7 +57,8 @@ describe("jsx-parser", () => {
     createRoot(() => {
       const parser = createJSXParser();
 
-      const MyToken = parser.createToken(
+      const MyToken = createToken(
+        parser,
         () => ({}),
         (props: { text: string }) => <div>{props.text}</div>
       );
@@ -73,9 +74,9 @@ describe("jsx-parser", () => {
   it("uses props as data if no data function is provided", () => {
     createRoot(() => {
       const parser = createJSXParser<{ text: string }>();
-      const MyToken = parser.createToken();
+      const MyToken = createToken(parser);
 
-      const tokens = parser.childrenTokens(() => (
+      const tokens = resolveTokens(parser, () => (
         <>
           <MyToken text="foo" />
           <MyToken text="bar" />
@@ -92,13 +93,13 @@ describe("jsx-parser", () => {
     createRoot(() => {
       let count = 0;
       const parser = createJSXParser<{ n: number }>();
-      const MyToken = parser.createToken(() => ({
+      const MyToken = createToken(parser, () => ({
         get n() {
           return count++;
         }
       }));
 
-      const tokens = parser.childrenTokens(() => <MyToken text="foo" />);
+      const tokens = resolveTokens(parser, () => <MyToken text="foo" />);
 
       expect(tokens()[0].data.n).toBe(0);
       expect(tokens()[0].data.n).toBe(1);

--- a/packages/jsx-parser/test/server.test.tsx
+++ b/packages/jsx-parser/test/server.test.tsx
@@ -1,6 +1,6 @@
 import { renderToString } from "solid-js/web";
 import { describe, expect, it } from "vitest";
-import { createJSXParser } from "../src";
+import { createJSXParser, createToken, resolveTokens } from "../src";
 
 describe("jsx-parser", () => {
   const parser1 = createJSXParser<{
@@ -8,13 +8,13 @@ describe("jsx-parser", () => {
     props: { text: string };
   }>();
 
-  const MyToken1 = parser1.createToken((props: { text: string }) => ({
+  const MyToken1 = createToken(parser1, (props: { text: string }) => ({
     type: "my-token",
     props
   }));
 
   it("should work", () => {
-    const tokens = parser1.childrenTokens(() => (
+    const tokens = resolveTokens(parser1, () => (
       <>
         <MyToken1 text="foo" />
         <MyToken1 text="bar" />
@@ -33,7 +33,8 @@ describe("jsx-parser", () => {
   it("should render tokens", () => {
     const parser2 = createJSXParser();
 
-    const MyToken2 = parser2.createToken(
+    const MyToken2 = createToken(
+      parser2,
       () => ({}),
       (props: { text: string }) => <div>{props.text}</div>
     );

--- a/packages/jsx-parser/test/server.test.tsx
+++ b/packages/jsx-parser/test/server.test.tsx
@@ -22,9 +22,9 @@ describe("jsx-parser", () => {
     ));
 
     expect(tokens()).toHaveLength(2);
-    tokens().forEach(token => expect(token.type).toBe("my-token"));
-    expect(tokens()[0].props.text).toBe("foo");
-    expect(tokens()[1].props.text).toBe("bar");
+    tokens().forEach(token => expect(token.data.type).toBe("my-token"));
+    expect(tokens()[0].data.props.text).toBe("foo");
+    expect(tokens()[1].data.props.text).toBe("bar");
 
     // shouldn't throw
     <>{tokens()}</>;

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -119,3 +119,8 @@ export type Position = {
   x: number;
   y: number;
 };
+
+export type Narrow<T> =
+  | (T extends [] ? [] : never)
+  | (T extends string | number | bigint | boolean ? T : never)
+  | { [K in keyof T]: T[K] extends Function ? T[K] : Narrow<T[K]> };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -316,8 +316,10 @@ importers:
 
   packages/jsx-parser:
     specifiers:
+      '@solid-primitives/utils': workspace:^5.0.0
       solid-js: ^1.6.0
     dependencies:
+      '@solid-primitives/utils': link:../utils
       solid-js: 1.6.9
 
   packages/keyboard:


### PR DESCRIPTION
@bigmistqke I think that the parser needs to be updated.
Haven't realized this previously but currently, the token data is being restructured and spread on the token with `Object.assign`. This is needlessly more expensive and prevents adding getters to the top-level object. Not only does getter, it just breaks the reference of the passed object.
First, this would be a weird issue to walk into if you have no idea how things get applied, and second, it isn't consistent with other solid APIs (context, props) where adding getters to passed object is common practice.

Also made it so that if you don't pass the function for creating the data object, the component props will be used as the object. Which is great if you only need one token in your api.