### PR TITLE
i18n: Add useScopedI18n(scope: string)

### DIFF
--- a/.changeset/kind-maps-notice.md
+++ b/.changeset/kind-maps-notice.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/i18n": minor
+---
+
+Add `useScopedI18n` helper for creating a module-specific translate

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -142,6 +142,36 @@ const App: Component = () => {
 </I18nContext.Provider>;
 ```
 
+## `useScopedI18n`
+
+Use `useScopedI18n` to create a module-specific translate.
+
+```tsx
+
+const dict = {
+  en: { 
+    login: {
+      username: 'User name',
+      password: 'Password',
+      login: 'Login'
+  },
+  fr: {
+     ...
+  }
+ }
+}
+
+export const LoginView = () => {
+  const [t] = useScopedI18n('login');
+  return <>
+      <div>{t('username')}<input /></div>
+      <div>{t('password')}<input /></div>
+      <button>{t('login') }</button>
+  </>
+}
+
+```
+
 ## Demo
 
 You may view a working example of createI18nContext here: https://codesandbox.io/s/use-i18n-rd7jq?file=/src/index.tsx

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -168,4 +168,10 @@ export const createI18nContext = (
 export type I18nContextInterface = ReturnType<typeof createI18nContext>;
 
 export const I18nContext = createContext<I18nContextInterface>({} as I18nContextInterface);
+
 export const useI18n = () => useContext(I18nContext);
+
+export const useScopedI18n = (scope: string): I18nContextInterface => {
+  const [translate, actions] = useContext(I18nContext);
+  return [(key, ...rest) => translate(`${scope}.${key}`, ...rest), actions];
+};

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,4 +1,4 @@
-export { createI18nContext, I18nContext, useI18n } from "./i18n";
+export { createI18nContext, I18nContext, useI18n, useScopedI18n } from "./i18n";
 export type { I18nContextInterface } from "./i18n";
 
 export {


### PR DESCRIPTION
Add `useScopedI18n`, so that we can:

```ts

const dict = {
  en: { 
    login: {
      username: 'User name',
      password: 'Password',
      login: 'Login'
  },
  fr: {
     ...
  }
 }
}

export const LoginView () => {
  const [t] = useScopedI18n('login');
  return <>
      <div>{t('username')}<input /></div>
      <div>{t('password')}<input /></div>
      <button>{t('login') }</button>
  </>
}
```