### PR TITLE
i18n: Add typings for `useI18n`

### DIFF
--- a/.changeset/warm-bottles-pump.md
+++ b/.changeset/warm-bottles-pump.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/i18n": patch
+---
+
+Add better typing for `useI18n` and `useScopedI18n`

--- a/.changeset/warm-bottles-pump.md
+++ b/.changeset/warm-bottles-pump.md
@@ -1,5 +1,5 @@
 ---
-"@solid-primitives/i18n": patch
+"@solid-primitives/i18n": minor
 ---
 
 Add better typing for `useI18n` and `useScopedI18n`

--- a/packages/i18n/src/i18n.ts
+++ b/packages/i18n/src/i18n.ts
@@ -1,5 +1,6 @@
 import { createContext, createSignal, useContext } from "solid-js";
 import { createStore } from "solid-js/store";
+import type { UseScopedI18n, I18nContextInterface } from "./types";
 
 /**
  * Safely access deep values in an object via a string path seperated by `.`
@@ -162,16 +163,17 @@ export const createI18nContext = (
      */
     dict: (lang: string) => deepReadObject(dict, lang),
   };
-  return [translate, actions as any];
+  return [translate, actions];
 };
-
-export type I18nContextInterface = ReturnType<typeof createI18nContext>;
 
 export const I18nContext = createContext<I18nContextInterface>({} as I18nContextInterface);
 
-export const useI18n = () => useContext(I18nContext);
+export const useI18n = <T = unknown>() => useContext(I18nContext) as I18nContextInterface<T>;
 
-export const useScopedI18n = (scope: string): I18nContextInterface => {
-  const [translate, actions] = useContext(I18nContext);
-  return [(key, ...rest) => translate(`${scope}.${key}`, ...rest), actions];
+export const useScopedI18n: UseScopedI18n = <T = unknown>(scope: string) => {
+  const [translate, actions] = useI18n();
+  return [
+    (key, ...rest) => translate(`${scope}.${key}`, ...rest),
+    actions,
+  ] satisfies I18nContextInterface as unknown as I18nContextInterface<T>;
 };

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -1,5 +1,5 @@
 export { createI18nContext, I18nContext, useI18n, useScopedI18n } from "./i18n";
-export type { I18nContextInterface } from "./i18n";
+export type { I18nContextInterface } from "./types";
 
 export {
   createChainedI18nDictionary,

--- a/packages/i18n/src/types.ts
+++ b/packages/i18n/src/types.ts
@@ -1,0 +1,34 @@
+export type NestedKeyOf<T extends object> = {
+  [Key in keyof T & (string | number)]: T[Key] extends object
+    ? `${Key}` | `${Key}.${NestedKeyOf<T[Key]>}`
+    : `${Key}`;
+}[keyof T & (string | number)];
+
+export type NestedValueOf<T extends object, K extends NestedKeyOf<T> | string> = K extends keyof T &
+  (string | number)
+  ? T[K]
+  : K extends `${infer P extends keyof T & (string | number)}.${infer R}`
+  ? T[P] extends object
+    ? NestedValueOf<T[P], R>
+    : unknown
+  : unknown;
+
+export type Translate<T = unknown> = T extends object
+  ? (key: NestedKeyOf<T>, params?: Record<string, string>, defaultValue?: string) => string
+  : (key: string, params?: Record<string, string>, defaultValue?: string) => string;
+
+export type I18nAction = {
+  add(lang: string, table: Record<string, unknown>): void;
+  locale: (lang?: string) => string;
+  dict: (lang: string) => Record<string, Record<string, unknown>>;
+};
+
+export type I18nContextInterface<T = unknown> = [Translate<T>, I18nAction];
+
+export type UseScopedI18n<T = unknown> = T extends object
+  ? <K extends NestedKeyOf<T>>(scope: K) => I18nContextInterface<NestedValueOf<T, K>>
+  :
+      | (<U extends object, K extends NestedKeyOf<U>>(
+          scope: K,
+        ) => I18nContextInterface<NestedValueOf<U, K>>)
+      | ((scope: string) => I18nContextInterface);


### PR DESCRIPTION
Add typings for `useI18n`, so that we can:


![图片](https://github.com/solidjs-community/solid-primitives/assets/16131917/19ee04ba-32a9-479d-8754-0771ff51b6a3)

![图片](https://github.com/solidjs-community/solid-primitives/assets/16131917/57d978f6-803f-4993-ae74-b10b21370143)
