### PR TITLE
input-mask: new pattern display primitive

### DIFF
--- a/.changeset/short-pugs-kneel.md
+++ b/.changeset/short-pugs-kneel.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/input-mask": minor
+---
+
+added mask-pattern primitive

--- a/packages/input-mask/README.md
+++ b/packages/input-mask/README.md
@@ -9,7 +9,7 @@
 [![version](https://img.shields.io/npm/v/@solid-primitives/input-mask?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/input-mask)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-1.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
-Primitive that returns an event handler to mask the inputs of an text input element (`<input>`, `<textarea>`) when applied in `oninput` or `onchange`.
+Primitive that returns an event handler to mask the inputs of an text input element (`<input>`, `<textarea>`) when applied in `oninput` or `onchange` and set attributes to handle pattern display.
 
 ## Installation
 
@@ -23,7 +23,7 @@ yarn add @solid-primitives/input-mask
 
 For convenience reasons, the handler returns the current value, which allows you to use it to fill a signal or assign a let variable. The masks come in 4 different formats: function, regex-replacer, array and string. There are tools to convert string masks to array masks and regex-replacer and array masks to function masks.
 
-```ts
+```tsx
 import {
   stringMaskToArray,
   regexMaskToFn,
@@ -90,6 +90,34 @@ return (
 ```
 
 In most cases you'll want to use `onInput` and `onPaste`.
+
+
+## Showing the pattern during input
+
+The placeholder attribute is nice, but it cannot show the pattern during input. In order to rectify this shortcoming, this package has a `createMaskPattern` export:
+
+```tsx
+import { createInputMask, createMaskPattern } from "@solid-primitives/input-mask";
+
+return <>
+  <style>{`
+    input { border: 0.1rem solid currentColor; padding: 0.5rem 0.75rem; }
+    label[data-mask-value] { position: absolute; padding: 0.5rem 0.75rem; border: 0.1rem solid transparent; }
+    label[data-mask-value]::before { content: attr(data-mask-value); color: transparent; }
+    label[data-mask-pattern]::after { content: attr(data-mask-pattern); opacity: 0.7; }
+  `}</style>
+  <label for="datefield">ISO Date:</label>
+  <label for="datefield"></label>
+  <input 
+    id="datefield"
+    placeholder="YYYY-MM-DD"
+    onInput={createMaskPattern(createInputMask("9999-99-99"), () => "YYYY-MM-DD")}
+  />
+</>;
+```
+
+As you can see, this function requires an empty label as `previousElementSibling` to the input field, which will be automatically given two attributes, `data-mask-value` and `data-mask-pattern`, which can be used to display the pattern over the input. This label must be formatted so that its content will match the text in the adjacent input; use a transparent border and padding to achieve this effect.
+
 
 ## Usage with form handling libraries
 

--- a/packages/input-mask/README.md
+++ b/packages/input-mask/README.md
@@ -9,7 +9,7 @@
 [![version](https://img.shields.io/npm/v/@solid-primitives/input-mask?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/input-mask)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-1.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
-Primitive that returns an event handler to mask the inputs of an text input element (`<input>`, `<textarea>`) when applied in `oninput` or `onchange` and set attributes to handle pattern display.
+Primitive that returns an event handler to mask the inputs of a text input element (`<input>`, `<textarea>`) when applied in `oninput` or `onchange` and set attributes to handle pattern display.
 
 ## Installation
 
@@ -100,20 +100,41 @@ The placeholder attribute is nice, but it cannot show the pattern during input. 
 import { createInputMask, createMaskPattern } from "@solid-primitives/input-mask";
 
 return <>
-  <style>{`
-    input { border: 0.1rem solid currentColor; padding: 0.5rem 0.75rem; }
-    label[data-mask-value] { position: absolute; border: 0.1rem solid transparent; padding: 0.5rem 0.75rem; }
-    label[data-mask-value]::before { content: attr(data-mask-value); color: transparent; }
-    label[data-mask-pattern]::after { content: attr(data-mask-pattern); opacity: 0.7; }
-  `}</style>
   <label for="datefield">ISO Date:</label>
-  <label for="datefield"></label>
-  <input 
-    id="datefield"
-    placeholder="YYYY-MM-DD"
-    onInput={createMaskPattern(createInputMask("9999-99-99"), () => "YYYY-MM-DD")}
-  />
+  <div>
+    <label for="datefield" id="datefield-pattern-view"></label>
+    <input 
+      id="datefield"
+      placeholder="YYYY-MM-DD"
+      onInput={createMaskPattern(createInputMask("9999-99-99"), () => "YYYY-MM-DD")}
+    />
+  </div>
 </>;
+```
+
+This uses something like the following CSS to make sure that the empty label: 
+
+```css
+input {
+  border: 0.1rem solid currentColor;
+  padding: 0.5rem 0.75rem;
+}
+/* make sure the pattern text is displayed at the exact position of the input text */
+label[data-mask-value] {
+  position: absolute;
+  border: 0.1rem solid transparent;
+  padding: 0.5rem 0.75rem;
+}
+/* Render the value in a transparent color to move the pattern to the correct position */
+label[data-mask-value]::before {
+  content: attr(data-mask-value);
+  color: transparent;
+}
+/* Render the visible pattern after the invisible value */
+label[data-mask-pattern]::after {
+  content: attr(data-mask-pattern);
+  opacity: 0.7;
+}
 ```
 
 As you can see, this function requires an empty label as `previousElementSibling` to the input field, which will be automatically given two attributes, `data-mask-value` and `data-mask-pattern`, which can be used to display the pattern over the input. This label must be formatted so that its content will match the text in the adjacent input; use a transparent border and padding to achieve this effect. You need not use an inline style; you can also use your favorite way to deploy the CSS (e.g. tailwind or solid-styled).
@@ -121,7 +142,7 @@ As you can see, this function requires an empty label as `previousElementSibling
 
 ## Usage with form handling libraries
 
-To use the mask handler with [solid-js-form](https://github.com/niliadu/solid-js-form), you need to steer clear of the `use:formHandler` directive, as it overwrites the input event with DOM level 2 events. Instead use the `handleChange`and `handleBlur` event handlers instead:
+To use the mask handler with [`solid-js-form`](https://github.com/niliadu/solid-js-form), you need to steer clear of the `use:formHandler` directive, as it overwrites the input event with DOM level 2 events. Instead, use the `handleChange`and `handleBlur` event handlers instead:
 
 ```tsx
 // don't
@@ -186,8 +207,8 @@ With [solar-forms](https://github.com/kajetansw/solar-forms), the only way to us
 
 ## FAQ
 
-- **Why not support contenteditable?**<br> In most reasonable cases, you won't need it. In those rare cases you do need it, check the [selection](../selection/README.md) package, it shows you how to employ the mask filter functions together with a selection that supports contenteditable.
-- **Why `oninput`/`onchange` instead of e.g. `onkeyup`?**<br> There are a few things happening after keydown, -press and -up, which would result in flickering. Generally, you could use `onblur`, but then you'd attempt to apply the mask even if nothing changed, which just seems unnecessarily wasteful.
+- **Why not support `contenteditable`?**<br> In most reasonable cases, you won't need it. In those rare cases you do need it, check the [selection](../selection/README.md) package, it shows you how to employ the mask filter functions together with a selection that supports `contenteditable`.
+- **Why `oninput`/`onchange` instead of e.g. `onkeyup`?**<br> There are a few things happening after `keydown`, `keypress` and `keyup`, which would result in flickering. Generally, you could use `onblur`, but then you'd attempt to apply the mask even if nothing changed, which just seems unnecessarily wasteful.
 - **Will it work with actual events?**<br> Yes, it will work with composed as well as native events, even with React's synthetic events; `createInputMask` has an optional generic that you can use to type the output events. Solid's composed events are more performant than DOM events, so it is best practice to use them.
 - **Is there a server version?**<br> No, since it only creates an event handler that will solely run on the client; it makes no sense to create a server version.
 - **Does this provide any error handling?**<br> There is no error handling, but it should work well together with any form handling library.

--- a/packages/input-mask/README.md
+++ b/packages/input-mask/README.md
@@ -206,7 +206,7 @@ return <input ref={ref} onInput={e => useMask && mask(e)} onPaste={e => useMask 
 
 ### DEMO
 
-https://codesandbox.io/s/solid-primitives-input-mask-demo-fnvg76?file=/index.tsx
+Here is a [working demonstration](https://primitives.solidjs.community/playground/input-mask/) ([Source code](https://github.com/solidjs-community/solid-primitives/tree/main/packages/input-mask/dev)).
 
 ## Changelog
 

--- a/packages/input-mask/README.md
+++ b/packages/input-mask/README.md
@@ -102,7 +102,7 @@ import { createInputMask, createMaskPattern } from "@solid-primitives/input-mask
 return <>
   <style>{`
     input { border: 0.1rem solid currentColor; padding: 0.5rem 0.75rem; }
-    label[data-mask-value] { position: absolute; padding: 0.5rem 0.75rem; border: 0.1rem solid transparent; }
+    label[data-mask-value] { position: absolute; border: 0.1rem solid transparent; padding: 0.5rem 0.75rem; }
     label[data-mask-value]::before { content: attr(data-mask-value); color: transparent; }
     label[data-mask-pattern]::after { content: attr(data-mask-pattern); opacity: 0.7; }
   `}</style>
@@ -116,7 +116,7 @@ return <>
 </>;
 ```
 
-As you can see, this function requires an empty label as `previousElementSibling` to the input field, which will be automatically given two attributes, `data-mask-value` and `data-mask-pattern`, which can be used to display the pattern over the input. This label must be formatted so that its content will match the text in the adjacent input; use a transparent border and padding to achieve this effect.
+As you can see, this function requires an empty label as `previousElementSibling` to the input field, which will be automatically given two attributes, `data-mask-value` and `data-mask-pattern`, which can be used to display the pattern over the input. This label must be formatted so that its content will match the text in the adjacent input; use a transparent border and padding to achieve this effect. You need not use an inline style; you can also use your favorite way to deploy the CSS (e.g. tailwind or solid-styled).
 
 
 ## Usage with form handling libraries

--- a/packages/input-mask/dev/index.tsx
+++ b/packages/input-mask/dev/index.tsx
@@ -1,10 +1,10 @@
 import { Component } from "solid-js";
 
-import { anyMaskToFn, createInputMask, maskArrayToFn, Selection } from "../src";
+import { anyMaskToFn, createInputMask, createMaskPattern, maskArrayToFn, Selection } from "../src";
 
 const App: Component = () => {
   // ISO Date
-  const isoDateHandler = createInputMask("9999-99-99");
+  const isoDateHandler = createMaskPattern(createInputMask("9999-99-99"), () => "YYYY-MM-DD");
 
   // Card Expiry Date
   const cardExpiryHandler = createInputMask([/\d/, /\d/, "/", /\d/, /\d/, /\d/, /\d/]);
@@ -32,20 +32,37 @@ const App: Component = () => {
 
   // Hex Color
   const hexMask = maskArrayToFn(["#", /[0-9a-f]{0,6}/i]);
-  const hexHandler = createInputMask(hexMask);
+  const hexHandler = createMaskPattern(createInputMask(hexMask), () => "#000000");
 
   return (
     <div class="box-border flex min-h-screen w-full flex-col items-center justify-center space-y-4 bg-gray-800 p-24 text-white">
       <div class="wrapper-v items-start">
+        <style>{`
+          label[data-mask-pattern] {
+            position: absolute;
+            padding: 0.55rem 0.8rem;
+          }
+          label[data-mask-value]::before {
+            content: attr(data-mask-value);
+            color: transparent;
+          }
+          label[data-mask-pattern]::after {
+            content: attr(data-mask-pattern);
+            opacity: 0.7;
+          }
+        `}</style>
         <h4>Input Mask</h4>
         <label for="isodate">ISO Date:</label>
-        <input
-          type="text"
-          id="isodate"
-          placeholder="YYYY-MM-DD"
-          onInput={isoDateHandler}
-          onPaste={isoDateHandler}
-        />
+        <div>
+          <label for="isodate"></label>
+          <input
+            type="text"
+            id="isodate"
+            placeholder="YYYY-MM-DD"
+            onInput={isoDateHandler}
+            onPaste={isoDateHandler}
+          />
+        </div>
         <br />
         <label for="cardexpiry">Card Expiry:</label>
         <input
@@ -77,13 +94,16 @@ const App: Component = () => {
         />
         <br />
         <label for="hex">Hex:</label>
-        <input
-          type="text"
-          id="hex"
-          placeholder="#000000"
-          onInput={hexHandler}
-          onPaste={hexHandler}
-        />
+        <div>
+          <label for="hex"></label>
+          <input
+            type="text"
+            id="hex"
+            placeholder="#000000"
+            onInput={hexHandler}
+            onPaste={hexHandler}
+          />
+        </div>
         <br />
       </div>
     </div>

--- a/packages/input-mask/package.json
+++ b/packages/input-mask/package.json
@@ -17,7 +17,8 @@
     "name": "input-mask",
     "stage": 1,
     "list": [
-      "createInputMask"
+      "createInputMask",
+      "createMaskPattern"
     ],
     "category": "Inputs"
   },

--- a/packages/input-mask/package.json
+++ b/packages/input-mask/package.json
@@ -59,6 +59,7 @@
   },
   "typesVersions": {},
   "devDependencies": {
+    "@solidjs/testing-library": "^0.7.1",
     "solid-js": "1.7.6"
   }
 }

--- a/packages/input-mask/src/index.ts
+++ b/packages/input-mask/src/index.ts
@@ -125,18 +125,24 @@ export const createInputMask = <
  * ```tsx
  * <style>
  * label[data-mask-value] {
- *   
+ *
  * }
  * label[data-mask-value]::before {
  *   content: attr(data-mask-value);
- *   opacity: 0;
+ *   color: transparent;
  * }
  * label[data-mask-pattern]::after {
  *   content: attr(data-mask-pattern);
  *   opacity: 0.7;
  * }
  * </style>
- * <input onInput={createMaskPattern(createInputMask("9999-99-99"), () => "YYYY-MM-DD")} />
+ * <div>
+ *   <label></label>
+ *   <input
+ *     placeholder="YYYY-MM-DD"
+ *     onInput={createMaskPattern(createInputMask("9999-99-99"), () => "YYYY-MM-DD")}
+ *   />
+ *</div>
  * ```
  */
 export const createMaskPattern = <
@@ -150,10 +156,9 @@ export const createMaskPattern = <
     const ref = (ev.currentTarget || ev.target) as HTMLInputElement | HTMLTextAreaElement;
     const prev = ref.previousElementSibling as HTMLElement;
     const fn = value === "" ? "removeAttribute" : "setAttribute";
-    prev[fn]('data-mask-value', value);
-    prev[fn]('data-mask-pattern', pattern(value).slice(value.length));
+    prev[fn]("data-mask-value", value);
+    prev[fn]("data-mask-pattern", pattern(value).slice(value.length));
     return value;
   };
   return handler;
-}
-
+};

--- a/packages/input-mask/src/index.ts
+++ b/packages/input-mask/src/index.ts
@@ -121,9 +121,10 @@ export const createInputMask = <
 };
 
 /**
- * Adds a data-attribute with the remaining pattern to be used in ::after
- * ```tsx
- * <style>
+ * Adds a data-attributes with value and remaining pattern to be used in ::before/::after
+ * > Requires an extra empty element (e.g. label) directly before the input
+ * ### CSS:
+ * ```css
  * label[data-mask-value] {
  *
  * }
@@ -135,14 +136,17 @@ export const createInputMask = <
  *   content: attr(data-mask-pattern);
  *   opacity: 0.7;
  * }
- * </style>
+ * ```
+ *
+ * ### JSX/TSX:
+ * ```tsx
  * <div>
  *   <label></label>
  *   <input
  *     placeholder="YYYY-MM-DD"
  *     onInput={createMaskPattern(createInputMask("9999-99-99"), () => "YYYY-MM-DD")}
  *   />
- *</div>
+ * </div>
  * ```
  */
 export const createMaskPattern = <

--- a/packages/input-mask/src/index.ts
+++ b/packages/input-mask/src/index.ts
@@ -96,9 +96,9 @@ export interface EventLike {
 
 /**
  * Create input mask handler
- * @param mask string or array or function mask
- * @param regexps optional object with regexps for string replacements used for string masks
- * @returns event handler to effectuate the input mask
+ * ```tsx
+ * <input onInput={createInputMask("9999-99-99")} />
+ * ```
  */
 export const createInputMask = <
   MaskEvent extends EventLike = KeyboardEvent | InputEvent | ClipboardEvent,
@@ -119,3 +119,41 @@ export const createInputMask = <
   };
   return handler;
 };
+
+/**
+ * Adds a data-attribute with the remaining pattern to be used in ::after
+ * ```tsx
+ * <style>
+ * label[data-mask-value] {
+ *   
+ * }
+ * label[data-mask-value]::before {
+ *   content: attr(data-mask-value);
+ *   opacity: 0;
+ * }
+ * label[data-mask-pattern]::after {
+ *   content: attr(data-mask-pattern);
+ *   opacity: 0.7;
+ * }
+ * </style>
+ * <input onInput={createMaskPattern(createInputMask("9999-99-99"), () => "YYYY-MM-DD")} />
+ * ```
+ */
+export const createMaskPattern = <
+  MaskEvent extends EventLike = KeyboardEvent | InputEvent | ClipboardEvent,
+>(
+  inputMask: (ev: MaskEvent) => string,
+  pattern: (value?: string) => string,
+): ((ev: MaskEvent) => string) => {
+  const handler = (ev: MaskEvent) => {
+    const value = inputMask(ev);
+    const ref = (ev.currentTarget || ev.target) as HTMLInputElement | HTMLTextAreaElement;
+    const prev = ref.previousElementSibling as HTMLElement;
+    const fn = value === "" ? "removeAttribute" : "setAttribute";
+    prev[fn]('data-mask-value', value);
+    prev[fn]('data-mask-pattern', pattern(value).slice(value.length));
+    return value;
+  };
+  return handler;
+}
+

--- a/packages/input-mask/test/index.test.tsx
+++ b/packages/input-mask/test/index.test.tsx
@@ -1,34 +1,18 @@
 import { describe, expect, it } from "vitest";
 
-import { render } from "solid-js/web";
+import { render } from "@solidjs/testing-library";
 
-import { createInputMask } from "../src/index";
-import type { JSX } from "solid-js";
+import { createInputMask, createMaskPattern } from "../src/index";
+
+const dispatchInputEvent = (node: HTMLElement) =>
+  new Promise<void>(resolve => {
+    node.addEventListener("input", () => resolve(), { once: true });
+    node.dispatchEvent(new Event("input", { bubbles: true, cancelable: false }));
+  });
 
 describe("createInputMask", () => {
-  const renderTest = (testCase: () => JSX.Element) => {
-    const container = document.createElement("div");
-    document.body.appendChild(container);
-    const unmount = render(testCase, container);
-    return {
-      container,
-      unmount: () => {
-        unmount();
-        document.body.removeChild(container);
-      },
-    };
-  };
-
-  const dispatchInputEvent = (node: HTMLElement) =>
-    new Promise<void>(resolve => {
-      node.addEventListener("input", () => resolve(), { once: true });
-      node.dispatchEvent(new Event("input", { bubbles: true, cancelable: false }));
-    });
-
   it("adds placeholder (e.g. to an iso date)", async () => {
-    const { container, unmount } = renderTest(() => (
-      <input onInput={createInputMask("9999-99-99")} />
-    ));
+    const { container } = render(() => <input onInput={createInputMask("9999-99-99")} />);
     const input = container.querySelector("input") as HTMLInputElement;
     input.value = "11111";
     await dispatchInputEvent(input);
@@ -45,13 +29,10 @@ describe("createInputMask", () => {
     input.value = "1111-11-111";
     await dispatchInputEvent(input);
     expect(input.value).toBe("1111-11-11");
-    unmount();
   });
 
   it("removes wrongful input (e.g. from iso-date)", async () => {
-    const { container, unmount } = renderTest(() => (
-      <input onInput={createInputMask("9999-99-99")} />
-    ));
+    const { container } = render(() => <input onInput={createInputMask("9999-99-99")} />);
     const input = container.querySelector("input") as HTMLInputElement;
     input.value = "a";
     await dispatchInputEvent(input);
@@ -59,11 +40,10 @@ describe("createInputMask", () => {
     input.value = "-";
     await dispatchInputEvent(input);
     expect(input.value).toBe("");
-    unmount();
   });
 
   it("works with regex mask", async () => {
-    const { container, unmount } = renderTest(() => (
+    const { container } = render(() => (
       <input
         onInput={createInputMask([
           /[^0-9a-zäöüß\-_/]|^(https?:\/\/|)(meet\.goto\.com|gotomeet\.me|)\/?/gi,
@@ -75,6 +55,31 @@ describe("createInputMask", () => {
     input.value = "https://meet.goto.com/test";
     await dispatchInputEvent(input);
     expect(input.value).toBe("test");
-    unmount();
+  });
+});
+
+describe("createMaskPattern", () => {
+  it("adds data-mask-value and data-mask-pattern to the previous element", async () => {
+    const { container } = render(() => (
+      <div>
+        <label></label>
+        <input
+          placeholder="YYYY-MM-DD"
+          onInput={createMaskPattern(createInputMask("9999-99-99"), () => "YYYY-MM-DD")}
+        />
+      </div>
+    ));
+    const label = container.querySelector("label")!;
+    const input = container.querySelector("input")!;
+    expect(label.hasAttribute("data-mask-value")).toBe(false);
+    expect(label.hasAttribute("data-mask-pattern")).toBe(false);
+    input.value = "1";
+    await dispatchInputEvent(input);
+    expect(label.getAttribute("data-mask-value")).toBe("1");
+    expect(label.getAttribute("data-mask-pattern")).toBe("YYY-MM-DD");
+    input.value = "20771";
+    await dispatchInputEvent(input);
+    expect(label.getAttribute("data-mask-value")).toBe("2077-1");
+    expect(label.getAttribute("data-mask-pattern")).toBe("M-DD");
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -479,7 +479,7 @@ importers:
     devDependencies:
       '@solidjs/testing-library':
         specifier: ^0.7.1
-        version: 0.7.1(solid-js@1.7.5)
+        version: 0.7.1(solid-js@1.7.6)
       solid-js:
         specifier: 1.7.6
         version: 1.7.6

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,9 @@ importers:
 
   packages/input-mask:
     devDependencies:
+      '@solidjs/testing-library':
+        specifier: ^0.7.1
+        version: 0.7.1(solid-js@1.7.5)
       solid-js:
         specifier: 1.7.6
         version: 1.7.6


### PR DESCRIPTION
Fabio requested the feature to be able to display a pattern mask while editing. Here it is.