### PR TITLE
clipboard: Minor improvements, fix #256

### DIFF
--- a/.changeset/forty-pigs-lick.md
+++ b/.changeset/forty-pigs-lick.md
@@ -1,0 +1,7 @@
+---
+"@solid-primitives/clipboard": minor
+---
+
+Stop reading from clipboard initially. (Fixes #256)
+Simplify item value returned by createClipboard.
+Add `writeClipboard` and `readClipboard` as standalone functions.

--- a/packages/clipboard/README.md
+++ b/packages/clipboard/README.md
@@ -11,80 +11,92 @@
 
 This primitive is designed to that make reading and writing to [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard_API) easy. It also comes with a convenient directive to write to clipboard.
 
+- [`readClipboard`](#readclipboard) - A basic non-reactive primitive that makes accessing the clipboard easy.
+- [`writeClipboard`](#writeclipboard) - A basic non-reactive primitive that makes writing to the clipboard easy.
+- [`createClipboard`](#createclipboard) - This primitive provides full facilities for reading and writing to the clipboard. It allows for writing to clipboard via exported function or input signal. It wraps the Clipboard Async API with a resource and supplies reactive helpers to make pulling from the clipboard easy.
+- [`copyToClipboard`](#copytoclipboard) - convenient directive for setting the clipboard value.
+
 ## Installation
 
 ```bash
 npm install @solid-primitives/clipboard
 # or
 yarn add @solid-primitives/clipboard
+# or
+pnpm add @solid-primitives/clipboard
 ```
 
-## How to use it
-
-### makeClipboard
+## `readClipboard`
 
 A basic non-reactive primitive that makes accessing the clipboard easy. Note that write supports both string and ClipboardItems object structure.
 
-```ts
-const [write, read, newItem] = makeClipboard();
-```
-
-#### Definition
+### How to use it
 
 ```ts
-function makeClipboard(): [
-  write: ClipboardSetter,
-  read: () => Promise<ClipboardItems | undefined>,
-  newItem: NewClipboardItem
-];
+import { readClipboard } from "@solid-primitives/clipboard";
+
+const clipboard = await readClipboard();
+
+clipboard.forEach(item => {
+  if (item.type == "text/plain") {
+    console.log(item.text());
+  }
+});
 ```
 
-### createClipboard
+## `writeClipboard`
+
+A basic non-reactive primitive that makes writing to the clipboard easy. Note that write supports both string and ClipboardItems object structure.
+
+### How to use it
+
+```ts
+import { writeClipboard } from "@solid-primitives/clipboard";
+
+writeClipboard("Hello World");
+
+// or
+
+writeClipboard([
+  new ClipboardItem({
+    "text/plain": new Blob(["Hello World"], { type: "text/plain" })
+  })
+]);
+```
+
+## `createClipboard`
 
 This primitive provides full facilities for reading and writing to the clipboard. It allows for writing to clipboard via exported function or input signal. It wraps the Clipboard Async API with a resource and supplies reactive helpers to make pulling from the clipboard easy.
 
+### How to use it
+
 ```tsx
-const [data, setData] = createSignal('Hello);
-const [clipboard, refresh] = createClipboard(data);
-setData("foobar");
+const [data, setData] = createSignal("Hello");
+const [clipboard, refresh] = createClipboard(data); // will write "Hello" to clipboard
+
+setData("foobar"); // will write "foobar" to clipboard
+
+refresh(); // will read from clipboard and update clipboard() signal
+
 return (
   <Suspense fallback={"Loading..."}>
     <For each={clipboard()}>
       {item => (
         <Switch>
-          <Match when={item.type == "text/plain"}>{item.text()}</Match>
-          <Match when={item.blob() && item.type == "image/png"}>
-            <img class="w-full" src={URL.createObjectURL(item.blob())} />
+          <Match when={item.type == "text/plain"}>{item.text}</Match>
+          <Match when={item.type == "image/png"}>
+            <img class="w-full" src={URL.createObjectURL(item.blob)} />
           </Match>
         </Switch>
       )}
     </For>
   </Suspense>
-)
+);
 ```
 
 Note: The primitive binds and listens for `clipboardchange` meaning that clipboard changes should automatically propagate. The implementation however is buggy on certain browsers.
 
-#### Definition
-
-```ts
-function createClipboard(
-  data?: Accessor<string | ClipboardItem[]>,
-  setInitial?: boolean
-): [
-  clipboardItems: Resource<
-    {
-      type: string;
-      text: Accessor<string>;
-      blob: Accessor<Blob>;
-    }[]
-  >,
-  refetch: VoidFunction,
-  write: ClipboardSetter
-];
-```
-
-### copyToClipboard
+## `copyToClipboard`
 
 You can also use clipboard as a convenient directive for setting the clipboard value. You can override the default value and the setter with the options parameter.
 
@@ -93,7 +105,7 @@ import { copyToClipboard } from "@solid-primitives/clipboard";
 <input type="text" use:copyToClipboard />;
 ```
 
-#### Definition
+### Definition
 
 ```ts
 function copyToClipboard(
@@ -106,7 +118,7 @@ function copyToClipboard(
 );
 ```
 
-#### Highlighters/Range Selection
+### Highlighters/Range Selection
 
 In some scenarios you'll want to highlight or select a range of text. copyToClipboard has an option to specify the type of highlighting you'd like. Use either `input` or `element` based on the type you're making selectable.
 
@@ -116,7 +128,7 @@ import { copyToClipboard, input, element } from "@solid-primitives/clipboard";
 <div use:copyToClipboard={{ highlight: element(5, 10) }} />;
 ```
 
-### newItem
+## `newItem`
 
 This package ships with newItem which is a helper method for creating new ClipboardItem types.
 
@@ -125,7 +137,7 @@ import { newItem } from "@solid-primitives/clipboard";
 write([newItem("image/png", await image.blob())]);
 ```
 
-#### Definition
+### Definition
 
 ```ts
 function newItem(type: string, data: ClipboardItemData): ClipboardItem;
@@ -133,7 +145,7 @@ function newItem(type: string, data: ClipboardItemData): ClipboardItem;
 
 ## Demo
 
-You may view a working example here: https://stackblitz.com/edit/vitejs-vite-okxns7
+You may view a working example in [the /dev playground](./dev/index.tsx) deplayed on [solidjs-community.github.io/solid-primitives/clipboard](https://solidjs-community.github.io/solid-primitives/clipboard/)
 
 ## Changelog
 

--- a/packages/clipboard/dev/index.tsx
+++ b/packages/clipboard/dev/index.tsx
@@ -1,5 +1,5 @@
 import { Component, createSignal, Suspense, For, Switch, Match } from "solid-js";
-import { createClipboard, copyToClipboard, newItem, input } from "../src";
+import { createClipboard, copyToClipboard, newClipboardItem, input } from "../src";
 import { render } from "solid-js/web";
 import img from "./img.png";
 import img2 from "./img2.png";
@@ -18,20 +18,20 @@ const App: Component = () => {
             <input
               use:copyToClipboard={{ highlight: input() }}
               class="p-3 text-2xl border-blue-700 border-3 rounded-md text-center"
-              value="Hello world!"
+              value="Copy me by clicking!"
             />
             <button
               class="mt-2 font-semibold p-3 text-white bg-blue-700 hover:bg-blue-600 transition cursor-pointer border-none rounded-md"
               use:copyToClipboard
             >
-              Copy this text
+              Copy button text
             </button>
             <div class="mt-2 grid grid-cols-2 gap-2">
               <button
                 class="font-semibold p-3 text-white bg-blue-700 hover:bg-blue-600 transition cursor-pointer border-none rounded-md"
                 onClick={async () => {
                   const image = await fetch(img);
-                  setClipboard([newItem("image/png", await image.blob())]);
+                  setClipboard([newClipboardItem("image/png", image.blob())]);
                 }}
               >
                 Copy Image 1
@@ -40,7 +40,7 @@ const App: Component = () => {
                 class="font-semibold p-3 text-white bg-blue-700 hover:bg-blue-600 transition cursor-pointer border-none rounded-md"
                 onClick={async () => {
                   const image = await fetch(img2);
-                  setClipboard([newItem("image/png", await image.blob())]);
+                  setClipboard([newClipboardItem("image/png", image.blob())]);
                 }}
               >
                 Copy Image 2
@@ -53,9 +53,9 @@ const App: Component = () => {
                 <For each={clipboard()}>
                   {item => (
                     <Switch>
-                      <Match when={item.type == "text/plain"}>{item.text()}</Match>
-                      <Match when={item.blob() && item.type == "image/png"}>
-                        <img class="w-full" src={URL.createObjectURL(item.blob())} />
+                      <Match when={item.type == "text/plain"}>{item.text}</Match>
+                      <Match when={item.type == "image/png"}>
+                        <img class="w-full" src={URL.createObjectURL(item.blob)} />
                       </Match>
                     </Switch>
                   )}

--- a/packages/clipboard/dev/vite.config.ts
+++ b/packages/clipboard/dev/vite.config.ts
@@ -1,11 +1,2 @@
-import { defineConfig } from "vite";
-import solidPlugin from "vite-plugin-solid";
-import Unocss from "unocss/vite";
-
-export default defineConfig({
-  plugins: [solidPlugin(), Unocss({})],
-  build: {
-    target: "esnext",
-    polyfillDynamicImport: false
-  }
-});
+import { viteConfig } from "../../../configs/vite.config";
+export default viteConfig;

--- a/packages/clipboard/package.json
+++ b/packages/clipboard/package.json
@@ -41,13 +41,6 @@
       "require": "./dist/server.cjs"
     },
     "browser": {
-      "development": {
-        "import": {
-          "types": "./dist/index.d.ts",
-          "default": "./dist/dev.js"
-        },
-        "require": "./dist/dev.cjs"
-      },
       "import": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
@@ -68,13 +61,6 @@
       },
       "require": "./dist/server.cjs"
     },
-    "development": {
-      "import": {
-        "types": "./dist/index.d.ts",
-        "default": "./dist/dev.js"
-      },
-      "require": "./dist/dev.cjs"
-    },
     "import": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
@@ -85,7 +71,7 @@
     "start": "vite serve dev",
     "dev": "vite serve dev",
     "page": "vite build dev",
-    "build": "jiti ../../scripts/build.ts --ssr --dev",
+    "build": "jiti ../../scripts/build.ts --ssr",
     "test": "vitest -c ../../configs/vitest.config.ts",
     "test:ssr": "pnpm run test --mode ssr"
   },

--- a/packages/clipboard/src/types.d.ts
+++ b/packages/clipboard/src/types.d.ts
@@ -1,9 +1,0 @@
-declare type ClipboardSetter = (data: string | ClipboardItem[]) => Promise<void>;
-declare type NewClipboardItem = (type: string, data: ClipboardItemData) => ClipboardItem;
-declare type HighlightModifier = (el: any) => void;
-declare type Highlighter = (start?: number, end?: number) => HighlightModifier;
-declare type CopyToClipboardOptions = {
-  value?: any;
-  setter?: ClipboardSetter;
-  highlight?: HighlightModifier;
-};

--- a/packages/clipboard/test/setup.ts
+++ b/packages/clipboard/test/setup.ts
@@ -2,7 +2,7 @@
 class ClipboardItem {
   value: any;
   type: string = "text/plain";
-  types: string[] = [];
+  types: string[] = ["text/plain"];
   constructor(value: any) {
     return (this.value = value);
   }


### PR DESCRIPTION
- Stop reading from the clipboard initially. (Fixes #256)
- Simplify item value returned by createClipboard.
- Add `writeClipboard` and `readClipboard` as standalone functions. (deprecate `makeClipboard` - it's useless as read and write can be exported on their own)

the docs still need to be updated I guess

I hope this doesn't mess with the createClipboard API too much... 
