### PR TITLE
graphql: fix resource states

### DIFF
--- a/.changeset/sixty-dryers-float.md
+++ b/.changeset/sixty-dryers-float.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/graphql": patch
+---
+
+fix resource states by omitting `initialValue` option if passed `undefined`

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -50,7 +50,7 @@ export const createGraphQLClient =
         const variables = typeof vars === "boolean" ? {} : vars;
         return request(access(url), query, { ...options, variables });
       },
-      { initialValue },
+      initialValue !== undefined ? { initialValue } : undefined,
     );
 
 /**


### PR DESCRIPTION
The current code passes `initialValue` unconditionally to the `createResource()` function, forcing an initial value even if the corresponding argument is undefined. This is bad because the sequence of states the resource goes through is:

* refreshing
* ready

while with an undefined `initialValue` the sequence is expected to be:

* pending
* ready

This patch fixes this problem and restores the correct resource states by passing a third argument to `createResource()` only when `initialState !== undefined`.