### PR TITLE
filesystem: improve fail case

### DIFF
--- a/.changeset/twenty-parrots-battle.md
+++ b/.changeset/twenty-parrots-battle.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/filesystem": major
+---
+
+improve fail case (return null instead of mock)

--- a/packages/filesystem/src/adapter-mocks.ts
+++ b/packages/filesystem/src/adapter-mocks.ts
@@ -1,25 +1,26 @@
-import { SyncFileSystemAdapter, AsyncFileSystemAdapter } from "./types";
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { DirEntries, ItemType, SyncFileSystemAdapter } from "./types";
 
 /** Mocks a synchronous file system adapter */
-export const makeNoFileSystem = (): SyncFileSystemAdapter => ({
-  async: false,
-  getType: () => null,
-  mkdir: () => undefined,
-  readdir: () => [],
-  readFile: () => "",
-  rename: () => undefined,
-  rm: () => undefined,
-  writeFile: () => undefined,
+export const makeNoFileSystem = () => ({
+  async: false as const,
+  getType: (path: string): ItemType => null,
+  mkdir: (path: string) => undefined,
+  readdir: (path: string): DirEntries => [],
+  readFile: (path: string) => "",
+  rename: (prev: string, next: string) => undefined,
+  rm: (path: string) => undefined,
+  writeFile: (path: string, data: string) => undefined,
 });
 
 /** Mocks an asynchronous file system adapter */
-export const makeNoAsyncFileSystem = (): AsyncFileSystemAdapter => ({
-  async: true,
-  getType: () => Promise.resolve(null),
-  mkdir: () => Promise.resolve(),
-  readdir: () => Promise.resolve([]),
-  readFile: () => Promise.resolve(""),
-  rename: () => Promise.resolve(),
-  rm: () => Promise.resolve(),
-  writeFile: () => Promise.resolve(),
+export const makeNoAsyncFileSystem = () => ({
+  async: true as const,
+  getType: (path: string): Promise<ItemType> => Promise.resolve(null),
+  mkdir: (path: string) => Promise.resolve(),
+  readdir: (path: string): Promise<DirEntries> => Promise.resolve([]),
+  readFile: (path: string) => Promise.resolve(""),
+  rename: (prev: string, next: string) => Promise.resolve(),
+  rm: (path: string) => Promise.resolve(),
+  writeFile: (path: string, data: string) => Promise.resolve(),
 });

--- a/packages/filesystem/src/adapter-node.ts
+++ b/packages/filesystem/src/adapter-node.ts
@@ -1,14 +1,12 @@
-import { makeNoAsyncFileSystem } from "./adapter-mocks";
 import { limitPath } from "./tools";
-import type { AsyncFileSystemAdapter } from "./types";
 import { isServer } from "solid-js/web";
 
 export const makeNodeFileSystem = isServer
-  ? async (basePath: string = "/"): Promise<AsyncFileSystemAdapter> => {
+  ? async (basePath: string = "/") => {
       const fs = await import("fs/promises");
       const p = limitPath(basePath);
       return {
-        async: true,
+        async: true as const,
         getType: (path: string) =>
           fs
             .stat(p(path))
@@ -23,4 +21,4 @@ export const makeNodeFileSystem = isServer
           fs.writeFile(p(path), data, { encoding: "utf8" }),
       };
     }
-  : makeNoAsyncFileSystem;
+  : () => Promise.resolve(null);

--- a/packages/filesystem/src/adapter-tauri.ts
+++ b/packages/filesystem/src/adapter-tauri.ts
@@ -1,36 +1,34 @@
-import { makeNoAsyncFileSystem } from "./adapter-mocks";
-import type { AsyncFileSystemAdapter } from "./types";
-import type { FileEntry, FsDirOptions } from "@tauri-apps/api/fs";
+import { BaseDirectory, type FileEntry, type FsDirOptions } from "@tauri-apps/api/fs";
 
-const taurifs = (globalThis as any).__TAURI__?.fs;
-
-export const makeTauriFileSystem = taurifs
-  ? (options: FsDirOptions = { dir: taurifs.BaseDirectory.AppData }): AsyncFileSystemAdapter => ({
-      async: true,
-      getType: (path: string) =>
-        taurifs.exists(path, options).then((present: boolean) =>
-          present
-            ? taurifs
-                .readdir(path)
-                .then(() => "dir" as const)
-                .catch(() => "file" as const)
-            : null,
-        ),
-      mkdir: (path: string) => taurifs.createDir(path, { ...options, recursive: true }),
-      readdir: (path: string) =>
-        taurifs.readdir(path, options).then((entries: FileEntry[]) =>
-          entries.reduce((list, entry) => {
-            entry.name && list.push(entry.name);
-            return list;
-          }, [] as string[]),
-        ),
-      readFile: (path: string) => taurifs.readTextFile(path, options),
-      rename: (previous: string, next: string) => taurifs.renameFile(previous, next),
-      rm: (path: string) =>
-        taurifs
-          .readdir(path)
-          .then(() => taurifs.removeDir(path, { ...options, recursive: true }))
-          .catch(() => taurifs.removeFile(path, options)),
-      writeFile: (path: string, data: string) => taurifs.writeTextFile(path, data),
-    })
-  : makeNoAsyncFileSystem;
+export const makeTauriFileSystem = (options: FsDirOptions = { dir: BaseDirectory.AppData }) =>
+  (taurifs =>
+    taurifs
+      ? {
+          async: true as const,
+          getType: (path: string) =>
+            taurifs.exists(path, options).then((present: boolean) =>
+              present
+                ? taurifs
+                    .readdir(path)
+                    .then(() => "dir" as const)
+                    .catch(() => "file" as const)
+                : null,
+            ),
+          mkdir: (path: string) => taurifs.createDir(path, { ...options, recursive: true }),
+          readdir: (path: string) =>
+            taurifs.readdir(path, options).then((entries: FileEntry[]) =>
+              entries.reduce((list, entry) => {
+                entry.name && list.push(entry.name);
+                return list;
+              }, [] as string[]),
+            ),
+          readFile: (path: string) => taurifs.readTextFile(path, options),
+          rename: (previous: string, next: string) => taurifs.renameFile(previous, next),
+          rm: (path: string) =>
+            taurifs
+              .readdir(path)
+              .then(() => taurifs.removeDir(path, { ...options, recursive: true }))
+              .catch(() => taurifs.removeFile(path, options)),
+          writeFile: (path: string, data: string) => taurifs.writeTextFile(path, data),
+        }
+      : null)((globalThis as any).__TAURI__?.fs);

--- a/packages/filesystem/src/adapter-vfs.ts
+++ b/packages/filesystem/src/adapter-vfs.ts
@@ -1,4 +1,4 @@
-import type { ItemType, SyncFileSystemAdapter } from "./types";
+import type { ItemType } from "./types";
 import { getParentDir } from "./tools";
 
 export type ObjectFileSystem = { [id: string]: string | ObjectFileSystem };
@@ -16,7 +16,7 @@ export const makeVirtualFileSystem = (
   initial?: ObjectFileSystem,
   storage?: Storage,
   key = "solid-primitive-filesystem",
-): SyncFileSystemAdapter & { toMap: () => Map<string, string> } => {
+) => {
   let storedValue;
   const storageValue = storage?.getItem(key);
   try {

--- a/packages/filesystem/src/reactive.ts
+++ b/packages/filesystem/src/reactive.ts
@@ -5,7 +5,6 @@ import type {
   ItemType,
   SyncFileSystem,
   AsyncFileSystem,
-  FileSystemAdapter,
   SyncFileSystemAdapter,
   AsyncFileSystemAdapter,
   DirEntries,
@@ -277,9 +276,12 @@ export function createFileSystem(
   watcher?: Watcher,
 ): Promise<AsyncFileSystem>;
 export function createFileSystem(
-  fs: FileSystemAdapter | Promise<AsyncFileSystemAdapter>,
+  fs: SyncFileSystemAdapter | AsyncFileSystemAdapter | Promise<AsyncFileSystemAdapter> | null,
   watcher?: Watcher,
 ): SyncFileSystem | AsyncFileSystem | Promise<AsyncFileSystem> {
+  if (fs === null) {
+    throw new Error("file system adapter is null");
+  }
   return fs instanceof Promise
     ? fs.then(fs => createAsyncFileSystem(fs, watcher))
     : fs.async

--- a/packages/filesystem/src/types.ts
+++ b/packages/filesystem/src/types.ts
@@ -1,6 +1,6 @@
 export type ItemType = "dir" | "file" | null;
 
-export type DirEntries = [] | [string, ...string[]];
+export type DirEntries = string[];
 
 export type SyncFileSystemAdapter = {
   async: false;

--- a/packages/filesystem/test/index.test.ts
+++ b/packages/filesystem/test/index.test.ts
@@ -5,8 +5,10 @@ import {
   makeNoFileSystem,
   makeNoAsyncFileSystem,
   makeVirtualFileSystem,
+  makeNodeFileSystem,
   FileSystemAdapter,
   makeWebAccessFileSystem,
+  makeTauriFileSystem,
 } from "../src";
 import { createEffect, createRoot, onError } from "solid-js";
 
@@ -165,6 +167,9 @@ const testReactive = (testcase: (done: () => void) => void): Promise<void> => {
 
 describe("createFileSystem(makeWebAccessFileSystem)", async () => {
   const wfs = await makeWebAccessFileSystem();
+  if (wfs === null) {
+    throw new Error("web fs access mock broke for some reason, see fsaccess-mock.fs");
+  }
   const fs = createFileSystem(wfs);
   test("fs.getType returns the correct output", async () => {
     await testReactive(done => {
@@ -292,6 +297,15 @@ describe("createFileSystem(makeWebAccessFileSystem)", async () => {
         }
         return run + 1;
       });
+    });
+  });
+  describe("fallbacks", () => {
+    test("makeNodeFileSystem returns null on client", async () => {
+      expect(await makeNodeFileSystem()).toBeNull();
+    });
+
+    test("makeTauriFileSystem returns null on client", () => {
+      expect(makeTauriFileSystem()).toBeNull();
     });
   });
 });

--- a/packages/filesystem/test/server.test.ts
+++ b/packages/filesystem/test/server.test.ts
@@ -1,5 +1,12 @@
-import { describe, test, expect } from "vitest";
-import { limitPath } from "../src";
+import "./tauri-mock";
+import { describe, test, expect, afterAll } from "vitest";
+import {
+  limitPath,
+  makeNodeFileSystem,
+  makeTauriFileSystem,
+  makeWebAccessFileSystem,
+} from "../src";
+import { mkdtemp, rm } from "fs/promises";
 
 describe("limitPath", () => {
   test("handle empty base path and root path correctly", () => {
@@ -20,5 +27,81 @@ describe("limitPath", () => {
 
   test("throws error when going below root", () => {
     expect(() => limitPath("/root/")("../../..")).toThrow("cannot go below root path: ../../..");
+  });
+});
+
+describe("makeNodeFileSystem", async () => {
+  const tmpDir = await mkdtemp("solid-primitives-fs-tests-");
+  const fs = await makeNodeFileSystem(tmpDir);
+  if (fs === null) throw new Error("makeNodeFileSystem should not return null");
+  afterAll(() => rm(tmpDir, { recursive: true }));
+
+  test("creates/reads a directory", async () => {
+    await fs.mkdir("dirtest");
+    await fs.mkdir("dirtest/test");
+    expect(await fs.readdir("/dirtest")).toEqual(["test"]);
+    await fs.rm("dirtest");
+  });
+  test("creates/reads a file", async () => {
+    await fs.mkdir("filetest");
+    await fs.writeFile("filetest/test", "data");
+    expect(await fs.readFile("filetest/test")).toBe("data");
+    await fs.rm("filetest");
+  });
+  test("renames a file", async () => {
+    await fs.mkdir("renametest");
+    await fs.writeFile("renametest/test", "data");
+    expect(await fs.readdir("renametest")).toEqual(["test"]);
+    await fs.rename("renametest/test", "renametest/test2");
+    expect(await fs.readdir("renametest")).toEqual(["test2"]);
+    expect(await fs.readFile("renametest/test2")).toBe("data");
+  });
+  test("gets the type of file/dir/non-existent", async () => {
+    await fs.mkdir("typetest/dir");
+    await fs.writeFile("typetest/file", "file");
+    expect(await fs.getType("typetest/file")).toBe("file");
+    expect(await fs.getType("typetest/dir")).toBe("dir");
+    expect(await fs.getType("typetest/null")).toBeNull();
+    await fs.rm("typetest");
+  });
+});
+
+describe.todo("makeTauriFileSystem", () => {
+  const fs = makeTauriFileSystem();
+  if (fs === null) throw new Error("makeTauriFileSystem should not return null");
+
+  test("creates/reads a directory", async () => {
+    await fs.mkdir("dirtest");
+    await fs.mkdir("dirtest/test");
+    expect(await fs.readdir("/dirtest")).toEqual(["test"]);
+    await fs.rm("dirtest");
+  });
+  test("creates/reads a file", async () => {
+    await fs.mkdir("filetest");
+    await fs.writeFile("filetest/test", "data");
+    expect(await fs.readFile("filetest/test")).toBe("data");
+    await fs.rm("filetest");
+  });
+  test("renames a file", async () => {
+    await fs.mkdir("renametest");
+    await fs.writeFile("renametest/test", "data");
+    expect(await fs.readdir("renametest")).toEqual(["test"]);
+    await fs.rename("renametest/test", "renametest/test2");
+    expect(await fs.readdir("renametest")).toEqual(["test2"]);
+    expect(await fs.readFile("renametest/test2")).toBe("data");
+  });
+  test("gets the type of file/dir/non-existent", async () => {
+    await fs.mkdir("typetest/dir");
+    await fs.writeFile("typetest/file", "file");
+    expect(await fs.getType("typetest/file")).toBe("file");
+    expect(await fs.getType("typetest/dir")).toBe("dir");
+    expect(await fs.getType("typetest/null")).toBeNull();
+    await fs.rm("typetest");
+  });
+});
+
+describe("fallbacks", () => {
+  test("makeWebAccessFileSystem returns Promise<null>", async () => {
+    expect(await makeWebAccessFileSystem()).toBeNull();
   });
 });

--- a/packages/filesystem/test/tauri-mock.ts
+++ b/packages/filesystem/test/tauri-mock.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { makeVirtualFileSystem } from "../src";
+import { FileEntry, FsDirOptions } from "@tauri-apps/api/fs";
+
+const vfs = makeVirtualFileSystem();
+
+(globalThis as any).__TAURI__ = {
+  fs: {
+    exists: (path: string, options: FsDirOptions) => Promise.resolve(vfs.getType(path) !== null),
+    createDir: (path: string, options: FsDirOptions) => (vfs.mkdir(path), Promise.resolve()),
+    readdir: (path: string, options: FsDirOptions) =>
+      vfs.getType(path) === "dir"
+        ? Promise.resolve(vfs.readdir(path).map(name => ({ name } as unknown as FileEntry)))
+        : Promise.reject(new Error("not a directory")),
+    readTextFile: (path: string, options: FsDirOptions) => Promise.resolve(vfs.readFile(path)),
+    renameFile: (prev: string, next: string) => Promise.resolve(vfs.rename(prev, next)),
+    writeFile: (path: string, data: string) => Promise.resolve(vfs.writeFile(path, data)),
+    removeDir: (path: string, options: FsDirOptions) =>
+      vfs.getType(path) === "dir"
+        ? Promise.resolve(vfs.rm(path))
+        : Promise.reject(new Error("not a directory")),
+    removeFile: (path: string, options: FsDirOptions) =>
+      vfs.getType(path) === "file"
+        ? Promise.resolve(vfs.rm(path))
+        : Promise.reject(new Error("not a file")),
+  },
+};


### PR DESCRIPTION
As previously announced, I wanted to improve the fail case; instead of returning a defunct file system adapter, returning null enables the user to detect if they need another case; this also allows to ||-chain file system adapters.