### PR TITLE
Allow for passing `null` to `createRoot` in `createSubRoot`.

### DIFF
--- a/.changeset/rare-tables-whisper.md
+++ b/.changeset/rare-tables-whisper.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/rootless": patch
+---
+
+Allow for passing `null` to `createRoot` in `createSubRoot`.

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "jsdom": "^20.0.3",
     "json-to-markdown-table": "^1.0.0",
     "prettier": "^2.8.3",
-    "solid-js": "^1.6.9",
+    "solid-js": "^1.6.11",
     "tsup": "^6.5.0",
     "tsup-preset-solid": "^0.1.3",
     "turbo": "^1.7.0",

--- a/packages/rootless/package.json
+++ b/packages/rootless/package.json
@@ -51,7 +51,7 @@
     "@solid-primitives/utils": "workspace:^5.0.0"
   },
   "peerDependencies": {
-    "solid-js": "^1.6.0"
+    "solid-js": "^1.6.11"
   },
   "typesVersions": {}
 }

--- a/packages/rootless/src/index.ts
+++ b/packages/rootless/src/index.ts
@@ -16,14 +16,17 @@ import { AnyFunction, asArray, access } from "@solid-primitives/utils";
  *    return [dispose, memo]
  * }, owner, owner2);
  */
-export function createSubRoot<T>(fn: (dispose: VoidFunction) => T, ...owners: (Owner | null)[]): T {
+export function createSubRoot<T>(
+  fn: (dispose: VoidFunction) => T,
+  ...owners: typeof Owner[]
+): T {
   if (owners.length === 0) owners = [getOwner()];
-  return createRoot(dispose => {
+  return createRoot((dispose) => {
     asArray(access(owners)).forEach(
-      owner => owner && runWithOwner(owner, onCleanup.bind(void 0, dispose))
+      (owner) => owner && runWithOwner(owner, onCleanup.bind(void 0, dispose))
     );
     return fn(dispose);
-  }, owners[0] || undefined);
+  }, owners[0]);
 }
 
 /** @deprecated Renamed to `createSubRoot` */

--- a/packages/rootless/src/index.ts
+++ b/packages/rootless/src/index.ts
@@ -16,14 +16,11 @@ import { AnyFunction, asArray, access } from "@solid-primitives/utils";
  *    return [dispose, memo]
  * }, owner, owner2);
  */
-export function createSubRoot<T>(
-  fn: (dispose: VoidFunction) => T,
-  ...owners: typeof Owner[]
-): T {
+export function createSubRoot<T>(fn: (dispose: VoidFunction) => T, ...owners: (typeof Owner)[]): T {
   if (owners.length === 0) owners = [getOwner()];
-  return createRoot((dispose) => {
+  return createRoot(dispose => {
     asArray(access(owners)).forEach(
-      (owner) => owner && runWithOwner(owner, onCleanup.bind(void 0, dispose))
+      owner => owner && runWithOwner(owner, onCleanup.bind(void 0, dispose))
     );
     return fn(dispose);
   }, owners[0]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
       jsdom: ^20.0.3
       json-to-markdown-table: ^1.0.0
       prettier: ^2.8.3
-      solid-js: ^1.6.9
+      solid-js: ^1.6.11
       tsup: ^6.5.0
       tsup-preset-solid: ^0.1.3
       turbo: ^1.7.0
@@ -31,7 +31,7 @@ importers:
       vitest: ^0.25.8
     devDependencies:
       '@changesets/cli': 2.26.0
-      '@solidjs/testing-library': 0.5.2_solid-js@1.6.9
+      '@solidjs/testing-library': 0.5.2_solid-js@1.6.11
       '@types/fs-extra': 9.0.13
       '@types/node': 18.11.18
       '@typescript-eslint/eslint-plugin': 5.48.2_caon6io6stgpr7lz2rtbhekxqy
@@ -45,15 +45,15 @@ importers:
       jsdom: 20.0.3
       json-to-markdown-table: 1.0.0
       prettier: 2.8.3
-      solid-js: 1.6.9
+      solid-js: 1.6.11
       tsup: 6.5.0_typescript@4.9.4
-      tsup-preset-solid: 0.1.3_dezi6rx5wf5rwq3gnivcvmds7y
+      tsup-preset-solid: 0.1.3_s5sejfrtrbw7nbpwhinkdb35ju
       turbo: 1.7.0
       type-fest: 3.5.2
       typescript: 4.9.4
       unocss: 0.47.6_vite@3.2.5
       vite: 3.2.5_@types+node@18.11.18
-      vite-plugin-solid: 2.5.0_solid-js@1.6.9+vite@3.2.5
+      vite-plugin-solid: 2.5.0_solid-js@1.6.11+vite@3.2.5
       vitest: 0.25.8_jsdom@20.0.3
 
   packages/active-element:
@@ -524,10 +524,10 @@ importers:
   packages/rootless:
     specifiers:
       '@solid-primitives/utils': workspace:^5.0.0
-      solid-js: ^1.6.0
+      solid-js: ^1.6.11
     dependencies:
       '@solid-primitives/utils': link:../utils
-      solid-js: 1.6.9
+      solid-js: 1.6.11
 
   packages/scheduled:
     specifiers:
@@ -2841,14 +2841,14 @@ packages:
       solid-js: 1.6.9
     dev: false
 
-  /@solidjs/testing-library/0.5.2_solid-js@1.6.9:
+  /@solidjs/testing-library/0.5.2_solid-js@1.6.11:
     resolution: {integrity: sha512-GXUiI0Itz/7FfTJrV0RoICS2lL0RE3D1lNSrnuNg9nLC28qKnEQhm9Gfk4gFP9rGVzmsJJJC7yf8kbHMuyR2AA==}
     engines: {node: '>= 14'}
     peerDependencies:
       solid-js: '>=1.0.0'
     dependencies:
       '@testing-library/dom': 8.20.0
-      solid-js: 1.6.9
+      solid-js: 1.6.11
     dev: true
 
   /@testing-library/dom/8.20.0:
@@ -4473,7 +4473,7 @@ packages:
     dev: true
     optional: true
 
-  /esbuild-plugin-solid/0.4.2_kecgasthplfmljbasjxed7p43y:
+  /esbuild-plugin-solid/0.4.2_ofwqa5r246kus6bc3beqssyq3q:
     resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
     peerDependencies:
       esbuild: '>=0.12'
@@ -4483,7 +4483,7 @@ packages:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
       babel-preset-solid: 1.6.9_@babel+core@7.20.12
       esbuild: 0.17.2
-      solid-js: 1.6.9
+      solid-js: 1.6.11
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -7213,6 +7213,11 @@ packages:
       solid-js: 1.6.9
     dev: true
 
+  /solid-js/1.6.11:
+    resolution: {integrity: sha512-JquQQHPArGq+i2PLURxJ99Pcz2/1docpbycSio/cKSA0SeI3z5zRjy0TNcH4NRYvbOLrcini+iovXwnexKabyw==}
+    dependencies:
+      csstype: 3.1.1
+
   /solid-js/1.6.9:
     resolution: {integrity: sha512-kV3fMmm+1C2J95c8eDOPKGfZHnuAkHUBLG4hX1Xu08bXeAIPqmxuz/QdH3B8SIdTp3EatBVIyA6RCes3hrGzpg==}
     dependencies:
@@ -7226,7 +7231,7 @@ packages:
       mapbox-gl: 2.12.0
     dev: true
 
-  /solid-refresh/0.4.2_solid-js@1.6.9:
+  /solid-refresh/0.4.2_solid-js@1.6.11:
     resolution: {integrity: sha512-6g1HsgQkY0X0ZmsaydNgHwRaQIhH3bAbagZiYwWnGO7mqli50ehlwQUN18RZ2MH3fTIs9Y1bankZapVhMVuijg==}
     peerDependencies:
       solid-js: ^1.3
@@ -7234,7 +7239,7 @@ packages:
       '@babel/generator': 7.20.7
       '@babel/helper-module-imports': 7.18.6
       '@babel/types': 7.20.7
-      solid-js: 1.6.9
+      solid-js: 1.6.11
     dev: true
 
   /solid-transition-group/0.0.8_solid-js@1.6.9:
@@ -7606,13 +7611,13 @@ packages:
     resolution: {integrity: sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==}
     dev: true
 
-  /tsup-preset-solid/0.1.3_dezi6rx5wf5rwq3gnivcvmds7y:
+  /tsup-preset-solid/0.1.3_s5sejfrtrbw7nbpwhinkdb35ju:
     resolution: {integrity: sha512-J+3FWntWFOL+qt7C8goIW3EYW/6tGiX8pSf91djBpXqLoBV8gDIAGd4nU6fC3nqjDaN1osmMIJHqhNupbRNUgQ==}
     engines: {node: '>=18'}
     peerDependencies:
       tsup: ^6.5.0
     dependencies:
-      esbuild-plugin-solid: 0.4.2_kecgasthplfmljbasjxed7p43y
+      esbuild-plugin-solid: 0.4.2_ofwqa5r246kus6bc3beqssyq3q
       tsup: 6.5.0_typescript@4.9.4
       type-fest: 3.5.2
     transitivePeerDependencies:
@@ -7987,7 +7992,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-plugin-solid/2.5.0_solid-js@1.6.9+vite@3.2.5:
+  /vite-plugin-solid/2.5.0_solid-js@1.6.11+vite@3.2.5:
     resolution: {integrity: sha512-VneGd3RyFJvwaiffsqgymeMaofn0IzQLPwDzafTV2f1agoWeeJlk5VrI5WqT9BTtLe69vNNbCJWqLhHr9fOdDw==}
     peerDependencies:
       solid-js: ^1.3.17 || ^1.4.0 || ^1.5.0 || ^1.6.0
@@ -7997,8 +8002,8 @@ packages:
       '@babel/preset-typescript': 7.18.6_@babel+core@7.20.12
       babel-preset-solid: 1.6.9_@babel+core@7.20.12
       merge-anything: 5.1.4
-      solid-js: 1.6.9
-      solid-refresh: 0.4.2_solid-js@1.6.9
+      solid-js: 1.6.11
+      solid-refresh: 0.4.2_solid-js@1.6.11
       vite: 3.2.5_@types+node@18.11.18
       vitefu: 0.2.4_vite@3.2.5
     transitivePeerDependencies:


### PR DESCRIPTION
From version Solid v1.6.11 createRoot now correctly handles `null` values as detachedOwner in createRoot. It should be allowed to createSubRoots with `null` owner in order to not inherit the context.