### PR TITLE
scheduled: Add `createScheduled` primitive

### DIFF
--- a/.changeset/bright-timers-trade.md
+++ b/.changeset/bright-timers-trade.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/scheduled": minor
+---
+
+Add `createScheduled` primitive.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "^2.8.4",
     "solid-js": "^1.6.11",
     "tsup": "^6.6.3",
-    "tsup-preset-solid": "^0.1.5",
+    "tsup-preset-solid": "^0.1.6",
     "turbo": "^1.7.4",
     "type-fest": "^3.6.0",
     "typescript": "^4.9.5",

--- a/packages/scheduled/README.md
+++ b/packages/scheduled/README.md
@@ -138,7 +138,7 @@ createEffect(() => {
   // track source signal
   const value = count();
   // track the debounced signal and check if it's dirty
-  if (debounced()) {
+  if (scheduled()) {
     console.log("count", value);
   }
 });
@@ -148,7 +148,7 @@ const debouncedCount = createMemo((p: number = 0) => {
   // track source signal
   const value = count();
   // track the debounced signal and check if it's dirty
-  return debounced() ? value : p;
+  return scheduled() ? value : p;
 });
 ```
 

--- a/packages/scheduled/README.md
+++ b/packages/scheduled/README.md
@@ -15,6 +15,8 @@ Primitives for creating scheduled — throttled or debounced — callbacks.
 - [`throttle`](#throttle) - Creates a callback that is **throttled** and cancellable.
 - [`scheduleIdle`](#scheduleIdle) - Creates a callback throttled using `window.requestIdleCallback()`.
 - [`leading`](#leading) - Creates a scheduled and cancellable callback that will be called on **leading** edge.
+- [`createScheduled`](#createscheduled) - Creates a signal used for scheduling execution of solid computations by tracking.
+- [Scheduling explanation](#scheduling-explanation)
 
 ## Installation
 
@@ -102,6 +104,52 @@ import { leading, throttle } from "@solid-primitives/scheduled";
 const trigger = leading(throttle, (message: string) => console.log(message), 250);
 trigger("Hello!");
 trigger.clear(); // clears a timeout in progress
+```
+
+## `createScheduled`
+
+Creates a signal used for scheduling execution of solid computations by tracking.
+
+### How to use it
+
+`createScheduled` takes only one parameter - a `schedule` function. This function is called with a callback that should be scheduled. It should return a function for triggering the timeout.
+
+```ts
+// e.g. with debounce
+createScheduled(fn => debounce(fn, 1000));
+// e.g. with throttle
+createScheduled(fn => throttle(fn, 1000));
+// e.g. with leading debounce
+createScheduled(fn => leading(debounce, fn, 1000));
+// e.g. with leading throttle
+createScheduled(fn => leading(throttle, fn, 1000));
+```
+
+It returns a signal that can be used to schedule execution of a solid computation. The signal returns `true` if it's dirty _(callback should be called)_ and `false` otherwise.
+
+```ts
+import { createScheduled } from "@solid-primitives/scheduled";
+
+const scheduled = createScheduled(fn => debounce(fn, 1000));
+
+const [count, setCount] = createSignal(0);
+
+createEffect(() => {
+  // track source signal
+  const value = count();
+  // track the debounced signal and check if it's dirty
+  if (debounced()) {
+    console.log("count", value);
+  }
+});
+
+// or with createMemo
+const debouncedCount = createMemo((p: number = 0) => {
+  // track source signal
+  const value = count();
+  // track the debounced signal and check if it's dirty
+  return debounced() ? value : p;
+});
 ```
 
 ## Scheduling explanation

--- a/packages/scheduled/README.md
+++ b/packages/scheduled/README.md
@@ -128,7 +128,7 @@ createScheduled(fn => leading(throttle, fn, 1000));
 It returns a signal that can be used to schedule execution of a solid computation. The signal returns `true` if it's dirty _(callback should be called)_ and `false` otherwise.
 
 ```ts
-import { createScheduled } from "@solid-primitives/scheduled";
+import { createScheduled, debounce } from "@solid-primitives/scheduled";
 
 const scheduled = createScheduled(fn => debounce(fn, 1000));
 

--- a/packages/scheduled/dev/index.tsx
+++ b/packages/scheduled/dev/index.tsx
@@ -1,90 +1,28 @@
 /* @refresh reload */
-import { Component, createSelector, Index } from "solid-js";
-import { createStore } from "solid-js/store";
+import { Component } from "solid-js";
 import { render } from "solid-js/web";
+import { Router, Routes, Route, A } from "@solidjs/router";
 import "uno.css";
-import { createPolled } from "@solid-primitives/timer";
-import { leading, debounce, throttle } from "../src";
-
-type TimelinesKeys = "source" | "deb" | "ldeb" | "thr" | "lthr";
-const LENGTH = 30;
-const TRANSITION = 80;
-const TIMEOUT = 400;
-const headings: Record<TimelinesKeys, string> = {
-  source: "Source",
-  deb: "Debounce",
-  ldeb: "Leading Debounce",
-  thr: "Throttle",
-  lthr: "Leading Throttle"
-};
-
-const getEmptyTieline = () => Array.from({ length: LENGTH }, () => false);
-const getEmptyTimelines = (): Record<TimelinesKeys, boolean[]> => ({
-  source: getEmptyTieline(),
-  deb: getEmptyTieline(),
-  ldeb: getEmptyTieline(),
-  thr: getEmptyTieline(),
-  lthr: getEmptyTieline()
-});
+import Timeline from "./timeline";
+import Reactive from "./reactive";
 
 const App: Component = () => {
-  const [timelines, setTimelines] = createStore(getEmptyTimelines());
-  const current = createPolled<number>(
-    p => {
-      if (++p === LENGTH) reset(), (p = 0);
-      return p;
-    },
-    TRANSITION,
-    0
-  );
-  const isCurrent = createSelector(current);
-
-  function reset() {
-    setTimelines(getEmptyTimelines());
-  }
-
-  const triggerDeb = debounce(() => setTimelines("deb", current(), true), TIMEOUT);
-  const triggerLDeb = leading(debounce, () => setTimelines("ldeb", current(), true), TIMEOUT);
-  const triggerThr = throttle(() => setTimelines("thr", current(), true), TIMEOUT);
-  const triggerLThr = leading(throttle, () => setTimelines("lthr", current(), true), TIMEOUT);
-
-  function trigger() {
-    setTimelines("source", current(), true);
-    triggerDeb();
-    triggerLDeb();
-    triggerThr();
-    triggerLThr();
-  }
-
   return (
     <div class="min-h-screen bg-gray-900 text-white overflow-hidden">
-      <div class="p-4 pb-0 center-child">
-        <button class="btn" onClick={trigger}>
-          TRIGGER!
-        </button>
-      </div>
-      <div class="p-4 pt-2 space-y-4">
-        {(Object.keys(timelines) as TimelinesKeys[]).map(name => (
-          <div>
-            <h3>{headings[name]}</h3>
-            <div
-              class="w-full grid gap-x-1.5"
-              style={`grid-template-columns: repeat(${LENGTH}, 1fr`}
-            >
-              <Index each={timelines[name]}>
-                {(state, index) => (
-                  <div
-                    class={`h-10vh bg-white rounded-sm transition-opacity duration-${TRANSITION}`}
-                    style={{
-                      opacity: state() ? 1 : isCurrent(index) ? 0.2 : 0.05
-                    }}
-                  ></div>
-                )}
-              </Index>
-            </div>
-          </div>
-        ))}
-      </div>
+      <Router>
+        <nav class="fixed top-2 left-2 flex space-x-4">
+          <A class="text-yellow-400" href="/">
+            Timeline
+          </A>
+          <A class="text-yellow-400" href="/page-reactive">
+            createScheduled
+          </A>
+        </nav>
+        <Routes>
+          <Route path="/" element={<Timeline />} />
+          <Route path="/page-reactive" element={<Reactive />} />
+        </Routes>
+      </Router>
     </div>
   );
 };

--- a/packages/scheduled/dev/reactive.tsx
+++ b/packages/scheduled/dev/reactive.tsx
@@ -1,4 +1,4 @@
-import { Component, createMemo, createSignal, untrack } from "solid-js";
+import { Component, createEffect, createMemo, createSignal, untrack } from "solid-js";
 import { createScheduled, debounce, leading, throttle } from "../src";
 
 const Reactive: Component<{}> = props => {
@@ -19,6 +19,10 @@ const Reactive: Component<{}> = props => {
               const c = count();
               return debounced() ? c : p;
             });
+            createEffect(() => {
+              count();
+              console.log("debounced", debounced());
+            });
             return <div>Debounced: {debouncedCount()}</div>;
           })}
 
@@ -27,6 +31,10 @@ const Reactive: Component<{}> = props => {
             const throttledCount = createMemo((p: number = 0) => {
               const c = count();
               return throttled() ? c : p;
+            });
+            createEffect(() => {
+              count();
+              console.log("throttled", throttled());
             });
             return <div>Throttled: {throttledCount()}</div>;
           })}
@@ -37,6 +45,10 @@ const Reactive: Component<{}> = props => {
               const c = count();
               return leadingDebounced() ? c : p;
             });
+            createEffect(() => {
+              count();
+              console.log("leadingDebounced", leadingDebounced());
+            });
             return <div>Leading Debounced: {leadingDebouncedCount()}</div>;
           })}
 
@@ -45,6 +57,10 @@ const Reactive: Component<{}> = props => {
             const leadingThrottledCount = createMemo((p: number = 0) => {
               const c = count();
               return leadingThrottled() ? c : p;
+            });
+            createEffect(() => {
+              count();
+              console.log("leadingThrottled", leadingThrottled());
             });
             return <div>Leading Throttled: {leadingThrottledCount()}</div>;
           })}

--- a/packages/scheduled/dev/reactive.tsx
+++ b/packages/scheduled/dev/reactive.tsx
@@ -1,0 +1,57 @@
+import { Component, createMemo, createSignal, untrack } from "solid-js";
+import { createScheduled, debounce, leading, throttle } from "../src";
+
+const Reactive: Component<{}> = props => {
+  const [count, setCount] = createSignal(0);
+
+  return (
+    <div class="p-4 pb-0 center-child">
+      <div class="wrapper-v">
+        <button class="btn" onClick={() => setCount(p => ++p)}>
+          Increment
+        </button>
+        <div class="mt-4">
+          <div>Count: {count()}</div>
+
+          {untrack(() => {
+            const debounced = createScheduled(fn => debounce(fn, 1000));
+            const debouncedCount = createMemo((p: number = 0) => {
+              const c = count();
+              return debounced() ? c : p;
+            });
+            return <div>Debounced: {debouncedCount()}</div>;
+          })}
+
+          {untrack(() => {
+            const throttled = createScheduled(fn => throttle(fn, 1000));
+            const throttledCount = createMemo((p: number = 0) => {
+              const c = count();
+              return throttled() ? c : p;
+            });
+            return <div>Throttled: {throttledCount()}</div>;
+          })}
+
+          {untrack(() => {
+            const leadingDebounced = createScheduled(fn => leading(debounce, fn, 1000));
+            const leadingDebouncedCount = createMemo((p: number = 0) => {
+              const c = count();
+              return leadingDebounced() ? c : p;
+            });
+            return <div>Leading Debounced: {leadingDebouncedCount()}</div>;
+          })}
+
+          {untrack(() => {
+            const leadingThrottled = createScheduled(fn => leading(throttle, fn, 1000));
+            const leadingThrottledCount = createMemo((p: number = 0) => {
+              const c = count();
+              return leadingThrottled() ? c : p;
+            });
+            return <div>Leading Throttled: {leadingThrottledCount()}</div>;
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Reactive;

--- a/packages/scheduled/dev/timeline.tsx
+++ b/packages/scheduled/dev/timeline.tsx
@@ -1,0 +1,89 @@
+import { Component, createSelector, Index } from "solid-js";
+import { createStore } from "solid-js/store";
+import { createPolled } from "@solid-primitives/timer";
+import { leading, debounce, throttle } from "../src";
+
+type TimelinesKeys = "source" | "deb" | "ldeb" | "thr" | "lthr";
+const LENGTH = 30;
+const TRANSITION = 80;
+const TIMEOUT = 400;
+const headings: Record<TimelinesKeys, string> = {
+  source: "Source",
+  deb: "Debounce",
+  ldeb: "Leading Debounce",
+  thr: "Throttle",
+  lthr: "Leading Throttle"
+};
+
+const getEmptyTieline = () => Array.from({ length: LENGTH }, () => false);
+const getEmptyTimelines = (): Record<TimelinesKeys, boolean[]> => ({
+  source: getEmptyTieline(),
+  deb: getEmptyTieline(),
+  ldeb: getEmptyTieline(),
+  thr: getEmptyTieline(),
+  lthr: getEmptyTieline()
+});
+
+const Timeline: Component = () => {
+  const [timelines, setTimelines] = createStore(getEmptyTimelines());
+  const current = createPolled<number>(
+    p => {
+      if (++p === LENGTH) reset(), (p = 0);
+      return p;
+    },
+    TRANSITION,
+    0
+  );
+  const isCurrent = createSelector(current);
+
+  function reset() {
+    setTimelines(getEmptyTimelines());
+  }
+
+  const triggerDeb = debounce(() => setTimelines("deb", current(), true), TIMEOUT);
+  const triggerLDeb = leading(debounce, () => setTimelines("ldeb", current(), true), TIMEOUT);
+  const triggerThr = throttle(() => setTimelines("thr", current(), true), TIMEOUT);
+  const triggerLThr = leading(throttle, () => setTimelines("lthr", current(), true), TIMEOUT);
+
+  function trigger() {
+    setTimelines("source", current(), true);
+    triggerDeb();
+    triggerLDeb();
+    triggerThr();
+    triggerLThr();
+  }
+
+  return (
+    <>
+      <div class="p-4 pb-0 center-child">
+        <button class="btn" onClick={trigger}>
+          TRIGGER!
+        </button>
+      </div>
+      <div class="p-4 pt-2 space-y-4">
+        {(Object.keys(timelines) as TimelinesKeys[]).map(name => (
+          <div>
+            <h3>{headings[name]}</h3>
+            <div
+              class="w-full grid gap-x-1.5"
+              style={`grid-template-columns: repeat(${LENGTH}, 1fr`}
+            >
+              <Index each={timelines[name]}>
+                {(state, index) => (
+                  <div
+                    class={`h-10vh bg-white rounded-sm transition-opacity duration-${TRANSITION}`}
+                    style={{
+                      opacity: state() ? 1 : isCurrent(index) ? 0.2 : 0.05
+                    }}
+                  ></div>
+                )}
+              </Index>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+export default Timeline;

--- a/packages/scheduled/package.json
+++ b/packages/scheduled/package.json
@@ -90,7 +90,8 @@
     "throttle"
   ],
   "devDependencies": {
-    "@solid-primitives/timer": "workspace:^1.3.5"
+    "@solid-primitives/timer": "workspace:^1.3.5",
+    "@solidjs/router": "^0.7.0"
   },
   "peerDependencies": {
     "solid-js": "^1.6.0"

--- a/packages/scheduled/package.json
+++ b/packages/scheduled/package.json
@@ -17,12 +17,13 @@
   },
   "primitive": {
     "name": "scheduled",
-    "stage": 2,
+    "stage": 3,
     "list": [
       "debounce",
       "throttle",
       "scheduleIdle",
-      "leading"
+      "leading",
+      "createSchedule"
     ],
     "category": "Utilities"
   },

--- a/packages/scheduled/src/index.ts
+++ b/packages/scheduled/src/index.ts
@@ -1,4 +1,4 @@
-import { getOwner, onCleanup } from "solid-js";
+import { Accessor, createSignal, getOwner, onCleanup } from "solid-js";
 
 export type ScheduleCallback = <Args extends unknown[]>(
   callback: (...args: Args) => void,
@@ -181,4 +181,20 @@ export function leading<Args extends unknown[]>(
   };
   if (getOwner()) onCleanup(clear);
   return Object.assign(func, { clear });
+}
+
+export function createScheduled(
+  schedule: (callback: VoidFunction) => VoidFunction
+): Accessor<boolean> {
+  let canCall = false;
+  const [track, dirty] = createSignal(void 0, { equals: false });
+  const call = schedule(() => {
+    canCall = true;
+    dirty();
+  });
+  return () => {
+    call();
+    track();
+    return canCall && !(canCall = false);
+  };
 }

--- a/packages/scheduled/test/create-scheduled.test.ts
+++ b/packages/scheduled/test/create-scheduled.test.ts
@@ -1,0 +1,103 @@
+import { createComputed, createRoot, createSignal } from "solid-js";
+import { describe, it, expect } from "vitest";
+import { createScheduled, debounce, leading } from "../src";
+
+describe("createScheduled", () => {
+  it("returns true after invalidated", () => {
+    let invalidate!: VoidFunction;
+    const scheduled = createScheduled(fn => {
+      invalidate = fn;
+      return () => {};
+    });
+    expect(scheduled()).toBe(false);
+    invalidate();
+    expect(scheduled()).toBe(true);
+  });
+
+  it("triggers observers on invalidate", () => {
+    createRoot(dispose => {
+      let invalidate!: VoidFunction;
+      const scheduled = createScheduled(fn => {
+        invalidate = fn;
+        return () => {};
+      });
+      let i = 0;
+      const [track, trigger] = createSignal(undefined, { equals: false });
+      createComputed(() => {
+        i++;
+        track();
+        expect(scheduled()).toBe(i === 3);
+        if (i === 1) return trigger();
+        if (i === 2) return invalidate();
+        dispose();
+      });
+    });
+  });
+
+  it("debounces", async () => {
+    await createRoot(
+      dispose =>
+        new Promise<void>(resolve => {
+          const scheduled = createScheduled(fn => debounce(fn, 20));
+          const [track, trigger] = createSignal(undefined, { equals: false });
+          let i = 0;
+          createComputed(() => {
+            i++;
+            track();
+            expect(scheduled(), `run ${i}`).toBe(i === 3);
+            if (i === 1) return trigger();
+            if (i === 2) return;
+            resolve();
+            dispose();
+          });
+        })
+    );
+  });
+
+  it("debounces with leading", async () => {
+    await createRoot(
+      dispose =>
+        new Promise<void>(resolve => {
+          const scheduled = createScheduled(fn => leading(debounce, fn, 20));
+          let i = 0;
+          const [track, trigger] = createSignal(undefined, { equals: false });
+          createComputed(() => {
+            i++;
+            track();
+            expect(scheduled(), `run ${i}`).toBe(i === 1);
+            if (i === 1) return trigger();
+            resolve();
+            dispose();
+          });
+        })
+    );
+  });
+
+  it("works with multiple computations", () => {
+    createRoot(dispose => {
+      let invalidate!: VoidFunction;
+      const scheduled = createScheduled(fn => {
+        invalidate = fn;
+        return () => {};
+      });
+      let i = 0;
+      const [track, trigger] = createSignal(undefined, { equals: false });
+      createComputed(() => {
+        i++;
+        track();
+        expect(scheduled(), `(a) run ${i}`).toBe(i === 3);
+        if (i === 1) return;
+        if (i === 2) return;
+      });
+      let j = 0;
+      createComputed(() => {
+        j++;
+        track();
+        expect(scheduled(), `(b) run ${j}`).toBe(j === 3);
+        if (j === 1) return trigger();
+        if (j === 2) return invalidate();
+      });
+      dispose();
+    });
+  });
+});

--- a/packages/scheduled/test/debounce.test.ts
+++ b/packages/scheduled/test/debounce.test.ts
@@ -1,10 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { createRoot } from "solid-js";
 import { debounce, leading } from "../src";
-
-function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
+import sleep from "./sleep";
 
 describe("debounce", () => {
   test("setup and trigger debounce", () =>

--- a/packages/scheduled/test/sleep.ts
+++ b/packages/scheduled/test/sleep.ts
@@ -1,0 +1,3 @@
+export default function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/packages/scheduled/test/throttle.test.ts
+++ b/packages/scheduled/test/throttle.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, test } from "vitest";
 import { createRoot } from "solid-js";
 import { throttle, leading } from "../src";
-
-function sleep(ms: number) {
-  return new Promise(resolve => setTimeout(resolve, ms));
-}
+import sleep from "./sleep";
 
 describe("throttle", () => {
   test("setup and trigger throttle", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -540,11 +540,13 @@ importers:
   packages/scheduled:
     specifiers:
       '@solid-primitives/timer': workspace:^1.3.5
+      '@solidjs/router': ^0.7.0
       solid-js: ^1.6.0
     dependencies:
       solid-js: 1.6.9
     devDependencies:
       '@solid-primitives/timer': link:../timer
+      '@solidjs/router': 0.7.0_solid-js@1.6.9
 
   packages/script-loader:
     specifiers:
@@ -2845,6 +2847,14 @@ packages:
     dependencies:
       solid-js: 1.6.9
     dev: false
+
+  /@solidjs/router/0.7.0_solid-js@1.6.9:
+    resolution: {integrity: sha512-8HI84twe5FjYRebSLMAhtkL9bRuTDIlxJK56kjfjU9WKGoUCTaWpCnkuj8Hqde1bWZ0X+GOZxKDfNkn1CjtjxA==}
+    peerDependencies:
+      solid-js: ^1.5.3
+    dependencies:
+      solid-js: 1.6.9
+    dev: true
 
   /@solidjs/testing-library/0.6.1_solid-js@1.6.11:
     resolution: {integrity: sha512-cS91EDopZhpVa+F55vLxbT+xrQEtc6jIYhXEleu7aCtPRKuBAhKGYQoiOAWrxRd2cXu678dhR8kuwp7ZS2gkNQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,7 +21,7 @@ importers:
       prettier: ^2.8.4
       solid-js: ^1.6.11
       tsup: ^6.6.3
-      tsup-preset-solid: ^0.1.5
+      tsup-preset-solid: ^0.1.6
       turbo: ^1.7.4
       type-fest: ^3.6.0
       typescript: ^4.9.5
@@ -47,7 +47,7 @@ importers:
       prettier: 2.8.4
       solid-js: 1.6.11
       tsup: 6.6.3_typescript@4.9.5
-      tsup-preset-solid: 0.1.5_mpb67xq6yqcmwxkx4udi7xjn6u
+      tsup-preset-solid: 0.1.6_mpb67xq6yqcmwxkx4udi7xjn6u
       turbo: 1.7.4
       type-fest: 3.6.0
       typescript: 4.9.5
@@ -81,7 +81,7 @@ importers:
       '@solid-primitives/utils': link:../utils
       solid-js: 1.6.9
     devDependencies:
-      solid-heroicons: 3.1.1
+      solid-heroicons: 3.1.1_solid-js@1.6.9
 
   packages/autofocus:
     specifiers:
@@ -734,11 +734,6 @@ packages:
       '@babel/highlight': 7.18.6
     dev: true
 
-  /@babel/compat-data/7.20.10:
-    resolution: {integrity: sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==}
-    engines: {node: '>=6.9.0'}
-    dev: true
-
   /@babel/compat-data/7.20.14:
     resolution: {integrity: sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==}
     engines: {node: '>=6.9.0'}
@@ -750,13 +745,13 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.7
+      '@babel/generator': 7.20.14
       '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
       '@babel/helper-module-transforms': 7.20.11
       '@babel/helpers': 7.20.7
-      '@babel/parser': 7.20.7
+      '@babel/parser': 7.20.15
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
       convert-source-map: 1.9.0
       debug: 4.3.4
@@ -769,15 +764,6 @@ packages:
 
   /@babel/generator/7.20.14:
     resolution: {integrity: sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.20.7
-      '@jridgewell/gen-mapping': 0.3.2
-      jsesc: 2.5.2
-    dev: true
-
-  /@babel/generator/7.20.7:
-    resolution: {integrity: sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.20.7
@@ -798,7 +784,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.20.10
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.20.12
       '@babel/helper-validator-option': 7.18.6
       browserslist: 4.21.4
@@ -869,7 +855,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -895,7 +881,7 @@ packages:
       '@babel/helper-member-expression-to-functions': 7.20.7
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -942,7 +928,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.12
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.20.7
     transitivePeerDependencies:
       - supports-color
@@ -959,14 +945,6 @@ packages:
 
   /@babel/parser/7.20.15:
     resolution: {integrity: sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.20.7
-    dev: true
-
-  /@babel/parser/7.20.7:
-    resolution: {integrity: sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
@@ -1333,24 +1311,6 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/parser': 7.20.15
       '@babel/types': 7.20.7
-    dev: true
-
-  /@babel/traverse/7.20.12:
-    resolution: {integrity: sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.7
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
     dev: true
 
   /@babel/traverse/7.20.13:
@@ -3586,19 +3546,6 @@ packages:
       - debug
     dev: true
 
-  /babel-plugin-jsx-dom-expressions/0.35.14_@babel+core@7.20.12:
-    resolution: {integrity: sha512-Eywfw/7cNbBsStTgj46JRvyGTb+RLyF2EJ0AV3/W2cUwbw3R3syOBqdzFLdHN2MPOs4nJA80XtGl9kSMjEekhA==}
-    peerDependencies:
-      '@babel/core': ^7.20.12
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
-      '@babel/types': 7.20.7
-      html-entities: 2.3.3
-      validate-html-nesting: 1.2.0
-    dev: true
-
   /babel-plugin-jsx-dom-expressions/0.35.16_@babel+core@7.20.12:
     resolution: {integrity: sha512-Z8vaeXRdtI4qyq3bmQiLjiZnbjn2Rr0mjpXMwN+QxHbWjtlAFOJSHlkcxbrwPz/DdcfSgkmZM0Atvt/zMLeLyA==}
     peerDependencies:
@@ -3668,7 +3615,7 @@ packages:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.20.12
-      babel-plugin-jsx-dom-expressions: 0.35.14_@babel+core@7.20.12
+      babel-plugin-jsx-dom-expressions: 0.35.16_@babel+core@7.20.12
     dev: true
 
   /balanced-match/1.0.2:
@@ -4474,8 +4421,8 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
-  /esbuild-plugin-solid/0.4.2_53k565wzpp55uni6zxdi7b642e:
-    resolution: {integrity: sha512-T5GphLoud3RumjeNYO3K9WVjWDzVKG5evlS7hUEUI0n9tiCL+CnbvJh3SSwFi3xeeXpZRrnZc1gd6FWQsVobTg==}
+  /esbuild-plugin-solid/0.5.0_53k565wzpp55uni6zxdi7b642e:
+    resolution: {integrity: sha512-ITK6n+0ayGFeDVUZWNMxX+vLsasEN1ILrg4pISsNOQ+mq4ljlJJiuXotInd+HE0MzwTcA9wExT1yzDE2hsqPsg==}
     peerDependencies:
       esbuild: '>=0.12'
       solid-js: '>= 1.0'
@@ -7176,10 +7123,12 @@ packages:
       solid-js: 1.6.9
     dev: true
 
-  /solid-heroicons/3.1.1:
+  /solid-heroicons/3.1.1_solid-js@1.6.9:
     resolution: {integrity: sha512-wfU/SqxqxWxInvfFlKJfCBPnJ94Zq1GQFiFL3M0KwZzT81lSF5yIC4HA/Czp3DYrn+dUumjO0qdrx8Ab3cy2sA==}
     peerDependencies:
       solid-js: '>= ^1.2.5'
+    dependencies:
+      solid-js: 1.6.9
     dev: true
 
   /solid-js/1.6.11:
@@ -7205,7 +7154,7 @@ packages:
     peerDependencies:
       solid-js: ^1.3
     dependencies:
-      '@babel/generator': 7.20.7
+      '@babel/generator': 7.20.14
       '@babel/helper-module-imports': 7.18.6
       '@babel/types': 7.20.7
       solid-js: 1.6.11
@@ -7610,12 +7559,12 @@ packages:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
     dev: true
 
-  /tsup-preset-solid/0.1.5_mpb67xq6yqcmwxkx4udi7xjn6u:
-    resolution: {integrity: sha512-lmXr0/0uv4reN6XFG1l79I1w7Z+yOEfVRxmPfaB+qdPmshYledIgDMEOsezsGEf///JJJzL0n3f0bKd8cmqScQ==}
+  /tsup-preset-solid/0.1.6_mpb67xq6yqcmwxkx4udi7xjn6u:
+    resolution: {integrity: sha512-9vocqmBU7k53DxwcybxcL8bH/hxKjEKYNSlZEA0GFNxldsaao7pfAemE4Mjdkcc5UCRYfFWf04GsfIYscl4Sqg==}
     peerDependencies:
       tsup: ^6.5.0
     dependencies:
-      esbuild-plugin-solid: 0.4.2_53k565wzpp55uni6zxdi7b642e
+      esbuild-plugin-solid: 0.5.0_53k565wzpp55uni6zxdi7b642e
       tsup: 6.6.3_typescript@4.9.5
       type-fest: 3.6.0
     transitivePeerDependencies:
@@ -7944,10 +7893,6 @@ packages:
 
   /v8-compile-cache-lib/3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
-    dev: true
-
-  /validate-html-nesting/1.2.0:
-    resolution: {integrity: sha512-sI65QUd3T/e5wbQkdPKjikFsIVLPIaOQK+9uowPp6/k609SN8hs5eqBLrnN5DeW9Kd932Q4Imo0fzK2dxoOsCA==}
     dev: true
 
   /validate-html-nesting/1.2.1:


### PR DESCRIPTION
Adds new `createScheduled` primitive to the `scheduled` package based on @fabiospampinato's idea.

It provides a nice API for composing scheduling with any scheduling primitive (`debounce`, `throttle`, `scheduleIdle`, etc.) and any solid computation primitive.

```ts
import { createScheduled, debounce } from "@solid-primitives/scheduled";

const scheduled = createScheduled(fn => debounce(fn, 1000));

const [count, setCount] = createSignal(0);

createEffect(() => {
  // track source signal
  const value = count();
  // track the debounced signal and check if it's dirty
  if (scheduled()) {
    console.log("count", value);
  }
});

// or with createMemo
const debouncedCount = createMemo((p: number = 0) => {
  // track source signal
  const value = count();
  // track the debounced signal and check if it's dirty
  return scheduled() ? value : p;
});
```

[README](https://github.com/solidjs-community/solid-primitives/tree/create-scheduled/packages/scheduled#createscheduled)