### PR TITLE
feat: new autofocus primitive

### DIFF
--- a/packages/autofocus/LICENSE
+++ b/packages/autofocus/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Solid Primitives Working Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/autofocus/README.md
+++ b/packages/autofocus/README.md
@@ -36,7 +36,7 @@ import { autofocus } from "@solid-primitives/autofocus";
 </button>;
 ```
 
-The `autofocus` directive uses the native `autofocus` attribute to determine if it should focus th element or not.
+The `autofocus` directive uses the native `autofocus` attribute to determine it should focus the element or not.
 Using this directive without `autofocus={true}` (or the shorthand `autofocus`) will not perform anything.
 
 ### createAutofocus

--- a/packages/autofocus/README.md
+++ b/packages/autofocus/README.md
@@ -28,7 +28,7 @@ pnpm add @solid-primitives/autofocus
 
 ### use:autofocus
 
-```ts
+```tsx
 import { autofocus } from "@solid-primitives/autofocus";
 
 <button use:autofocus autofocus={true}>
@@ -41,7 +41,7 @@ Using this directive without `autofocus={true}` (or the shorthand `autofocus`) w
 
 ### createAutofocus
 
-```ts
+```tsx
 import { createAutofocus } from "@solid-primitives/autofocus";
 
 // Using ref

--- a/packages/autofocus/README.md
+++ b/packages/autofocus/README.md
@@ -11,6 +11,8 @@
 
 Primitives for autofocusing HTML elements.
 
+The native autofocus attribute only works on page load, which makes it incompatible with SolidJS. These primitives run on render, allowing autofocus on initial render as well as dynamically added components.
+
 - `autofocus` - Directive to autofocus an element on render.
 - `createAutofocus` - Reactive primitive to autofocus an element on render.
 
@@ -31,9 +33,12 @@ pnpm add @solid-primitives/autofocus
 ```tsx
 import { autofocus } from "@solid-primitives/autofocus";
 
-<button use:autofocus autofocus={true}>
+<button use:autofocus autofocus>
   Autofocused
 </button>;
+
+// autofocus directive can be disabled if `false` is pased as options
+<button use:autofocus={false}>Not Autofocused</button>;
 ```
 
 The `autofocus` directive uses the native `autofocus` attribute to determine it should focus the element or not.

--- a/packages/autofocus/README.md
+++ b/packages/autofocus/README.md
@@ -26,7 +26,7 @@ pnpm add @solid-primitives/autofocus
 
 ## How to use it
 
-### use:autofocus directive
+### use:autofocus
 
 ```ts
 import { autofocus } from "@solid-primitives/autofocus";
@@ -39,7 +39,7 @@ import { autofocus } from "@solid-primitives/autofocus";
 The `autofocus` directive uses the native `autofocus` attribute to determine if it should focus th element or not.
 Using this directive without `autofocus={true}` (or the shorthand `autofocus`) will not perform anything.
 
-### createAutofocus;
+### createAutofocus
 
 ```ts
 import { createAutofocus } from "@solid-primitives/autofocus";

--- a/packages/autofocus/README.md
+++ b/packages/autofocus/README.md
@@ -37,8 +37,8 @@ import { autofocus } from "@solid-primitives/autofocus";
   Autofocused
 </button>;
 
-// autofocus directive can be disabled if `false` is pased as options
-<button use:autofocus={false}>Not Autofocused</button>;
+// Autofocus directive can be disabled if `false` is passed as option
+<button use:autofocus={false} autofocus>Not Autofocused</button>;
 ```
 
 The `autofocus` directive uses the native `autofocus` attribute to determine it should focus the element or not.
@@ -60,12 +60,6 @@ const [ref, setRef] = createSignal<HTMLButtonElement>();
 createAutofocus(ref);
 
 <button ref={setRef}>Autofocused</button>;
-```
-
-```ts
-createAutofocus(ref: Accessor<HTMLElement | undefined>, autofocus: boolean = true);
-
-createAutofocus(ref, false); // Will not autofocus
 ```
 
 ## Changelog

--- a/packages/autofocus/README.md
+++ b/packages/autofocus/README.md
@@ -1,0 +1,68 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=autofocus" alt="Solid Primitives Autofocus">
+</p>
+
+# @solid-primitives/autofocus
+
+[![turborepo](https://img.shields.io/badge/built%20with-turborepo-cc00ff.svg?style=for-the-badge&logo=turborepo)](https://turborepo.org/)
+[![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/autofocus?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-primitives/autofocus)
+[![version](https://img.shields.io/npm/v/@solid-primitives/autofocus?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/autofocus)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
+
+Primitives for autofocusing HTML elements.
+
+- `autofocus` - Directive to autofocus an element on render.
+- `createAutofocus` - Reactive primitive to autofocus an element on render.
+
+## Installation
+
+```bash
+npm install @solid-primitives/autofocus
+# or
+yarn add @solid-primitives/autofocus
+# or
+pnpm add @solid-primitives/autofocus
+```
+
+## How to use it
+
+### use:autofocus directive
+
+```ts
+import { autofocus } from "@solid-primitives/autofocus";
+
+<button use:autofocus autofocus={true}>
+  Autofocused
+</button>;
+```
+
+The `autofocus` directive uses the native `autofocus` attribute to determine if it should focus th element or not.
+Using this directive without `autofocus={true}` (or the shorthand `autofocus`) will not perform anything.
+
+### createAutofocus;
+
+```ts
+import { createAutofocus } from "@solid-primitives/autofocus";
+
+// Using ref
+let ref!: HTMLButtonElement;
+createAutofocus(() => ref);
+
+<button ref={ref}>Autofocused</button>;
+
+// Using ref signal
+const [ref, setRef] = createSignal<HTMLButtonElement>();
+createAutofocus(ref);
+
+<button ref={setRef}>Autofocused</button>;
+```
+
+```ts
+createAutofocus(ref: Accessor<HTMLElement | undefined>, autofocus: boolean = true);
+
+createAutofocus(ref, false); // Will not autofocus
+```
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md)

--- a/packages/autofocus/dev/index.html
+++ b/packages/autofocus/dev/index.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <title>Solid App</title>
+    <style>
+      html {
+        font-family: "Gill Sans", "Gill Sans MT", Calibri, "Trebuchet MS", sans-serif;
+      }
+
+      body {
+        padding: 0;
+        margin: 0;
+      }
+
+      a,
+      button {
+        cursor: pointer;
+      }
+
+      * {
+        margin: 0;
+      }
+
+      button:focus,
+      button:focus-visible {
+        outline: 5px solid red;
+      }
+    </style>
+  </head>
+
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+
+    <script src="/index.tsx" type="module"></script>
+  </body>
+</html>

--- a/packages/autofocus/dev/index.tsx
+++ b/packages/autofocus/dev/index.tsx
@@ -1,0 +1,54 @@
+import { JSX, Component, createSignal, Switch, Match } from "solid-js";
+import { render } from "solid-js/web";
+import { autofocus, createAutofocus } from "../src";
+import "uno.css";
+
+autofocus;
+
+const AutofocusDirective: Component = () => {
+  return (
+    <button autofocus use:autofocus>
+      directive
+    </button>
+  );
+};
+
+const AutofocusRef: Component = () => {
+  let ref!: HTMLButtonElement;
+
+  createAutofocus(() => ref);
+
+  return <button ref={ref}>ref</button>;
+};
+
+const AutofocusRefSignal: Component = () => {
+  const [ref, setRef] = createSignal<HTMLButtonElement>();
+
+  createAutofocus(ref);
+
+  return <button ref={setRef}>ref signal</button>;
+};
+
+const App: Component = () => {
+  const [toggle, setToggle] = createSignal(0);
+
+  return (
+    <div class="flex gap-4 m-4">
+      <button onClick={() => setToggle((toggle() + 1) % 6)}>toggle</button>
+
+      <Switch fallback={<button>no autofocus</button>}>
+        <Match when={toggle() === 0}>
+          <AutofocusDirective />
+        </Match>
+        <Match when={toggle() === 2}>
+          <AutofocusRef />
+        </Match>
+        <Match when={toggle() === 4}>
+          <AutofocusRefSignal />
+        </Match>
+      </Switch>
+    </div>
+  );
+};
+
+render(() => <App />, document.getElementById("root")!);

--- a/packages/autofocus/dev/vite.config.ts
+++ b/packages/autofocus/dev/vite.config.ts
@@ -1,0 +1,2 @@
+import { viteConfig } from "../../../configs/vite.config";
+export default viteConfig;

--- a/packages/autofocus/package.json
+++ b/packages/autofocus/package.json
@@ -1,0 +1,74 @@
+{
+  "name": "@solid-primitives/autofocus",
+  "version": "0.0.100",
+  "description": "Primitives for autofocusing HTML elements",
+  "author": "jer3m01 <jer3m01@jer3m01.com>",
+  "contributors": [],
+  "license": "MIT",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/autofocus#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solidjs-community/solid-primitives.git"
+  },
+  "bugs": {
+    "url": "https://github.com/solidjs-community/solid-primitives/issues"
+  },
+  "primitive": {
+    "name": "autofocus",
+    "stage": 0,
+    "list": [
+      "autofocus",
+      "createAutofocus"
+    ],
+    "category": "Inputs"
+  },
+  "keywords": [
+    "solid",
+    "primitives",
+    "focus",
+    "autofocus"
+  ],
+  "private": false,
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "./dist/server.cjs",
+  "module": "./dist/server.js",
+  "browser": {
+    "./dist/server.cjs": "./dist/index.cjs",
+    "./dist/server.js": "./dist/index.js"
+  },
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "worker": {
+      "import": "./dist/server.js",
+      "require": "./dist/server.cjs"
+    },
+    "browser": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "deno": {
+      "import": "./dist/server.js",
+      "require": "./dist/server.cjs"
+    },
+    "node": {
+      "import": "./dist/server.js",
+      "require": "./dist/server.cjs"
+    },
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
+  "scripts": {
+    "dev": "vite serve dev",
+    "page": "vite build dev",
+    "build": "jiti ../../scripts/build.ts --ssr",
+    "test": "vitest -c ../../configs/vitest.config.ts",
+    "test:ssr": "pnpm run test --mode ssr"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.6.0"
+  }
+}

--- a/packages/autofocus/src/index.ts
+++ b/packages/autofocus/src/index.ts
@@ -1,4 +1,5 @@
 import { createEffect, onMount, JSX, Accessor } from "solid-js";
+import { FalsyValue } from "../../utils";
 
 declare module "solid-js" {
   namespace JSX {
@@ -21,7 +22,7 @@ declare module "solid-js" {
  * <button use:autofocus autofocus={true}>Autofocused</button>;
  * ```
  */
-export const autofocus = (element: HTMLInputElement, autofocus: () => boolean) => {
+export const autofocus = (element: HTMLElement, autofocus: Accessor<boolean>) => {
   if (!autofocus()) {
     return;
   }
@@ -50,15 +51,10 @@ export const autofocus = (element: HTMLInputElement, autofocus: () => boolean) =
  * <button ref={ref}>Autofocused</button>;
  * ```
  */
-export const createAutofocus = (
-  ref: Accessor<HTMLElement | undefined>,
-  autofocus: boolean = true
-) => {
+export const createAutofocus = (ref: Accessor<HTMLElement | FalsyValue>) => {
   createEffect(() => {
-    if (autofocus)
-      setTimeout(() => {
-        ref()?.focus();
-      });
+    const el = ref();
+    el && setTimeout(() => el.focus());
   });
 };
 

--- a/packages/autofocus/src/index.ts
+++ b/packages/autofocus/src/index.ts
@@ -1,5 +1,5 @@
 import { createEffect, onMount, JSX, Accessor } from "solid-js";
-import { FalsyValue } from "../../utils";
+import { FalsyValue } from "@solid-primitives/utils";
 
 declare module "solid-js" {
   namespace JSX {

--- a/packages/autofocus/src/index.ts
+++ b/packages/autofocus/src/index.ts
@@ -1,0 +1,66 @@
+import { createEffect, onMount, JSX, Accessor } from "solid-js";
+
+declare module "solid-js" {
+  namespace JSX {
+    interface Directives {
+      autofocus: boolean;
+    }
+  }
+}
+
+/**
+ * Directive to autofocus the element on render. Uses the native `autofocus` attribute to decided whether to focus.
+ *
+ * @param element - Element to focus.
+ * @param autofocus - Should this directive be enabled. defaults to false.
+ *
+ * @example
+ * ```ts
+ * import { autofocus } from "@solid-primitives/autofocus";
+ *
+ * <button use:autofocus autofocus={true}>Autofocused</button>;
+ * ```
+ */
+export const autofocus = (element: HTMLInputElement, autofocus: () => boolean) => {
+  if (!autofocus()) {
+    return;
+  }
+
+  onMount(() => {
+    // Using a timeout makes it consistent
+    if (element.hasAttribute("autofocus"))
+      setTimeout(() => {
+        element.focus();
+      });
+  });
+};
+
+/**
+ * Creates a new reactive primitive for autofocusing the element on render.
+ *
+ * @param ref - Element to focus.
+ * @param autofocus - Whether the element should be autofocused. defaults to true.
+ *
+ * @example
+ * ```ts
+ * let ref!: HTMLButtonElement;
+ *
+ * createAutofocus(() => ref); // Or using a signal accessor.
+ *
+ * <button ref={ref}>Autofocused</button>;
+ * ```
+ */
+export const createAutofocus = (
+  ref: Accessor<HTMLElement | undefined>,
+  autofocus: boolean = true
+) => {
+  createEffect(() => {
+    if (autofocus)
+      setTimeout(() => {
+        ref()?.focus();
+      });
+  });
+};
+
+// only here so the `JSX` import won't be shaken off the tree:
+export type E = JSX.Element;

--- a/packages/autofocus/test/index.test.tsx
+++ b/packages/autofocus/test/index.test.tsx
@@ -1,0 +1,79 @@
+import { describe, test, expect } from "vitest";
+import { createSignal } from "solid-js";
+import { autofocus, createAutofocus } from "../src";
+import { render } from "@solidjs/testing-library";
+
+autofocus;
+
+describe("use:autofocus", () => {
+  test("use:autofocus focuses the element", async () => {
+    const result = render(() => (
+      <button use:autofocus autofocus>
+        Autofocused
+      </button>
+    ));
+    await new Promise(r => setTimeout(r, 1)); // Wait for the internal setTimeout() to run.
+    expect(document.activeElement).toBe(result.container.querySelector("button"));
+  });
+
+  test("use:autofocus doesn't focus when autofocus={false}", async () => {
+    const result = render(() => (
+      <button use:autofocus autofocus={false}>
+        Not Autofocused
+      </button>
+    ));
+    await new Promise(r => setTimeout(r, 1)); // Wait for the internal setTimeout() to run.
+    expect(document.activeElement).toBe(document.body);
+  });
+
+  test("doesn't focus with use:autofocus={false}", async () => {
+    const result = render(() => (
+      <button use:autofocus={false} autofocus>
+        Not Autofocused
+      </button>
+    ));
+    await new Promise(r => setTimeout(r, 1)); // Wait for the internal setTimeout() to run.
+    expect(document.activeElement).toBe(document.body);
+  });
+});
+
+describe("createAutofocus", () => {
+  test("createAutofocus focuses the element", async () => {
+    const result = render(() => {
+      let ref!: HTMLButtonElement;
+
+      createAutofocus(() => ref);
+
+      return <button ref={ref}>Autofocused</button>;
+    });
+
+    await new Promise(r => setTimeout(r, 1)); // Wait for the internal setTimeout() to run.
+    expect(document.activeElement).toBe(result.container.querySelector("button"));
+  });
+
+  test("createAutofocus works with signal", async () => {
+    const result = render(() => {
+      const [ref, setRef] = createSignal<HTMLButtonElement>();
+
+      createAutofocus(ref);
+
+      return <button ref={setRef}>Autofocused</button>;
+    });
+
+    await new Promise(r => setTimeout(r, 1)); // Wait for the internal setTimeout() to run.
+    expect(document.activeElement).toBe(result.container.querySelector("button"));
+  });
+
+  test("createAutofocus doesn't focus when autofocus is passed false", async () => {
+    const result = render(() => {
+      let ref!: HTMLButtonElement;
+
+      createAutofocus(() => ref, false);
+
+      return <button ref={ref}>Autofocused</button>;
+    });
+
+    await new Promise(r => setTimeout(r, 1)); // Wait for the internal setTimeout() to run.
+    expect(document.activeElement).toBe(document.body);
+  });
+});

--- a/packages/autofocus/test/index.test.tsx
+++ b/packages/autofocus/test/index.test.tsx
@@ -63,17 +63,4 @@ describe("createAutofocus", () => {
     await new Promise(r => setTimeout(r, 1)); // Wait for the internal setTimeout() to run.
     expect(document.activeElement).toBe(result.container.querySelector("button"));
   });
-
-  test("createAutofocus doesn't focus when autofocus is passed false", async () => {
-    const result = render(() => {
-      let ref!: HTMLButtonElement;
-
-      createAutofocus(() => ref, false);
-
-      return <button ref={ref}>Autofocused</button>;
-    });
-
-    await new Promise(r => setTimeout(r, 1)); // Wait for the internal setTimeout() to run.
-    expect(document.activeElement).toBe(document.body);
-  });
 });


### PR DESCRIPTION
Solid does not natively support the `autofocus` attribute. This PR adds a new package with 2 new primitives to support it.
`@solid-primitives/autofocus`:
- `use:autofocus` a directive to use on HTML components.
- `createAutofocus` a ref based autofocus for custom components.

See [autofocus/README](https://github.com/jer3m01/solid-primitives/blob/feat/autofocus/packages/autofocus/README.md) for more details and examples.

The `use:autofocus` directive uses the native `autofocus` attribute to decide on focusing. This provides a seamless integration with existing code<sup>1</sup>, but might come as repetitive/confusing (`use:autofocus autofocus`). Let me know what you think! 


1: Add `use:autofocus` and, provided the intrinsic props are passed down, no extra logic is required.