### PR TITLE
utils: new createHydrateSignal - fix:hydration issues

### DIFF
--- a/.changeset/twenty-glasses-act.md
+++ b/.changeset/twenty-glasses-act.md
@@ -1,0 +1,11 @@
+---
+"@solid-primitives/active-element": patch
+"@solid-primitives/connectivity": patch
+"@solid-primitives/media": patch
+"@solid-primitives/page-visibility": patch
+"@solid-primitives/share": patch
+"@solid-primitives/styles": patch
+"@solid-primitives/utils": minor
+---
+
+Add `createHydrateSignal` primitive to utils and fix hydration issues

--- a/packages/active-element/package.json
+++ b/packages/active-element/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.7",
   "description": "A reactive document.activeElement. Check which element is currently focused.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
+  "contributors": [
+    "Tom Pichaud <dev.tompichaud@icloud.com>"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/active-element#readme",
   "repository": {

--- a/packages/active-element/src/index.ts
+++ b/packages/active-element/src/index.ts
@@ -1,5 +1,5 @@
-import { Accessor, createSignal, JSX } from "solid-js";
-import { MaybeAccessor, Directive } from "@solid-primitives/utils";
+import { Accessor, JSX } from "solid-js";
+import { MaybeAccessor, Directive, createHydrateSignal } from "@solid-primitives/utils";
 import { makeEventListener, createEventListener } from "@solid-primitives/event-listener";
 
 declare module "solid-js" {
@@ -50,7 +50,7 @@ export function createActiveElement(): Accessor<Element | null> {
   if (process.env.SSR) {
     return () => null;
   }
-  const [active, setActive] = createSignal<Element | null>(getActiveElement());
+  const [active, setActive] = createHydrateSignal<Element | null>(null, getActiveElement);
   makeActiveElementListener(setActive);
   return active;
 }
@@ -94,7 +94,10 @@ export function createFocusSignal(target: MaybeAccessor<Element>): Accessor<bool
   if (process.env.SSR) {
     return () => false;
   }
-  const [isActive, setIsActive] = createSignal(document.activeElement === target);
+  const [isActive, setIsActive] = createHydrateSignal(
+    false,
+    () => document.activeElement === target
+  );
   createEventListener(target, "blur", () => setIsActive(false), true);
   createEventListener(target, "focus", () => setIsActive(true), true);
   return isActive;

--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -4,7 +4,8 @@
   "description": "A navigator.onLine signal.",
   "author": "Klemen Slavič <krof.drakula@gmail.com>",
   "contributors": [
-    "Damian Tarnawski <gthetarnav@gmail.com>"
+    "Damian Tarnawski <gthetarnav@gmail.com>",
+    "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/utils#readme",

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -9,7 +9,8 @@
       "email": "adityaa803@gmail.com",
       "url": "https://devadi.netlify.app"
     },
-    "Damian Tarnawski <gthetarnav@gmail.com>"
+    "Damian Tarnawski <gthetarnav@gmail.com>",
+    "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/media",

--- a/packages/media/src/index.ts
+++ b/packages/media/src/index.ts
@@ -1,6 +1,6 @@
-import { createSignal, Accessor, sharedConfig, createEffect } from "solid-js";
+import { Accessor, sharedConfig } from "solid-js";
 import { makeEventListener } from "@solid-primitives/event-listener";
-import { createStaticStore, entries, noop } from "@solid-primitives/utils";
+import { createStaticStore, entries, noop, createHydrateSignal } from "@solid-primitives/utils";
 import { createSharedRoot } from "@solid-primitives/rootless";
 
 /**
@@ -44,15 +44,8 @@ export function createMediaQuery(query: string, serverFallback = false) {
     return () => serverFallback;
   }
   const mql = window.matchMedia(query);
-  let init = !!sharedConfig.context;
-  const [state, setState] = createSignal(init ? serverFallback : mql.matches, {
-    equals(a, b) {
-      if (init) return (init = false);
-      return a === b;
-    }
-  });
+  const [state, setState] = createHydrateSignal(serverFallback, () => mql.matches);
   const update = () => setState(mql.matches);
-  init && createEffect(update);
   makeEventListener(mql, "change", update);
   return state;
 }
@@ -80,7 +73,7 @@ const sharedPrefersDark: () => Accessor<boolean> = /*#__PURE__*/ createSharedRoo
 /**
  * Provides a signal indicating if the user has requested dark color theme. The setting is being watched with a [Media Query](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme).
  *
- * This is a [shared root primitive](https://github.com/solidjs-community/solid-primitives/tree/main/packages/rootless#createSharedRoot).
+ * This is a [shared root primitive](https://github.com/solidjs-community/solid-primitives/tree/main/packages/rootless#createSharedRoot) except if during hydration.
  *
  * @returns a boolean signal
  * @example
@@ -91,10 +84,7 @@ const sharedPrefersDark: () => Accessor<boolean> = /*#__PURE__*/ createSharedRoo
  */
 export const usePrefersDark: () => Accessor<boolean> = process.env.SSR
   ? () => () => false
-  : // do not use a shared root if during hydration
-    // this is to avoid a mismatch between the server and client
-    // see issue: https://github.com/solidjs-community/solid-primitives/issues/310
-    () => (sharedConfig.context ? createPrefersDark() : sharedPrefersDark());
+  : () => (sharedConfig.context ? createPrefersDark() : sharedPrefersDark());
 
 export type Breakpoints = Record<string, string>;
 

--- a/packages/page-visibility/package.json
+++ b/packages/page-visibility/package.json
@@ -95,7 +95,9 @@
     "primitives"
   ],
   "dependencies": {
-    "@solid-primitives/rootless": "workspace:^1.2.2"
+    "@solid-primitives/event-listener": "workspace:^2.2.6",
+    "@solid-primitives/rootless": "workspace:^1.2.3",
+    "@solid-primitives/utils": "workspace:^5.0.0"
   },
   "peerDependencies": {
     "solid-js": "^1.6.0"

--- a/packages/page-visibility/package.json
+++ b/packages/page-visibility/package.json
@@ -4,7 +4,8 @@
   "description": "Primitive to track page visibility",
   "author": "David Di Biase",
   "contributors": [
-    "Damian Tarnawski <gthetarnav@gmail.com>"
+    "Damian Tarnawski <gthetarnav@gmail.com>",
+    "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/page-visibility",

--- a/packages/share/package.json
+++ b/packages/share/package.json
@@ -4,7 +4,8 @@
   "description": "Primitives to help with sharing content on social media and beyond.",
   "author": "David Di Biase <dave.dibiase@gmail.com",
   "contributors": [
-    "Omer Ma<mapinxue@qq.com>"
+    "Omer Ma<mapinxue@qq.com>",
+    "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/share",

--- a/packages/share/src/web-share.ts
+++ b/packages/share/src/web-share.ts
@@ -67,12 +67,10 @@ export const createWebShare = (
   data: Accessor<ShareData>,
   deferInitial: boolean = false
 ): ShareStatus => {
-  const [status, setStatus] = createSignal<ShareStatus>({});
-
   if (process.env.SSR) {
     return {};
   }
-
+  const [status, setStatus] = createSignal<ShareStatus>({});
   const share = makeWebShare();
   createEffect(
     on(

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -98,7 +98,8 @@
     "css"
   ],
   "dependencies": {
-    "@solid-primitives/rootless": "workspace:^1.2.2"
+    "@solid-primitives/rootless": "workspace:^1.2.2",
+    "@solid-primitives/utils": "workspace:^5.0.0"
   },
   "peerDependencies": {
     "solid-js": "^1.6.0"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.102",
   "description": "Collection of reactive primitives focused on styles.",
   "author": "Damian Tarnawski <gthetaranv@gmail.com>",
-  "contributors": [],
+  "contributors": [
+    "Tom Pichaud <dev.tompichaud@icloud.com>"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/styles#readme",
   "repository": {

--- a/packages/styles/src/index.ts
+++ b/packages/styles/src/index.ts
@@ -1,5 +1,6 @@
 import { createSharedRoot } from "@solid-primitives/rootless";
-import { Accessor, createSignal, onCleanup } from "solid-js";
+import { Accessor, onCleanup, sharedConfig } from "solid-js";
+import { createHydrateSignal } from "@solid-primitives/utils";
 
 let serverRemSize = 16;
 
@@ -30,7 +31,7 @@ export function createRemSize(): Accessor<number> {
   if (process.env.SSR) {
     return () => serverRemSize;
   }
-  const [remSize, setRemSize] = createSignal(getRemSize());
+  const [remSize, setRemSize] = createHydrateSignal(serverRemSize, getRemSize);
   const el = document.createElement("div");
   Object.assign(el.style, totallyHiddenStyles, { width: "1rem" });
   document.body.appendChild(el);
@@ -47,10 +48,13 @@ export function createRemSize(): Accessor<number> {
   return remSize;
 }
 
+const sharedRemSize: () => Accessor<number> = /*#__PURE__*/ createSharedRoot(createRemSize);
+
 /**
  * Returns a reactive signal with value of the current rem size, and tracks it's changes.
  *
- * This is a [shared root primitive](https://github.com/solidjs-community/solid-primitives/tree/main/packages/rootless#createSharedRoot).
+ * This is a [shared root primitive](https://github.com/solidjs-community/solid-primitives/tree/main/packages/rootless#createSharedRoot) except if during hydration.
+ *
  * @returns A signal with the current rem size in pixels.
  * @see [Primitive documentation](https://github.com/solidjs-community/solid-primitives/tree/main/packages/styles#useRemSize).
  * @example
@@ -58,8 +62,8 @@ export function createRemSize(): Accessor<number> {
  * console.log(remSize()); // 16
  */
 export const useRemSize: () => Accessor<number> = process.env.SSR
-  ? /*#__PURE__*/ () => () => serverRemSize
-  : /*#__PURE__*/ createSharedRoot(createRemSize);
+  ? () => () => serverRemSize
+  : () => (sharedConfig.context ? createRemSize() : sharedRemSize());
 
 /**
  * Set the server fallback value for the rem size. {@link getRemSize}, {@link createRemSize} and {@link useRemSize} will return this value on the server.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -3,6 +3,9 @@
   "version": "5.1.1",
   "description": "A bunch of reactive utility types and functions, for building primitives with Solid.js",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
+  "contributors": [
+    "Tom Pichaud <dev.tompichaud@icloud.com>"
+  ],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/utils#readme",
   "repository": {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -323,11 +323,12 @@ export function handleDiffArray<T>(
  * A signal object that handle hydration.
  * @param serverValue initial value of the state on the server
  * @param update called once on the client or on hydration to initialise the value
- * @param options SignalOptions<T>
+ * @param options {@link SignalOptions}
  * @returns
  * ```ts
  * [state: Accessor<T>, setState: Setter<T>]
  * ```
+ * @see {@link createSignal}
  */
 export function createHydrateSignal<T>(
   serverValue: T,

--- a/packages/utils/test/index.test.ts
+++ b/packages/utils/test/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, assert } from "vitest";
 import { createComputed, createRoot } from "solid-js";
-import { createStaticStore, handleDiffArray, arrayEquals } from "../src";
+import { createStaticStore, handleDiffArray, arrayEquals, createHydrateSignal } from "../src";
 
 describe("createStaticStore", () => {
   test("individual keys only update when changed", () => {
@@ -154,5 +154,13 @@ describe("arrayEquals", () => {
     assert(!arrayEquals([1, 2, 3], [1, 2, 3, 4]));
     assert(!arrayEquals([1, 2, 3], [1, 0, 3]));
     assert(!arrayEquals([1, 2, _1], [1, 2, []]));
+  });
+});
+
+describe("createHydrateSignal", () => {
+  test("createHydrateSignal() - CSR", () => {
+    const [state, setState] = createHydrateSignal("server", () => "client");
+    expect(state()).toEqual("client");
+    expect(setState).toBeInstanceOf(Function);
   });
 });

--- a/packages/utils/test/server.test.ts
+++ b/packages/utils/test/server.test.ts
@@ -1,0 +1,10 @@
+import { createHydrateSignal } from "../src";
+import { describe, expect, it } from "vitest";
+
+describe("API doesn't break in SSR", () => {
+  it("createHydrateSignal() - SSR", () => {
+    const [state, setState] = createHydrateSignal("server", () => "client");
+    expect(state()).toEqual("server");
+    expect(setState).toBeInstanceOf(Function);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,10 +420,14 @@ importers:
 
   packages/page-visibility:
     specifiers:
-      '@solid-primitives/rootless': workspace:^1.2.2
+      '@solid-primitives/event-listener': workspace:^2.2.6
+      '@solid-primitives/rootless': workspace:^1.2.3
+      '@solid-primitives/utils': workspace:^5.0.0
       solid-js: ^1.6.0
     dependencies:
+      '@solid-primitives/event-listener': link:../event-listener
       '@solid-primitives/rootless': link:../rootless
+      '@solid-primitives/utils': link:../utils
       solid-js: 1.6.9
 
   packages/pagination:
@@ -611,9 +615,11 @@ importers:
   packages/styles:
     specifiers:
       '@solid-primitives/rootless': workspace:^1.2.2
+      '@solid-primitives/utils': workspace:^5.0.0
       solid-js: ^1.6.0
     dependencies:
       '@solid-primitives/rootless': link:../rootless
+      '@solid-primitives/utils': link:../utils
       solid-js: 1.6.9
 
   packages/timer:


### PR DESCRIPTION
Following https://github.com/solidjs-community/solid-primitives/issues/310

New `createHydrateSignal` with test on `utils:package`

Fixes hydration issue and improve shared root usage on : 

- `createMediaQuery` & `usePrefersDark`
- `createActiveElement` & `createFocusSignal`
- `createConnectivitySignal` & `useConnectivitySignal`
- `createPageVisibility` & `usePageVisibility`
- `createRemSize` & `useRemSize`

Fixes SSR function return order on `createWebShare`

Thank you @thetarnav for helping on my first contribution, I've tried my best.