### PR TITLE
Fix MutationObserver doesn't disconnect when there're no pending notifications

### DIFF
--- a/.changeset/quick-plums-punch.md
+++ b/.changeset/quick-plums-punch.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/mutation-observer": patch
+---
+
+Fix MutationObserver doesn't disconnect when there're no pending notifications

--- a/packages/mutation-observer/src/index.ts
+++ b/packages/mutation-observer/src/index.ts
@@ -90,7 +90,7 @@ export function createMutationObserver(
       item instanceof Node ? add(item, defaultOptions) : add(item[0], item[1]);
     });
   };
-  const stop = () => instance?.takeRecords().length && instance.disconnect();
+  const stop = () => instance?.disconnect();
   onMount(start);
   onCleanup(stop);
   return [


### PR DESCRIPTION
Since this is a one-line change, I wasn't bothered to post a issue for it.

> **MutationObserver: takeRecords() method**
> The [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) method takeRecords() returns a list of all matching DOM changes that have been detected but not yet processed by the observer's callback function, leaving the mutation queue empty.
> -- <https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/takeRecords>

Therefore `takeRecords()` returns an empty array when there're no pending notifications, canceling the `disconnect()`call.