### PR TITLE
Add `createUndoHistory` primitive

### DIFF
--- a/configs/vite.config.ts
+++ b/configs/vite.config.ts
@@ -25,7 +25,7 @@ export const viteConfig = defineConfig({
       shortcuts: {
         "center-child": "flex justify-center items-center",
         caption: "text-sm font-mono leading-tight",
-        btn: "bg-teal-600 border-1 border-teal-500 hover:bg-teal-500 rounded cursor-pointer center-child select-none text-white font-semibold p-4 py-3 m-2",
+        btn: "bg-teal-600 border-1 border-teal-500 hover:bg-teal-500 rounded cursor-pointer center-child select-none text-white font-semibold p-4 py-3 m-2 disabled:bg-teal-700 disabled:saturate-50 disabled:hover:bg-teal-700 disabled:cursor-not-allowed",
         "wrapper-h":
           "p-6 flex justify-center items-center space-x-4 space-y-0 bg-gray-700 rounded-2xl",
         "wrapper-v": "wrapper-h flex-col space-x-0 space-y-4",

--- a/packages/history/LICENSE
+++ b/packages/history/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Solid Primitives Working Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/history/README.md
+++ b/packages/history/README.md
@@ -9,9 +9,7 @@
 [![version](https://img.shields.io/npm/v/@solid-primitives/history?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/history)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
-A sample primitive that is made up for templating with the following options:
-
-`createPrimitiveTemplate` - Provides a getter and setter for the primitive.
+Primitives for managing undo/redo history in Solid.
 
 ## Installation
 
@@ -23,15 +21,117 @@ yarn add @solid-primitives/history
 pnpm add @solid-primitives/history
 ```
 
-## How to use it
+## `createUndoHistory`
 
-```ts
-const [value, setValue] = createPrimitiveTemplate(false);
+Creates an undo history from a reactive source for going back and forth between state snapshots.
+
+### How to use it
+
+`createUndoHistory` takes two arguments:
+
+- `source` - A function or an array thereof that tracks the state to be restored, and returns a callback to restore it.
+- `options` - Configuration object. Optional.
+  - `limit` - The maximum number of history states. Defaults to `100`.
+
+```tsx
+import { createUndoHistory } from "@solid-primitives/history";
+
+const [count, setCount] = createSignal(0);
+
+const history = createUndoHistory(() => {
+  // track the changes to the state (and clone if you need to)
+  const v = count();
+  // return a callback to set the state back to the tracked value
+  return () => setCount(v);
+});
+
+// undo the last change
+history.undo();
+
+// redo the last change
+history.redo();
+
+// check if there are any changes to undo/redo with .canUndo() and .canRedo()
+return (
+  <>
+    <button disabled={!history.canUndo()} onClick={history.undo}>
+      Undo
+    </button>
+    <button disabled={!history.canRedo()} onClick={history.redo}>
+      Redo
+    </button>
+  </>
+);
 ```
 
-## Demo
+### Observing stores
 
-You can use this template for publishing your demo on CodeSandbox: https://codesandbox.io/s/solid-primitives-demo-template-sz95h
+Stores have many independent points of updates, so you can choose how and what to track.
+
+But for the most part, you may want to track and copy the whole store value.
+
+Copying is important so that the history points are not affected by future mutations to the store.
+
+```ts
+const [state, setState] = createStore({ a: 0, b: 0 });
+
+const history = createUndoHistory(() => {
+  // track and clone the whole state
+  const stateVal = structuredClone(state);
+  // reconcile the state back to the tracked value
+  return () => setState(reconcile(stateVal));
+});
+```
+
+### Observing multiple sources
+
+You can track as many signals in the `source` callback as you want. Then any updates will create a point in history for all of them.
+
+```ts
+const [a, setA] = createSignal(0);
+const [b, setB] = createSignal(0);
+
+const history = createUndoHistory(() => {
+  const aVal = a();
+  const bVal = b();
+  return () => {
+    setA(aVal);
+    setB(bVal);
+  };
+});
+
+// set them both at the same time, to only create one point in history
+batch(() => {
+  setA(1);
+  setB(1);
+});
+```
+
+### Observing multiple independent sources
+
+If you want to track multiple independent sources, you can pass an array of source functions to `createUndoHistory`.
+
+This way the undo history will still be shared, but the individual source and setter functions will be called when needed, instead of all at once. This is useful for tracking multiple stores where you want to avoid unnecessary cloning and reconciliation.
+
+```ts
+const [a, setA] = createSignal(0);
+const [b, setB] = createSignal(0);
+
+const history = createUndoHistory([
+  () => {
+    const aVal = a();
+    return () => setA(aVal);
+  },
+  () => {
+    const bVal = b();
+    return () => setB(bVal);
+  },
+]);
+
+// e.g.
+setA(1);
+history.undo(); // will only call setA(0)
+```
 
 ## Changelog
 

--- a/packages/history/README.md
+++ b/packages/history/README.md
@@ -1,0 +1,38 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=history" alt="Solid Primitives history">
+</p>
+
+# @solid-primitives/history
+
+[![turborepo](https://img.shields.io/badge/built%20with-turborepo-cc00ff.svg?style=for-the-badge&logo=turborepo)](https://turborepo.org/)
+[![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/history?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-primitives/history)
+[![version](https://img.shields.io/npm/v/@solid-primitives/history?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/history)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
+
+A sample primitive that is made up for templating with the following options:
+
+`createPrimitiveTemplate` - Provides a getter and setter for the primitive.
+
+## Installation
+
+```bash
+npm install @solid-primitives/history
+# or
+yarn add @solid-primitives/history
+# or
+pnpm add @solid-primitives/history
+```
+
+## How to use it
+
+```ts
+const [value, setValue] = createPrimitiveTemplate(false);
+```
+
+## Demo
+
+You can use this template for publishing your demo on CodeSandbox: https://codesandbox.io/s/solid-primitives-demo-template-sz95h
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md)

--- a/packages/history/dev/index.html
+++ b/packages/history/dev/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="theme-color" content="#000000" />
+    <title>Solid App</title>
+    <style>
+      html {
+        font-family: "Gill Sans", "Gill Sans MT", Calibri, "Trebuchet MS", sans-serif;
+      }
+
+      body {
+        padding: 0;
+        margin: 0;
+      }
+
+      a,
+      button {
+        cursor: pointer;
+      }
+
+      * {
+        margin: 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+
+    <script src="/index.tsx" type="module"></script>
+  </body>
+</html>

--- a/packages/history/dev/index.tsx
+++ b/packages/history/dev/index.tsx
@@ -1,0 +1,46 @@
+import { Component, createSignal } from "solid-js";
+import { render } from "solid-js/web";
+import "uno.css";
+import { createUndoHistory } from "../src";
+
+const App: Component = () => {
+  const [count, setCount] = createSignal(0);
+
+  const history = createUndoHistory(() => {
+    const v = count();
+    return () => setCount(v);
+  });
+
+  return (
+    <div class="box-border flex min-h-screen w-full flex-col items-center justify-center space-y-4 bg-gray-800 p-24 text-white">
+      <div class="wrapper-v">
+        <h4>Counter component</h4>
+        <p class="caption">it's very important...</p>
+        <button
+          class="btn"
+          onClick={() => setCount(count() + 1)}
+          onContextMenu={e => {
+            e.preventDefault();
+            setCount(count() - 1);
+          }}
+        >
+          {count()}
+        </button>
+      </div>
+      <div class="wrapper-v">
+        <h4>History</h4>
+        <button class="btn" disabled={!history.getCanUndo()} onClick={history.undo}>
+          Undo
+        </button>
+        <button class="btn" disabled={!history.getCanRedo()} onClick={history.redo}>
+          Redo
+        </button>
+        {/* <button class="btn" onClick={history.clear}>
+          Clear
+        </button> */}
+      </div>
+    </div>
+  );
+};
+
+render(() => <App />, document.getElementById("root")!);

--- a/packages/history/dev/index.tsx
+++ b/packages/history/dev/index.tsx
@@ -1,38 +1,66 @@
-import { Component, createSignal } from "solid-js";
+import { Component, JSX, createSignal } from "solid-js";
 import { render } from "solid-js/web";
 import "uno.css";
 import { createUndoHistory } from "../src";
 
-const App: Component = () => {
-  const [count, setCount] = createSignal(0);
+const Button = (props: {
+  onClick: () => void;
+  onRightClick: () => void;
+  children: JSX.Element;
+}) => (
+  <button
+    class="btn"
+    onClick={() => props.onClick()}
+    onContextMenu={e => {
+      e.preventDefault();
+      props.onRightClick();
+    }}
+  >
+    {props.children}
+  </button>
+);
 
-  const history = createUndoHistory(() => {
-    const v = count();
-    return () => setCount(v);
-  });
+const App: Component = () => {
+  const [a, setA] = createSignal(0);
+  const [b, setB] = createSignal(0);
+
+  const history = createUndoHistory(
+    // createMultiHistorySource(
+    (
+      [
+        ["a", a, setA],
+        ["b", b, setB],
+      ] as const
+    ).map(([name, get, set]) => () => {
+      const v = get();
+      return () => {
+        console.log("set", name, v);
+        set(v);
+      };
+    }),
+    // ),
+  );
 
   return (
     <div class="box-border flex min-h-screen w-full flex-col items-center justify-center space-y-4 bg-gray-800 p-24 text-white">
       <div class="wrapper-v">
         <h4>Counter component</h4>
         <p class="caption">it's very important...</p>
-        <button
-          class="btn"
-          onClick={() => setCount(count() + 1)}
-          onContextMenu={e => {
-            e.preventDefault();
-            setCount(count() - 1);
-          }}
-        >
-          {count()}
-        </button>
+        <div class="flex flex-row space-x-4">
+          <Button onClick={() => setA(p => p + 1)} onRightClick={() => setA(p => p - 1)}>
+            A: {a()}
+          </Button>
+          <Button onClick={() => setB(p => p + 1)} onRightClick={() => setB(p => p - 1)}>
+            B: {b()}
+          </Button>
+        </div>
       </div>
       <div class="wrapper-v">
         <h4>History</h4>
-        <button class="btn" disabled={!history.getCanUndo()} onClick={history.undo}>
+        <button class="btn" disabled={!history.canUndo()} onClick={history.undo}>
           Undo
         </button>
-        <button class="btn" disabled={!history.getCanRedo()} onClick={history.redo}>
+        <button class="btn" disabled={!history.canRedo()} onClick={history.redo}>
           Redo
         </button>
         {/* <button class="btn" onClick={history.clear}>

--- a/packages/history/dev/vite.config.ts
+++ b/packages/history/dev/vite.config.ts
@@ -1,0 +1,2 @@
+import { viteConfig } from "../../../configs/vite.config";
+export default viteConfig;

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@solid-primitives/history",
+  "version": "0.0.100",
+  "description": "A template primitive example.",
+  "author": "Damian Tarnawski <gthetarnav@gmail.com>",
+  "contributors": [],
+  "license": "MIT",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/history#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solidjs-community/solid-primitives.git"
+  },
+  "bugs": {
+    "url": "https://github.com/solidjs-community/solid-primitives/issues"
+  },
+  "primitive": {
+    "name": "history",
+    "stage": 0,
+    "list": [
+      "createUndoHistory"
+    ],
+    "category": "Utilities"
+  },
+  "keywords": [
+    "solid",
+    "primitives",
+    "undo",
+    "redo",
+    "history",
+    "time travel"
+  ],
+  "private": false,
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "browser": {},
+  "exports": {
+    "import": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "require": "./dist/index.cjs"
+  },
+  "typesVersions": {},
+  "scripts": {
+    "dev": "vite serve dev",
+    "page": "vite build dev",
+    "build": "jiti ../../scripts/build.ts",
+    "test": "vitest -c ../../configs/vitest.config.ts",
+    "test:ssr": "pnpm run test --mode ssr"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.6.12"
+  },
+  "dependencies": {
+    "@solid-primitives/utils": "workspace:^"
+  }
+}

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@solid-primitives/history",
-  "version": "0.0.100",
-  "description": "A template primitive example.",
+  "version": "0.0.1",
+  "description": "Primitives for managing undo/redo history in Solid.",
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -1,0 +1,113 @@
+import { createMicrotask, falseFn, noop } from "@solid-primitives/utils";
+import { Accessor, Signal, batch, createMemo, createSignal, untrack } from "solid-js";
+import { isServer } from "solid-js/web";
+
+const untracked =
+  <T>(fn: () => T): (() => T) =>
+  () =>
+    untrack(fn);
+
+/**
+ * Configuration object for {@link createUndoHistory}.
+ */
+export type UndoHistoryOptions = {
+  /**
+   * The maximum number of undo steps to keep in memory.
+   * @default 100
+   */
+  limit?: number;
+};
+
+/**
+ * Return type of {@link createUndoHistory}.
+ */
+export type UndoHistoryReturn = {
+  /**
+   * @returns `true` if an undo step is available, `false` otherwise.
+   *
+   * @see {@link UndoHistoryReturn.undo}
+   *
+   * This accessor is not memoized and should be used in a {@link createMemo} to ensure it.
+   */
+  getCanUndo: Accessor<boolean>;
+  /**
+   * @returns `true` if an redo step is available, `false` otherwise.
+   *
+   * @see {@link UndoHistoryReturn.redo}
+   *
+   * This accessor is not memoized and should be used in a {@link createMemo} to ensure it.
+   */
+  getCanRedo: Accessor<boolean>;
+  /**
+   * Undo the last step. Does nothing if {@link UndoHistoryReturn.getCanUndo} is `false`.
+   *
+   * It calls the callback returned from the {@link createUndoHistory} source.
+   */
+  undo: VoidFunction;
+  /**
+   * Redo the last step. Does nothing if {@link UndoHistoryReturn.getCanRedo} is `false`.
+   *
+   * It calls the callback returned from the {@link createUndoHistory} source.
+   */
+  redo: VoidFunction;
+};
+
+export function createUndoHistory(
+  source: Accessor<VoidFunction>,
+  options?: UndoHistoryOptions,
+): UndoHistoryReturn {
+  if (isServer) {
+    return {
+      getCanUndo: falseFn,
+      getCanRedo: falseFn,
+      undo: noop,
+      redo: noop,
+    };
+  }
+
+  let ignoreNext = false;
+
+  // +1 to account for the current state
+  const limit = (options?.limit ?? 100) + 1,
+    history: VoidFunction[] = [],
+    clearIgnore = createMicrotask(() => (ignoreNext = false)),
+    memo = createMemo<{ count: Signal<number> }>(
+      p => {
+        const setter = source();
+
+        if (ignoreNext) {
+          ignoreNext = false;
+          return p;
+        }
+
+        const count = untrack(p.count[0]);
+
+        history.splice(history.length - count, count, setter);
+
+        if (history.length > limit) {
+          history.splice(0, history.length - limit);
+        }
+
+        return { count: count ? createSignal(0) : p.count };
+      },
+      { count: createSignal(0) },
+    ),
+    getCanUndo = () => {
+      // access memo first to ensure history is up to date
+      const { count } = memo();
+      return history.length - count[0]() > 1;
+    },
+    getCanRedo = () => memo().count[0]() > 0,
+    move = (n: -1 | 1) => {
+      ignoreNext = true;
+      clearIgnore();
+      batch(() => history[history.length - memo().count[1](p => p + n) - 1]!());
+    };
+
+  return {
+    getCanUndo,
+    getCanRedo,
+    undo: untracked(() => getCanUndo() && move(1)),
+    redo: untracked(() => getCanRedo() && move(-1)),
+  };
+}

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -43,6 +43,33 @@ export type UndoHistoryReturn = {
   redo: VoidFunction;
 };
 
+/**
+ * Creates an undo history from a reactive source for going back and forth between state snapshots.
+ *
+ * @param source A function or an array thereof that tracks the state to be restored, and returns a callback to restore it.
+ * @param options Configuration object. See {@link UndoHistoryOptions}.
+ * @returns An object for interacting with the undo history. See {@link UndoHistoryReturn}.
+ *
+ * @see https://github.com/solidjs-community/solid-primitives/tree/main/packages/history#createUndoHistory
+ *
+ * @example
+ * ```ts
+ * const [count, setCount] = createSignal(0);
+ *
+ * const history = createUndoHistory(() => {
+ *   // track the changes to the state (and clone if you need to)
+ *   const v = count();
+ *   // return a callback to set the state back to the tracked value
+ *   return () => setCount(v);
+ * });
+ *
+ * // undo the last change
+ * history.undo();
+ *
+ * // redo the last change
+ * history.redo();
+ * ```
+ */
 export function createUndoHistory(
   source: Many<Accessor<VoidFunction>>,
   options?: UndoHistoryOptions,
@@ -102,7 +129,11 @@ export function createUndoHistory(
   return {
     canUndo,
     canRedo,
-    undo: () => untrack(() => canUndo() && batch(() => move(1))),
-    redo: () => untrack(() => canRedo() && batch(() => move(-1))),
+    undo() {
+      untrack(() => canUndo() && batch(() => move(1)));
+    },
+    redo() {
+      untrack(() => canRedo() && batch(() => move(-1)));
+    },
   };
 }

--- a/packages/history/test/index.test.ts
+++ b/packages/history/test/index.test.ts
@@ -1,9 +1,9 @@
 import { describe, test, expect } from "vitest";
-import { createRoot, createSignal } from "solid-js";
+import { batch, createRoot, createSignal } from "solid-js";
 import { createUndoHistory } from "../src";
 
 describe("createUndoHistory", () => {
-  test("timetravel", () =>
+  test("single source", () =>
     createRoot(dispose => {
       const [a, setA] = createSignal(0);
 
@@ -87,7 +87,7 @@ describe("createUndoHistory", () => {
     });
   });
 
-  test("multiple sources", () => {
+  test("combined single source", () => {
     createRoot(dispose => {
       const [a, setA] = createSignal(0),
         [b, setB] = createSignal(0);
@@ -125,6 +125,109 @@ describe("createUndoHistory", () => {
 
       expect(history.canUndo()).toBe(false);
       expect(history.canRedo()).toBe(true);
+      expect(a()).toBe(0);
+      expect(b()).toBe(0);
+
+      dispose();
+    });
+  });
+
+  test("multiple sources", () => {
+    createRoot(dispose => {
+      const [a, setA] = createSignal(0),
+        [b, setB] = createSignal(0);
+
+      let aCount = 0,
+        bCount = 0;
+
+      const history = createUndoHistory([
+        () => {
+          const v = a();
+          return () => {
+            aCount++;
+            setA(v);
+          };
+        },
+        () => {
+          const v = b();
+          return () => {
+            bCount++;
+            setB(v);
+          };
+        },
+      ]);
+
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(false);
+      expect(aCount).toBe(0);
+      expect(bCount).toBe(0);
+
+      setA(1);
+
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(false);
+      expect(aCount).toBe(0);
+      expect(bCount).toBe(0);
+
+      setB(1);
+
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(false);
+      expect(aCount).toBe(0);
+      expect(bCount).toBe(0);
+
+      history.undo();
+
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(true);
+      expect(aCount).toBe(0);
+      expect(bCount).toBe(1);
+      expect(a()).toBe(1);
+      expect(b()).toBe(0);
+
+      history.undo();
+
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(true);
+      expect(aCount).toBe(1);
+      expect(bCount).toBe(1);
+      expect(a()).toBe(0);
+      expect(b()).toBe(0);
+
+      history.redo();
+
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(true);
+      expect(aCount).toBe(2);
+      expect(bCount).toBe(1);
+      expect(a()).toBe(1);
+      expect(b()).toBe(0);
+
+      batch(() => {
+        setA(2);
+        setB(2);
+      });
+
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(false);
+      expect(aCount).toBe(2);
+      expect(bCount).toBe(1);
+
+      history.undo();
+
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(true);
+      expect(aCount).toBe(3);
+      expect(bCount).toBe(2);
+      expect(a()).toBe(1);
+      expect(b()).toBe(0);
+
+      history.undo();
+
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(true);
+      expect(aCount).toBe(4);
+      expect(bCount).toBe(2);
       expect(a()).toBe(0);
       expect(b()).toBe(0);
 

--- a/packages/history/test/index.test.ts
+++ b/packages/history/test/index.test.ts
@@ -12,52 +12,52 @@ describe("createUndoHistory", () => {
         return () => setA(v);
       });
 
-      expect(history.getCanUndo()).toBe(false);
-      expect(history.getCanRedo()).toBe(false);
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(false);
 
       setA(1);
 
-      expect(history.getCanUndo()).toBe(true);
-      expect(history.getCanRedo()).toBe(false);
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(false);
 
       history.undo();
 
-      expect(history.getCanUndo()).toBe(false);
-      expect(history.getCanRedo()).toBe(true);
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(true);
       expect(a()).toBe(0);
 
       history.redo();
 
-      expect(history.getCanUndo()).toBe(true);
-      expect(history.getCanRedo()).toBe(false);
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(false);
       expect(a()).toBe(1);
 
       setA(2);
 
-      expect(history.getCanUndo()).toBe(true);
-      expect(history.getCanRedo()).toBe(false);
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(false);
 
       history.undo();
 
-      expect(history.getCanUndo()).toBe(true);
-      expect(history.getCanRedo()).toBe(true);
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(true);
       expect(a()).toBe(1);
 
       history.undo();
 
-      expect(history.getCanUndo()).toBe(false);
-      expect(history.getCanRedo()).toBe(true);
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(true);
       expect(a()).toBe(0);
 
       setA(3);
 
-      expect(history.getCanUndo()).toBe(true);
-      expect(history.getCanRedo()).toBe(false);
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(false);
 
       history.undo();
 
-      expect(history.getCanUndo()).toBe(false);
-      expect(history.getCanRedo()).toBe(true);
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(true);
       expect(a()).toBe(0);
 
       dispose();
@@ -75,13 +75,13 @@ describe("createUndoHistory", () => {
         { limit: 0 },
       );
 
-      expect(history.getCanUndo()).toBe(false);
-      expect(history.getCanRedo()).toBe(false);
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(false);
 
       setA(1);
 
-      expect(history.getCanUndo()).toBe(false);
-      expect(history.getCanRedo()).toBe(false);
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(false);
 
       dispose();
     });
@@ -101,30 +101,30 @@ describe("createUndoHistory", () => {
         };
       });
 
-      expect(history.getCanUndo()).toBe(false);
-      expect(history.getCanRedo()).toBe(false);
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(false);
 
       setA(1);
 
-      expect(history.getCanUndo()).toBe(true);
-      expect(history.getCanRedo()).toBe(false);
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(false);
 
       setB(1);
 
-      expect(history.getCanUndo()).toBe(true);
-      expect(history.getCanRedo()).toBe(false);
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(false);
 
       history.undo();
 
-      expect(history.getCanUndo()).toBe(true);
-      expect(history.getCanRedo()).toBe(true);
+      expect(history.canUndo()).toBe(true);
+      expect(history.canRedo()).toBe(true);
       expect(a()).toBe(1);
       expect(b()).toBe(0);
 
       history.undo();
 
-      expect(history.getCanUndo()).toBe(false);
-      expect(history.getCanRedo()).toBe(true);
+      expect(history.canUndo()).toBe(false);
+      expect(history.canRedo()).toBe(true);
       expect(a()).toBe(0);
       expect(b()).toBe(0);
 

--- a/packages/history/test/index.test.ts
+++ b/packages/history/test/index.test.ts
@@ -1,0 +1,134 @@
+import { describe, test, expect } from "vitest";
+import { createRoot, createSignal } from "solid-js";
+import { createUndoHistory } from "../src";
+
+describe("createUndoHistory", () => {
+  test("timetravel", () =>
+    createRoot(dispose => {
+      const [a, setA] = createSignal(0);
+
+      const history = createUndoHistory(() => {
+        const v = a();
+        return () => setA(v);
+      });
+
+      expect(history.getCanUndo()).toBe(false);
+      expect(history.getCanRedo()).toBe(false);
+
+      setA(1);
+
+      expect(history.getCanUndo()).toBe(true);
+      expect(history.getCanRedo()).toBe(false);
+
+      history.undo();
+
+      expect(history.getCanUndo()).toBe(false);
+      expect(history.getCanRedo()).toBe(true);
+      expect(a()).toBe(0);
+
+      history.redo();
+
+      expect(history.getCanUndo()).toBe(true);
+      expect(history.getCanRedo()).toBe(false);
+      expect(a()).toBe(1);
+
+      setA(2);
+
+      expect(history.getCanUndo()).toBe(true);
+      expect(history.getCanRedo()).toBe(false);
+
+      history.undo();
+
+      expect(history.getCanUndo()).toBe(true);
+      expect(history.getCanRedo()).toBe(true);
+      expect(a()).toBe(1);
+
+      history.undo();
+
+      expect(history.getCanUndo()).toBe(false);
+      expect(history.getCanRedo()).toBe(true);
+      expect(a()).toBe(0);
+
+      setA(3);
+
+      expect(history.getCanUndo()).toBe(true);
+      expect(history.getCanRedo()).toBe(false);
+
+      history.undo();
+
+      expect(history.getCanUndo()).toBe(false);
+      expect(history.getCanRedo()).toBe(true);
+      expect(a()).toBe(0);
+
+      dispose();
+    }));
+
+  test("going over limit", () => {
+    createRoot(dispose => {
+      const [a, setA] = createSignal(0);
+
+      const history = createUndoHistory(
+        () => {
+          const v = a();
+          return () => setA(v);
+        },
+        { limit: 0 },
+      );
+
+      expect(history.getCanUndo()).toBe(false);
+      expect(history.getCanRedo()).toBe(false);
+
+      setA(1);
+
+      expect(history.getCanUndo()).toBe(false);
+      expect(history.getCanRedo()).toBe(false);
+
+      dispose();
+    });
+  });
+
+  test("multiple sources", () => {
+    createRoot(dispose => {
+      const [a, setA] = createSignal(0),
+        [b, setB] = createSignal(0);
+
+      const history = createUndoHistory(() => {
+        const aValue = a();
+        const bValue = b();
+        return () => {
+          setA(aValue);
+          setB(bValue);
+        };
+      });
+
+      expect(history.getCanUndo()).toBe(false);
+      expect(history.getCanRedo()).toBe(false);
+
+      setA(1);
+
+      expect(history.getCanUndo()).toBe(true);
+      expect(history.getCanRedo()).toBe(false);
+
+      setB(1);
+
+      expect(history.getCanUndo()).toBe(true);
+      expect(history.getCanRedo()).toBe(false);
+
+      history.undo();
+
+      expect(history.getCanUndo()).toBe(true);
+      expect(history.getCanRedo()).toBe(true);
+      expect(a()).toBe(1);
+      expect(b()).toBe(0);
+
+      history.undo();
+
+      expect(history.getCanUndo()).toBe(false);
+      expect(history.getCanRedo()).toBe(true);
+      expect(a()).toBe(0);
+      expect(b()).toBe(0);
+
+      dispose();
+    });
+  });
+});

--- a/packages/history/tsconfig.json
+++ b/packages/history/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,15 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3(graphql@16.6.0)
 
+  packages/history:
+    dependencies:
+      '@solid-primitives/utils':
+        specifier: workspace:^
+        version: link:../utils
+      solid-js:
+        specifier: ^1.6.12
+        version: 1.7.3
+
   packages/i18n:
     dependencies:
       '@solid-primitives/context':


### PR DESCRIPTION
This adds a new package `history` and the `createUndoHistory` primitive for managing a history of updates and going back and forth in time to update the state to different snapshots.

```tsx
import { createUndoHistory } from "@solid-primitives/history";

const [count, setCount] = createSignal(0);

const history = createUndoHistory(() => {
  // track the changes to the state (and clone if you need to)
  const v = count();
  // return a callback to set the state back to the tracked value
  return () => setCount(v);
});

// undo the last change
history.undo();

// redo the last change
history.redo();

// check if there are any changes to undo/redo with .canUndo() and .canRedo()
return (
  <>
    <button disabled={!history.canUndo()} onClick={history.undo}>
      Undo
    </button>
    <button disabled={!history.canRedo()} onClick={history.redo}>
      Redo
    </button>
  </>
);
```

[README](https://github.com/solidjs-community/solid-primitives/tree/history/packages/history#readme)