### PR TITLE
transition-group: Correct order of callbacks

### DIFF
--- a/.changeset/warm-ties-cover.md
+++ b/.changeset/warm-ties-cover.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/transition-group": patch
+---
+
+Correct order of callbacks in parallel switch transition.

--- a/packages/transition-group/src/index.ts
+++ b/packages/transition-group/src/index.ts
@@ -121,8 +121,8 @@ export function createSwitchTransition<T>(
         prev => enterTransition(() => exitTransition(prev))
       : // exit & enter
         prev => {
-          enterTransition();
           exitTransition(prev);
+          enterTransition();
         };
 
   createComputed(


### PR DESCRIPTION
Correct order of callbacks in parallel switch transition.