### PR TITLE
i18n: add custom readFn function

### DIFF
--- a/.changeset/good-trees-wait.md
+++ b/.changeset/good-trees-wait.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/i18n": patch
+---
+
+Add an option to provide a custom function for resolving translation values.

--- a/packages/i18n/src/chained-i18n.ts
+++ b/packages/i18n/src/chained-i18n.ts
@@ -57,7 +57,7 @@ function buildChainedDictionary<T extends I18nObject>(obj: T, readFn: <A = any>(
         break;
       case "string":
         mapped[key] = (args: I18nFormatOptions) =>
-          value.replace(/{{([^{}]+)}}/g, (_, key) => readFn(args, key, ""));
+          value.replace(/{{([^{}]+)}}/g, (_, key) => readFn(args, key, "").toString());
         break;
       default:
         throw new Error(

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -64,21 +64,26 @@ const template = (
  *
  * @param [init={}] {Record<string, Record<string, any>>} - Initial dictionary of languages
  * @param [lang=navigator.language] {string} - The default language fallback to browser language if not set
- * @param [options={}] { chained: boolean } -
+ * @param [readFn=deepReadObject] {<T = any>(obj: Record<string, unknown>, path: string, defaultValue?: unknown) => T} - Read function used to read the dictionary
  */
 export const createI18nContext = (
   init: Record<string, Record<string, any>> = {},
   lang: string = typeof navigator !== "undefined" && navigator.language in init
     ? navigator.language
     : Object.keys(init)[0] ?? "",
+  readFn: <T = any>(
+    obj: Record<string, unknown>,
+    path: string,
+    defaultValue?: unknown,
+  ) => T = deepReadObject,
 ): [
-  template: (key: string, params?: Record<string, string>, defaultValue?: string) => any,
-  actions: {
-    add(lang: string, table: Record<string, any>): void;
-    locale: (lang?: string) => string;
-    dict: (lang: string) => Record<string, Record<string, any>>;
-  },
-] => {
+    template: (key: string, params?: Record<string, string>, defaultValue?: string) => any,
+    actions: {
+      add(lang: string, table: Record<string, any>): void;
+      locale: (lang?: string) => string;
+      dict: (lang: string) => Record<string, Record<string, any>>;
+    },
+  ] => {
   const [locale, setLocale] = createSignal(lang);
   const [dict, setDict] = createStore(init);
   /**
@@ -113,7 +118,7 @@ export const createI18nContext = (
     params?: Record<string, string>,
     defaultValue?: string,
   ): string => {
-    const val = deepReadObject(dict[locale()]!, key, defaultValue || "");
+    const val = readFn(dict[locale()]!, key, defaultValue || "");
     if (typeof val === "function") return val(params);
     if (typeof val === "string") return template(val, params || {});
     return val as string;

--- a/packages/i18n/test/setup.ts
+++ b/packages/i18n/test/setup.ts
@@ -5,6 +5,7 @@ export const dict = {
     food: {
       meat: "viande",
     },
+    "keys.with.dots": "salut"
   },
   en: {
     hello: "hello {{ name }}, how are you?",
@@ -12,6 +13,7 @@ export const dict = {
     food: {
       meat: "meat",
     },
+    "keys.with.dots": "hi"
   },
   es: {
     hello: "hola {{ name }}, como usted?",
@@ -19,5 +21,6 @@ export const dict = {
     food: {
       meat: "carne",
     },
+    "keys.with.dots": "hola"
   },
 };


### PR DESCRIPTION
Hello!

This PR adds support to the i18n module for specifying a custom `readFn` function which is used in place of `deepReadObject`. The default behaviour when reading the store is to consider keys with dots as wanting to traverse nested objects in the store.

This breaks a series of use-cases: 
 - "some.namespace.key.intro_text": "Welcome!"
 - "I like to have the keys being the english version of a string, there is a negligible perf hit but the code is more readable": "Mi piace che le chiavi siano la versione inglese di una stringa, c'è un calo di prestazioni ma il codice è più leggibile"
 
An anecdotal experience:
As a user who quickly skimmed through the examples, I was not expecting this behaviour and I imagined it would just try to `dict[key]` and I was puzzled when I didn't see my translations appearing
 
I think adding a custom function allows us to keep retro-compatibilty and give the users the chance to provide an alternative implementation for accessing the store.

EDIT: Thanks for the reviews and apologies, I will be very busy until June but I'll try to come back to it asap! 🙌 