### PR TITLE
site: Performance optimization, fix #393

### DIFF
--- a/site/src/components/Primitives/VersionBadge.tsx
+++ b/site/src/components/Primitives/VersionBadge.tsx
@@ -50,9 +50,7 @@ function createPackageVersion(source: Accessor<string>) {
   return () => memo()();
 }
 
-export const VersionBadge: ParentComponent<{ name: string }> = props => {
-  const version = createPackageVersion(() => props.name);
-
+export const VersionBadge: ParentComponent<{ name: string; version: string }> = props => {
   return (
     <a
       class="flex h-[28px] min-w-[90px] items-baseline justify-center rounded-md border-2 border-[#cae0ff] bg-[#cae0ff40] font-sans transition-colors hover:border-[#80a7de] hover:bg-[#cae0ff66] dark:border-[#5577a7] dark:bg-[#6eaaff14] dark:hover:border-[#8ba8d3] dark:hover:bg-[#6eaaff33]"
@@ -61,7 +59,7 @@ export const VersionBadge: ParentComponent<{ name: string }> = props => {
       target="_blank"
     >
       <span class="text-[14px] font-semibold text-[#7689a4] dark:text-[#8b9eba]">v</span>
-      {version()}
+      {props.version}
     </a>
   );
 };

--- a/site/src/routes/index.tsx
+++ b/site/src/routes/index.tsx
@@ -133,7 +133,7 @@ const PrimitivesTable: Component<{ packages: PackageListItem[] | undefined }> = 
                         ))}
                       </Table.TD>
                       <Table.TD>
-                        <VersionBadge name={pkg.name} />
+                        <VersionBadge name={pkg.name} version={pkg.version} />
                       </Table.TD>
                     </Table.TR>
                   ))}


### PR DESCRIPTION
This PR fixes the issue #393 regarding initial load times & unneccesary fetch requests on the client,

Changes:
1. i've changed the VersionBadge component to accept a `version` prop, which we can use instead of calling `createPackageVersion` which introduced the request flood.
2. i've changed the `route.tsx` (homepage) to pass the `pkg.version` as a prop to `VersionBadge`, which is already available without extra requests.

i'm not used to the codebase so feel free to suggest changes.