### PR TITLE
fix link to jsx-tokenizer example

### DIFF
--- a/packages/jsx-tokenizer/README.md
+++ b/packages/jsx-tokenizer/README.md
@@ -293,7 +293,7 @@ isToken([tokenizer1, tokenizer2, MyTokenComponent], token);
 
 ## Demo
 
-[Live Example](https://primitives.solidjs.community/playground/) | [Source Code](./dev/index.tsx)
+[Live Example](https://primitives.solidjs.community/playground/jsx-tokenizer) | [Source Code](./dev/index.tsx)
 
 ## Changelog
 


### PR DESCRIPTION
fixed link to jsx-tokenizer example (was `https://primitives.solidjs.community/playground/` before)