### PR TITLE
filesystem: rsync utility

### DIFF
--- a/.changeset/witty-seahorses-boil.md
+++ b/.changeset/witty-seahorses-boil.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/filesystem": minor
+---
+
+filesystem: rsync utility

--- a/packages/filesystem/README.md
+++ b/packages/filesystem/README.md
@@ -21,6 +21,7 @@ A primitive that allows to manage different file system access methods:
 - `makeNodeFileSystem` (server only) - Adapter that abstracts the node fs/promises module for the use with this primitive
 - `makeTauriFileSystem` (tauri with fs access enabled only) - Adapter that connects to the tauri fs module
 - `makeChokidarWatcher` - (experimental): use chokidar to watch for file system changes and trigger reactive updates
+- `rsync` - small tool to copy over recursively from one file system or adapter to another
 
 ## Installation
 
@@ -126,6 +127,14 @@ const Item = (props: { path: string; fs: SyncFileSystem | AsyncFileSystem }) => 
     </>
   );
 };
+```
+
+### rsync
+
+In some cases, you might need to move data from one file system (or adapter) to another one. In order to do so, this package comes with an rsync utility:
+
+```ts
+rsync(srcFs, srcPath, destFs, destPath): Promise<void>;
 ```
 
 ## Demo

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -17,7 +17,17 @@
     "name": "filesystem",
     "stage": 0,
     "list": [
-      "createFileSystem"
+      "createFileSystem",
+      "createSyncFileSystem",
+      "createAsyncFileSystem",
+      "makeNoFileSystem",
+      "makeNoAsyncFileSystem",
+      "makeVirtualFileSystem",
+      "makeWebAccessFileSystem",
+      "makeNodeFileSystem",
+      "makeTauriFileSystem",
+      "makeChokidarWatcher",
+      "rsync"
     ],
     "category": "Display & Media"
   },

--- a/packages/filesystem/src/adapter-tauri.ts
+++ b/packages/filesystem/src/adapter-tauri.ts
@@ -1,6 +1,6 @@
-import { BaseDirectory, type FileEntry, type FsDirOptions } from "@tauri-apps/api/fs";
+import { type BaseDirectory, type FileEntry, type FsDirOptions } from "@tauri-apps/api/fs";
 
-export const makeTauriFileSystem = (options: FsDirOptions = { dir: BaseDirectory.AppData }) =>
+export const makeTauriFileSystem = (options: FsDirOptions = { dir: 22 as BaseDirectory.AppData }) =>
   (taurifs =>
     taurifs
       ? {

--- a/packages/filesystem/src/adapter-tauri.ts
+++ b/packages/filesystem/src/adapter-tauri.ts
@@ -1,4 +1,4 @@
-import { type BaseDirectory, type FileEntry, type FsDirOptions } from "@tauri-apps/api/fs";
+import type { BaseDirectory, FileEntry, FsDirOptions } from "@tauri-apps/api/fs";
 
 export const makeTauriFileSystem = (options: FsDirOptions = { dir: 22 as BaseDirectory.AppData }) =>
   (taurifs =>

--- a/packages/filesystem/src/tools.ts
+++ b/packages/filesystem/src/tools.ts
@@ -1,3 +1,6 @@
+import { createEffect, createRoot } from "solid-js";
+import type { AsyncFileSystem, SyncFileSystem, FileSystemAdapter, DirEntries } from "./types";
+
 export const getParentDir = (path: string) => path.split("/").slice(0, -1).join("/") || "/";
 
 export const getItemName = (path: string) => path.split("/").at(-1);
@@ -19,3 +22,53 @@ export const limitPath =
     }
     return result;
   };
+
+export const toPromise = <T>(command: () => T | undefined): Promise<T> => new Promise<T>(resolve =>
+  createRoot(dispose => createEffect(() => {
+    const result = command();
+    if (result !== undefined) {
+      resolve(result);
+      dispose();
+    }
+  }))
+);
+
+export const rsync = async (
+  fs1: SyncFileSystem | AsyncFileSystem | FileSystemAdapter,
+  src: string,
+  fs2: SyncFileSystem | AsyncFileSystem | FileSystemAdapter,
+  dest: string,
+): Promise<void> => {
+  const srcType = "async" in fs1
+    ? await fs1.getType(src)
+    : await toPromise(() => fs1.getType(src));
+  if (srcType === null) {
+    throw new Error(`${src} does not exist in src filesystem`);
+  } else if (srcType === "dir") {
+    const dirEntries: DirEntries | undefined = "async" in fs1
+      ? await fs1.readdir(src)
+      : await toPromise(() => fs1.readdir(src));
+    const destType = "async" in fs2
+      ? await fs2.getType(dest)
+      : await toPromise(() => fs2.getType(dest));
+    if (destType === "file") {
+      throw new Error(`cannot overwrite file ${dest} with directory`);
+    } else if (destType === null) {      
+      await fs2.mkdir(dest);
+    }
+    for (var i = 0, len = dirEntries.length; i < len; i++) {
+      const entry = dirEntries[i];
+      entry && await rsync(
+        fs1,
+        `${src}${src.endsWith("/") ? "" : "/"}${getItemName(entry)}`,
+        fs2,
+        `${dest}${dest.endsWith("/") ? "" : "/"}${getItemName(entry)}`
+      );
+    }
+  } else if (srcType === "file") {
+    const fileData = "async" in fs1
+      ? await fs1.readFile(src)
+      : await toPromise(() => fs1.readFile(src));
+    return fs2.writeFile(dest, fileData);
+  }
+};

--- a/packages/filesystem/test/index.test.ts
+++ b/packages/filesystem/test/index.test.ts
@@ -9,6 +9,7 @@ import {
   FileSystemAdapter,
   makeWebAccessFileSystem,
   makeTauriFileSystem,
+  rsync,
 } from "../src";
 import { createEffect, createRoot, onError } from "solid-js";
 
@@ -307,5 +308,63 @@ describe("createFileSystem(makeWebAccessFileSystem)", async () => {
     test("makeTauriFileSystem returns null on client", () => {
       expect(makeTauriFileSystem()).toBeNull();
     });
+  });
+});
+
+describe('rsync', () => {
+  test('it copies parts of a file system using the adapter', async () => {
+    const sourceobj = { test: { 
+      "file.json": "[1, 2, 3]",
+      "file.ts": "console.log(1);",
+      folder: { folder2: { folder3: { "test.txt": "test" } } }
+    } };
+    const destobj = {};
+    const sourcevfs = makeVirtualFileSystem(sourceobj);
+    const destvfs = makeVirtualFileSystem(destobj);
+    await rsync(sourcevfs, "/", destvfs, "/");
+    expect(destobj).toEqual(sourceobj);
+  });
+
+  test('it copies from a file system adapter to a file system', async () => {
+    const sourceobj = { test: { 
+      "file.json": "[1, 2, 3]",
+      "file.ts": "console.log(1);",
+      folder: { folder2: { folder3: { "test.txt": "test" } } }
+    } };
+    const destobj = {};
+    const sourcevfs = makeVirtualFileSystem(sourceobj);
+    const destvfs = makeVirtualFileSystem(destobj);
+    const destfs = createFileSystem(destvfs);
+    await rsync(sourcevfs, "/", destfs, "/");
+    expect(destobj).toEqual(sourceobj);
+  });
+
+  test('it copies from a file system to a file system adapter', async () => {
+    const sourceobj = { test: { 
+      "file.json": "[1, 2, 3]",
+      "file.ts": "console.log(1);",
+      folder: { folder2: { folder3: { "test.txt": "test" } } }
+    } };
+    const destobj = {};
+    const sourcevfs = makeVirtualFileSystem(sourceobj);
+    const sourcefs = createFileSystem(sourcevfs);
+    const destvfs = makeVirtualFileSystem(destobj);
+    await rsync(sourcefs, "/", destvfs, "/");
+    expect(destobj).toEqual(sourceobj);
+  });
+
+  test('it copies from a file system to a file system', async () => {
+    const sourceobj = { test: { 
+      "file.json": "[1, 2, 3]",
+      "file.ts": "console.log(1);",
+      folder: { folder2: { folder3: { "test.txt": "test" } } }
+    } };
+    const destobj = {};
+    const sourcevfs = makeVirtualFileSystem(sourceobj);
+    const sourcefs = createFileSystem(sourcevfs);
+    const destvfs = makeVirtualFileSystem(destobj);
+    const destfs = createFileSystem(destvfs);
+    await rsync(sourcefs, "/", destfs, "/");
+    expect(destobj).toEqual(sourceobj);
   });
 });


### PR DESCRIPTION
Filesystems are much more useful if you can connect them. So, in order to do exactly that, I have created a small (421bytes minzipped) rsync utility for the package that allows copying stuff recursively from one file system (or file system adapter) to another.

I also fixed an import for the tauri file system adapter, bringing down its size from 1.43kb to a mere 283bytes minzipped.