### PR TITLE
grapgql: resource options and reactive `url`, `options`

### DIFF
--- a/.changeset/bright-cherries-destroy.md
+++ b/.changeset/bright-cherries-destroy.md
@@ -5,3 +5,5 @@
 **Breaking:** The query primitive now accepts a `ResourceOptions` object, instead of just `initialValue`.
 
 Changes to `url` or `options` will invalidate the resource now. Fixes #328
+
+Changes `@graphql-typed-document-node/core` and `graphql` to be peer dependencies.

--- a/.changeset/bright-cherries-destroy.md
+++ b/.changeset/bright-cherries-destroy.md
@@ -1,0 +1,7 @@
+---
+"@solid-primitives/graphql": major
+---
+
+**Breaking:** The query primitive now accepts a `ResourceOptions` object, instead of just `initialValue`.
+
+Changes to `url` or `options` will invalidate the resource now. Fixes #328

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -33,11 +33,12 @@ import { createGraphQLClient, gql, request } from "@solid-primitives/graphql";
 
 #### Using the client
 
-`createGraphQLClient` takes 3 arguments:
+`createGraphQLClient` takes 2 arguments:
 
 - `url` - target api endpoint, as string or signal
-- `headers` - _optional_, A list of request headers to supply the client
-- `fetchFn` - _optional_, A fetch function to replace the default one, that is Fetch API on browser and `node-fetch` on server.
+- `options` - _optional_, Options for the `fetch` function, `headers`, the `fetcher` method etc.
+  - `fetcher` - A fetch function to replace the default one, that is Fetch API on browser and `node-fetch` on server.
+  - `headers` - A headers object to be passed to the `fetch` function.
 
 ```ts
 import { createGraphQLClient, gql } from "@solid-primitives/graphql";
@@ -103,8 +104,10 @@ const [countries] = newQuery<{ countries: { name: string }[] }>(
   `,
   // no variables
   undefined,
-  // the initial value
-  { countries: [] },
+  // resource options with the initial value
+  {
+    initialValue: { countries: [] },
+  },
 );
 countries(); // T: { countries: { name: string }[] }
 ```

--- a/packages/graphql/dev/index.tsx
+++ b/packages/graphql/dev/index.tsx
@@ -1,4 +1,4 @@
-import { Component, createSignal, Show, For } from "solid-js";
+import { Component, createSignal, Show, For, Suspense } from "solid-js";
 
 import { gql, createGraphQLClient, request, multipartRequest } from "../src";
 import { CountryQueryDocument } from "./gqlgen";
@@ -40,7 +40,7 @@ const App: Component = () => {
     () => ({
       code: code(),
     }),
-    { country: { name: "loading..." } },
+    { initialValue: { country: { name: "loading..." } } },
   );
 
   // Send a simple mutation with the multipart option. This will never work with the
@@ -68,22 +68,26 @@ const App: Component = () => {
       <h3>Get country by code</h3>
       <input value={code()} oninput={e => setCode(e.currentTarget.value.toUpperCase())}></input>
       <h4>
-        <Show when={countryData()?.country?.name} fallback="not found">
-          <p>{countryData()!.country!.name}</p>
-        </Show>
+        <Suspense fallback="loading country name...">
+          <Show when={countryData()?.country?.name} fallback="not found">
+            <p>{countryData()!.country!.name}</p>
+          </Show>
+        </Suspense>
       </h4>
       <h3>Countries:</h3>
-      <Show when={countriesData()}>
-        <ul>
-          <For each={countriesData()!.countries}>
-            {country => (
-              <li>
-                {country.code} - {country.name}
-              </li>
-            )}
-          </For>
-        </ul>
-      </Show>
+      <Suspense fallback="loading countries...">
+        <Show when={countriesData()}>
+          <ul>
+            <For each={countriesData()!.countries}>
+              {country => (
+                <li>
+                  {country.code} - {country.name}
+                </li>
+              )}
+            </For>
+          </ul>
+        </Show>
+      </Suspense>
     </div>
   );
 };

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -56,15 +56,17 @@
     "@graphql-codegen/cli": "^3.3.0",
     "@graphql-codegen/typed-document-node": "^3.0.2",
     "@graphql-codegen/typescript": "^3.0.3",
-    "@graphql-codegen/typescript-operations": "^3.0.3"
-  },
-  "dependencies": {
+    "@graphql-codegen/typescript-operations": "^3.0.3",
     "@graphql-typed-document-node/core": "^3.2.0",
-    "@solid-primitives/utils": "workspace:^",
     "graphql": "^16.6.0"
   },
+  "dependencies": {
+    "@solid-primitives/utils": "workspace:^"
+  },
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "solid-js": "^1.6.12",
+    "@graphql-typed-document-node/core": "^3.2.0",
+    "graphql": "^16.6.0"
   },
   "typesVersions": {}
 }

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -1,7 +1,13 @@
-import { createResource, ResourceReturn } from "solid-js";
-import { DocumentNode, print } from "graphql";
-import { TypedDocumentNode } from "@graphql-typed-document-node/core";
-import { access, FalsyValue, MaybeAccessor, Modify } from "@solid-primitives/utils";
+import {
+  createResource,
+  type InitializedResourceOptions,
+  type NoInfer,
+  type ResourceOptions,
+  type ResourceReturn,
+} from "solid-js";
+import { print, type DocumentNode } from "graphql";
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { asAccessor, type MaybeAccessor, type Modify } from "@solid-primitives/utils";
 
 export type RequestHeaders = { [key: string]: string };
 
@@ -14,17 +20,32 @@ export type RequestOptions<V extends object = {}> = Modify<
   }
 >;
 
+export type GraphQLResourceSource<V extends object = {}> = {
+  url: string;
+  options: RequestOptions<V>;
+};
+
+/**
+ * A function returned by {@link createGraphQLClient}.
+ * It wraps {@link createResource} and performs a GraphQL fetch to endpoint form the client.
+ *
+ * @param query GraphQL query string *(use {@link gql} function or `DocumentNode`/`TypedDocumentNode` type)*
+ * @param variables variables for the GraphQL query
+ * @param options options passed to {@link createResource}
+ */
 export type GraphQLClientQuery = {
-  <T = unknown, V extends object = {}>(
-    query: string | DocumentNode | TypedDocumentNode<T, V>,
-    variables: MaybeAccessor<V | FalsyValue> | undefined,
-    initialValue: T,
-  ): ResourceReturn<T>;
-  <T = unknown, V extends object = {}>(
-    query: string | DocumentNode | TypedDocumentNode<T, V>,
-    variables?: MaybeAccessor<V | FalsyValue>,
-    initialValue?: undefined,
-  ): ResourceReturn<T | undefined>;
+  // initialized
+  <TResult = unknown, TVariables extends object = {}>(
+    query: string | DocumentNode | TypedDocumentNode<TResult, TVariables>,
+    variables: MaybeAccessor<TVariables | false | undefined | null> | undefined,
+    options: InitializedResourceOptions<NoInfer<TResult>, GraphQLResourceSource<TVariables>>,
+  ): ResourceReturn<TResult>;
+  // not initialized
+  <TResult = unknown, TVariables extends object = {}>(
+    query: string | DocumentNode | TypedDocumentNode<TResult, TVariables>,
+    variables?: MaybeAccessor<TVariables | false | undefined | null>,
+    options?: ResourceOptions<NoInfer<TResult>, GraphQLResourceSource<TVariables>>,
+  ): ResourceReturn<TResult | undefined>;
 };
 
 /**
@@ -42,16 +63,25 @@ export type GraphQLClientQuery = {
  * ```
  */
 export const createGraphQLClient =
-  (url: MaybeAccessor<string>, options?: Omit<RequestOptions, "variables">): GraphQLClientQuery =>
-  (query, variables: any = {}, initialValue) =>
-    createResource(
-      () => access(variables),
-      (vars: any) => {
-        const variables = typeof vars === "boolean" ? {} : vars;
-        return request(access(url), query, { ...options, variables });
+  (
+    url: MaybeAccessor<string>,
+    options: MaybeAccessor<Omit<RequestOptions, "variables">> = {},
+  ): GraphQLClientQuery =>
+  (query, variables: any = {}, resourceOptions) => {
+    const getUrl = asAccessor(url),
+      getVariables = asAccessor(variables),
+      getOptions = asAccessor(options);
+    return createResource(
+      () => {
+        const url = getUrl(),
+          variables = getVariables(),
+          options = getOptions();
+        return url && variables && { url, options: { ...options, variables } };
       },
-      initialValue !== undefined ? { initialValue } : undefined,
+      ({ url, options }) => request(url, query, options),
+      resourceOptions,
     );
+  };
 
 /**
  * Performs a GraphQL fetch to provided endpoint.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -381,15 +381,9 @@ importers:
 
   packages/graphql:
     dependencies:
-      '@graphql-typed-document-node/core':
-        specifier: ^3.2.0
-        version: 3.2.0(graphql@16.6.0)
       '@solid-primitives/utils':
         specifier: workspace:^
         version: link:../utils
-      graphql:
-        specifier: ^16.6.0
-        version: 16.6.0
       solid-js:
         specifier: ^1.6.12
         version: 1.7.3
@@ -406,6 +400,12 @@ importers:
       '@graphql-codegen/typescript-operations':
         specifier: ^3.0.3
         version: 3.0.3(graphql@16.6.0)
+      '@graphql-typed-document-node/core':
+        specifier: ^3.2.0
+        version: 3.2.0(graphql@16.6.0)
+      graphql:
+        specifier: ^16.6.0
+        version: 16.6.0
 
   packages/history:
     dependencies:
@@ -3203,6 +3203,7 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 16.6.0
+    dev: true
 
   /@hapi/hoek@9.3.0:
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -6347,6 +6348,7 @@ packages:
   /graphql@16.6.0:
     resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    dev: true
 
   /grid-index@1.1.0:
     resolution: {integrity: sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==}


### PR DESCRIPTION
**Breaking:** The query primitive now accepts a `ResourceOptions` object, instead of just `initialValue`.

Changes to `url` or `options` will invalidate the resource now. Fixes #328

@fogzot 