### PR TITLE
Refactor transition-group to use per-element state machines

### DIFF
--- a/packages/transition-group/dev/list-page.tsx
+++ b/packages/transition-group/dev/list-page.tsx
@@ -163,6 +163,12 @@ const ListPage: Component = () => {
 
                 useOnEnter(done => {
                   console.log("onEnter", el);
+
+                  for (const animation of el.getAnimations()) {
+                    animation.commitStyles();
+                    animation.cancel();
+                  }
+
                   const animation = el.animate(
                     [
                       { opacity: 0, transform: "translateY(-30px)" },
@@ -170,10 +176,8 @@ const ListPage: Component = () => {
                     ],
                     { ...options, fill: "both" },
                   );
-                  onCleanup(() => {
-                    animation.commitStyles();
-                    animation.cancel();
-                  });
+
+                  animation.play();
                   animation.finished.then(done).catch(done);
                 });
 
@@ -187,7 +191,6 @@ const ListPage: Component = () => {
                     { ...options, fill: "both" },
                   );
                   onCleanup(() => {
-                    animation.commitStyles();
                     animation.cancel();
                   });
                   animation.finished.then(done).catch(done);

--- a/packages/transition-group/dev/list-page.tsx
+++ b/packages/transition-group/dev/list-page.tsx
@@ -110,7 +110,7 @@ const ListPage: Component = () => {
       });
     });
 
-    return mapArray(
+    const els = mapArray(
       () => transition()(),
       ([el, { state, useOnEnter, useOnExit, useOnRemain }]) => {
         createEffect(() => {
@@ -145,10 +145,10 @@ const ListPage: Component = () => {
           }
 
           const { top: top1, left: left1 } = el.getBoundingClientRect();
-          el.style.position = "absolute";
-          el.style.transform = "";
 
           queueMicrotask(() => {
+            el.style.position = "absolute";
+            el.style.transform = "";
             const { top: top2, left: left2 } = el.getBoundingClientRect();
 
             const animation = el.animate(
@@ -177,18 +177,20 @@ const ListPage: Component = () => {
           }
 
           const { top: top1, left: left1 } = el.getBoundingClientRect();
-          el.style.transform = "";
 
           queueMicrotask(() => {
-            const { top: top2, left: left2 } = el.getBoundingClientRect();
+            queueMicrotask(() => {
+              el.style.transform = "";
+              const { top: top2, left: left2 } = el.getBoundingClientRect();
 
-            el.animate(
-              [
-                { transform: `translate(${left1 - left2}px, ${top1 - top2}px)` },
-                { opacity: 1, transform: `translate(0px, 0px)` },
-              ],
-              animationOptions,
-            );
+              el.animate(
+                [
+                  { transform: `translate(${left1 - left2}px, ${top1 - top2}px)` },
+                  { opacity: 1, transform: `translate(0px, 0px)` },
+                ],
+                animationOptions,
+              );
+            });
           });
         });
 
@@ -196,7 +198,7 @@ const ListPage: Component = () => {
       },
     );
 
-    return <>{els()()}</>;
+    return <>{els()}</>;
   };
 
   return (

--- a/packages/transition-group/dev/list-page.tsx
+++ b/packages/transition-group/dev/list-page.tsx
@@ -7,7 +7,6 @@ import {
   onCleanup,
   onMount,
   Suspense,
-  untrack,
   useTransition,
 } from "solid-js";
 import { resolveElements } from "@solid-primitives/refs";

--- a/packages/transition-group/src/index.ts
+++ b/packages/transition-group/src/index.ts
@@ -426,6 +426,7 @@ export function createListTransition<T extends object>(
       : (items, item) => items.push(item);
 
   createComputed(() => {
+    console.log("computed");
     const sourceList = source();
     const elsToRemove = toRemove();
     (sourceList as any)[$TRACK]; // top level store tracking

--- a/packages/transition-group/src/utils.ts
+++ b/packages/transition-group/src/utils.ts
@@ -7,12 +7,6 @@ export function makeSetItem<T>(set: Set<T>, item: T) {
   });
 }
 
-export function allCallbacks(set: Set<(done: () => void) => void>): Promise<unknown> {
-  return Promise.all(
-    Array.from(set.values()).map(callback => new Promise<void>(resolve => callback(resolve))),
-  );
-}
-
 export function arrayEquals<T extends Array<unknown>>(a: T, b: T): boolean {
   if (a.length !== b.length) return false;
   for (let i = 0; i < a.length; i++) {

--- a/packages/transition-group/src/utils.ts
+++ b/packages/transition-group/src/utils.ts
@@ -1,0 +1,31 @@
+import { Accessor, onCleanup, untrack } from "solid-js";
+
+export function makeSetItem<T>(set: Set<T>, item: T) {
+  set.add(item);
+  onCleanup(() => {
+    set.delete(item);
+  });
+}
+
+export function allCallbacks(set: Set<(done: () => void) => void>): Promise<unknown> {
+  return Promise.all(
+    Array.from(set.values()).map(callback => new Promise<void>(resolve => callback(resolve))),
+  );
+}
+
+export function arrayEquals<T extends Array<unknown>>(a: T, b: T): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+export function trackTransitionPending(isPending: Accessor<boolean>, callback: () => void): void {
+  if (untrack(isPending)) {
+    isPending();
+    return;
+  } else {
+    callback();
+  }
+}

--- a/site/src/routes/playground/playground.scss
+++ b/site/src/routes/playground/playground.scss
@@ -15,8 +15,13 @@ Styles applied in the package playgrounds.
     @apply font-mono text-sm leading-tight;
   }
 
-  button {
+  button,
+  select {
     @apply border-1 flex cursor-pointer select-none items-center justify-center rounded border-teal-500 bg-teal-600 p-3 py-2 font-semibold text-white hover:bg-teal-500 disabled:cursor-not-allowed disabled:bg-teal-700 disabled:saturate-50 disabled:hover:bg-teal-700;
+  }
+
+  label:has(select) {
+    @apply flex items-center gap-2;
   }
 
   .wrapper-h {


### PR DESCRIPTION
WIP

This PR is an effort to resolve Issue #466 by taking the best of both worlds from `transition-group` and `presence`

As mentioned in #466 `presence` primarily works by deriving element appearance from transition state. However, it is missing:
1. Modes: parallel and in-out
2. Callbacks for animation completion (instead of duration-based timeout)
3. List transitions

In opposition, `transition-group` works by attaching callbacks to elements that have already rendered. It is lacking:
1. Access to transition state from within the transitioning item's context
2. The ability to run different animations per transitioning element.

This PR resolves these differences by introducing the `TransitionItemContext` type, an instance of which holds the transition state for each element in a list. `createListTransition` now returns an array of tuples: `[T, TransitionItemContext]`. The user can use `TransitionItemContext` to register transition events or track the transition state independently for each element.

Currently only `createListTransition` has been modified. If this PR goes over well I will extend the functionality to `createTransition` as well.

---

This also has the added benefit of removing from jank from the playground's transitions.

Old:

https://github.com/solidjs-community/solid-primitives/assets/3441123/9fa290a1-4ec0-4afe-ab2d-321ebbd19bae

New:

https://github.com/solidjs-community/solid-primitives/assets/3441123/d3081081-7c7d-4c2e-a2eb-c995d7a3a98a

