### PR TITLE
withContext and withMultiContexts

### DIFF
--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -182,7 +182,7 @@ Type validation of the `values` array thanks to the amazing @otonashixav (https:
  * const NumberContext = createContext<number>
  * const StringContext = createContext<string>
  * const children = withContext(
- *    () => children(props.children),
+ *    () => props.children,
  *    [
  *      [NumberContext, 1],
  *      [StringContext, "string"]

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -1,12 +1,11 @@
 import {
-  createContext,
-  createComponent,
-  useContext,
-  JSX,
+  Accessor,
   Context,
   FlowComponent,
-  Accessor,
-  untrack,
+  JSX,
+  createComponent,
+  createContext,
+  useContext,
 } from "solid-js";
 import type { ContextProviderComponent } from "solid-js/types/reactive/signal";
 
@@ -130,67 +129,92 @@ export function MultiProvider<T extends readonly [unknown?, ...unknown[]]>(props
 }
 
 /**
- * A utility-helper to provide context to unresolved JSX-elements.
+ * A utility-function to provide context to components.
  *
- * @param elements Array of tuples of `[ContextProviderComponent, value]` or `[Context, value]` or bound `ContextProviderComponent` (that doesn't take a `value` property).
- * @param values Array of tuples of `[ContextProviderComponent, value]` or `[Context, value]` or bound `ContextProviderComponent` (that doesn't take a `value` property).
- * @param values Array of tuples of `[ContextProviderComponent, value]` or `[Context, value]` or bound `ContextProviderComponent` (that doesn't take a `value` property).
+ * @param children Accessor of Children
+ * @param context Context<T>
+ * @param value T
  *
  * @example
  * ```tsx
- * // single context
- * const resolvedChildren = withContext(
- *    () => children(props.children),
- *    CounterContext,
+ * const NumberContext = createContext<number>
+ *
+ * const children = withContext(
+ *    () => props.children,
+ *    NumberContext,
  *    1
  * )
- *
- * // multiple contexts
- * const resolvedChildren = withContext(
- *    () => children(props.children),
- *    [[CounterContext, 1]]
  * ```
  */
-export function withContext<T extends unknown, U extends unknown>(
-  children: Accessor<U>,
+
+export function withContext<T>(
+  children: Accessor<JSX.Element | JSX.Element[]>,
   context: Context<T>,
   value: T,
-): U;
-export function withContext<T extends [unknown?, ...unknown[]], U extends unknown>(
-  children: Accessor<U>,
-  contexts: {
+) {
+  let result: JSX.Element | JSX.Element[];
+
+  context.Provider({
+    value,
+    children: (() => {
+      result = children();
+      return "";
+    }) as any as JSX.Element,
+  });
+
+  return () => result;
+}
+
+/*
+
+Type validation of the `values` array thanks to the amazing @otonashixav (https://github.com/otonashixav)
+
+*/
+
+/**
+ * A utility-function to provide multiple context to components.
+ *
+ * @param children Accessor of Children
+ * @param values Array of tuples of `[Context<T>, value T]`.
+ *
+ * @example
+ * ```tsx
+ * const NumberContext = createContext<number>
+ * const StringContext = createContext<string>
+ * const children = withContext(
+ *    () => children(props.children),
+ *    [
+ *      [NumberContext, 1],
+ *      [StringContext, "string"]
+ *    ]
+ * )
+ * ```
+ */
+
+export function withMultiContexts<T extends readonly [unknown?, ...unknown[]]>(
+  children: Accessor<JSX.Element | JSX.Element[]>,
+  values: {
     [K in keyof T]: readonly [Context<T[K]>, [T[K]][T extends unknown ? 0 : never]];
   },
-): U;
-export function withContext<
-  T extends any[],
-  U extends Element,
-  V extends {
-    [K in keyof T]: readonly [Context<T[K]>, [T[K]][T extends unknown ? 0 : never]];
-  },
->(children: Accessor<U>, contexts: V | Context<T>, value?: T) {
-  let result: U;
+) {
+  let result: JSX.Element | JSX.Element[];
 
-  let values = Array.isArray(contexts) ? contexts : ([[contexts, value]] as unknown as V);
-
-  const fn = (i: number) => {
-    let item: any = values[i];
-
-    if (!item) return (result = children());
-
-    const ctxProps: { value?: any; children: JSX.Element } = {
-      get children() {
-        return fn(i + 1);
-      },
-    };
-    if (Array.isArray(item)) {
-      ctxProps.value = item[1];
-      item = item[0];
-      if (typeof item !== "function") item = item.Provider;
-    }
-
-    return createComponent(item, ctxProps);
+  const fn = (index: number) => {
+    const [context, value] = values[index]!;
+    context.Provider({
+      value,
+      children: (() => {
+        if (index < values.length - 1) {
+          fn(index + 1);
+        } else {
+          result = children();
+        }
+        return "";
+      }) as any as JSX.Element,
+    });
   };
 
-  return result!;
+  fn(0);
+
+  return () => result;
 }


### PR DESCRIPTION
Using context with `jsx-tokenizer` can be [quite painful](https://github.com/solidjs-community/solid-primitives/tree/main/packages/jsx-tokenizer#usage-with-context-api). To remedy this I have been using a utility-function `withContext` in my side-project [solid-canvas](https://github.com/bigmistqke/solid-canvas) [(see)](https://github.com/bigmistqke/solid-canvas/blob/main/src/utils/withContext.tsx). 

I modified this function into `withContext` and `withMultiContexts` to be more in-line with other `solid-primitives` like `MultiProvider`.

# API

## withContext

```ts
const NumberContext = createContext<number>
const children = withContext(
   () => props.children,
   NumberContext,
   1
)
```

## withMultiContexts

the API mirrors `MultiProvider` (for now I have kept it simple and only `[Context<T>, T]` is allowed), but the implementation is a bit different, since with `jsx-tokenizer` we have to be careful not to resolve the tokens [(see)](https://playground.solidjs.com/anonymous/0970d73c-e743-453f-abf0-af626e445106) this would cause a warning and prevent the token to be passed on.

```ts
const NumberContext = createContext<number>
const StringContext = createContext<string>
const children = withContext(
   () => props.children,
   [
     [NumberContext, 1],
     [StringContext, "string"]
   ]
)
```

Its usage is not limited to `jsx-tokenizer`, it could be used with 'regular' solid as well.

Demos: 
- [jsx-tokenizer](https://playground.solidjs.com/anonymous/4d018284-60f7-4c4a-8fb4-541e13c9dd70)
- [regular solid](https://playground.solidjs.com/anonymous/6f6ffd28-2151-44d7-af64-be389f1117e5)