### PR TITLE
State machine

### DIFF
--- a/packages/state-machine/LICENSE
+++ b/packages/state-machine/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Solid Primitives Working Group
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/state-machine/README.md
+++ b/packages/state-machine/README.md
@@ -35,7 +35,7 @@ pnpm add @solid-primitives/state-machine
 
 - `value` - Value returned from the state callback.
 
-- `to` - Array of state names that can be transitioned to from this state. If not provided, any state can be transitioned to from this state.
+- `to` - Union of state names that can be transitioned to from this state. If not provided, any state can be transitioned to from this state. `never` will create a terminal state.
 
 ```ts
 import { createMachine } from "@solid-primitives/state-machine";
@@ -196,14 +196,15 @@ const state = createMachine<{
   red: {
     value: Events;
     // you can limit the states that can be transitioned to
-    to: ["yellow"];
+    to: "yellow";
   };
   yellow: {
     value: Events;
+    to: "green" | "red";
   };
   green: {
     value: Events;
-    to: ["red"];
+    to: "red";
   };
 }>({
   initial: "red",

--- a/packages/state-machine/README.md
+++ b/packages/state-machine/README.md
@@ -9,9 +9,7 @@
 [![version](https://img.shields.io/npm/v/@solid-primitives/state-machine?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/state-machine)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
-A sample primitive that is made up for templating with the following options:
-
-`createPrimitiveTemplate` - Provides a getter and setter for the primitive.
+A primitive for creating a reactive state machine. For expressing possible states and transitions, and bounding reactive computations to the lifecycle of those states.
 
 ## Installation
 
@@ -25,13 +23,272 @@ pnpm add @solid-primitives/state-machine
 
 ## How to use it
 
+`createMachine` is a simple primitive for creating a reactive state machine. It takes a configuration object with the following properties:
+
+- `initial` - The initial state of the machine.
+
+- `states` - Implementation of the states of the machine. Each state implements a callback called when the machine enters that state with parameters received from the transition. Value returned from the callback will be available as the value of the state.
+
+`createMachine` requires passing a type parameter defining the states. It expects an object with keys being the names of the states and values being objects with the following properties:
+
+- `input` - Value to be passed to the state callback when the machine enters that state.
+
+- `value` - Value returned from the state callback.
+
+- `to` - Array of state names that can be transitioned to from this state. If not provided, any state can be transitioned to from this state.
+
 ```ts
-const [value, setValue] = createPrimitiveTemplate(false);
+const state = createMachine<{
+  idle: {
+    value: "foo";
+  };
+  loading: {
+    input: number;
+    value: "bar";
+  };
+}>({
+  initial: "idle",
+  states: {
+    idle(input, to) {
+      return "foo";
+    },
+    loading(input, to) {
+      setTimeout(() => to("idle"), input);
+      return "bar";
+    },
+  },
+});
+```
+
+Value returned from `createMachine` is a signal with the following properties:
+
+- `type` - Current state of the machine.
+
+- `value` - Value returned from the state callback.
+
+- `to` - Function for transitioning to another state. It takes a state name and optional input for the state callback.
+
+```ts
+const v = state();
+v.type; // "idle"
+v.value; // "foo"
+
+if (v.type === "idle") {
+  v.to.loading(1000);
+
+  v.type; // "loading"
+  v.value; // "bar"
+}
+```
+
+The state properties are also implemented as getters on the function itself:
+
+```ts
+state.type; // "idle"
+state.value; // "foo"
+
+if (state.type === "idle") {
+  state.to.loading(1000);
+}
+```
+
+### Lifecycle
+
+`createMachine` is implemented using `createMemo`, which reruns when the state is changed. This means that any reactive computations can be used inside the state callbacks and they will be disposed when the state changes. (owner context will be available in the callbacks)
+
+```tsx
+const state = createMachine({
+  initial: "counter",
+  states: {
+    counter() {
+      const [count, setCount] = createSignal(0);
+      const interval = setInterval(() => setCount(c => c + 1), 1000);
+
+      createEffect(() => {
+        console.log(count());
+      });
+
+      // will be disposed when the state changes
+      onCleanup(() => clearInterval(interval));
+
+      // can return a JSX element
+      return <span>{count()}</span>;
+    },
+    disabled() {
+      return "disabled";
+    },
+  },
+});
+
+return (
+  <>
+    <div>Count: {state.value}</div>
+    <button
+      disabled={state.type === "disabled"}
+      onClick={() => {
+        if (state.type === "counter") {
+          state.to.disabled();
+        }
+      }}
+    >
+      Disable
+    </button>
+  </>
+);
+```
+
+### JSX Elements
+
+`createMachine` can be used like a `<Switch/>` component, and used for rendering different JSX elements based on the current state.
+
+```tsx
+function TodoItem(props: TodoProps) {
+  const state = createMachine<{
+    Reading: {
+      value: JSX.Element;
+    };
+    Editing: {
+      value: JSX.Element;
+    };
+  }>({
+    initial: "Reading",
+    states: {
+      Reading(_, next) {
+        return (
+          <>
+            <input type="checkbox" checked={props.todo.done} onChange={props.onToggle} />
+            <div onClick={() => next.Editing()}>{props.todo.title}</div>
+            <button onClick={() => props.onRemove()}>x</button>
+          </>
+        );
+      },
+    },
+    Editing(_, next) {
+      function commit() {
+        onEdit(input.value);
+        next.Reading();
+      }
+
+      let input!: HTMLInputElement;
+      return <input ref={input} type="text" value={props.todo.title} onChange={commit} />;
+    },
+  });
+
+  return <div>{state.value}</div>;
+}
+```
+
+### Events
+
+`createMachine` can be used for handling events in a declarative way. Although it doesn't implement anything special for handling events, any function can be returned from the state callback and it will be called when the event is triggered.
+
+```tsx
+type Events = {
+  NEXT: () => void;
+  // make events optional to not have to
+  // implement them in every state
+  RESET?: () => void;
+};
+
+const state = createMachine<{
+  red: {
+    value: Events;
+  };
+  yellow: {
+    value: Events;
+  };
+  green: {
+    value: Events;
+  };
+}>({
+  initial: "red",
+  states: {
+    red(_, next) {
+      return {
+        NEXT: () => next.yellow(),
+      };
+    },
+    yellow(_, next) {
+      return {
+        NEXT: () => next.green(),
+        RESET: () => next.red(),
+      };
+    },
+    green(_, next) {
+      return {
+        NEXT: () => next.red(),
+        RESET: () => next.red(),
+      };
+    },
+  },
+});
+
+state.value.NEXT(); // transition to the next state
+
+state.value.RESET?.(); // reset to the initial state
+```
+
+### Hoisting
+
+To avoid recreating the state machine callbacks each time, the state implementation object can be hoisted outside of the `createMachine` call.
+
+Then to define a way for the machine to communicate with the outside world, declate a shared type for the state inputs (kinda like component props), and use it when initializing the machine.
+
+```tsx
+type TodoProps = {
+  todo: Todo;
+};
+
+const todo_states: MachineStates<{
+  Reading: {
+    input: TodoProps;
+    value: JSX.Element;
+  };
+  Editing: {
+    input: TodoProps;
+    value: JSX.Element;
+  };
+}> = {
+  Reading(props, next) {
+    return (
+      <>
+        <input type="checkbox" checked={props.todo.done} onChange={props.onToggle} />
+        <div onClick={() => next.Editing(props)}>{props.todo.title}</div>
+        <button onClick={props.onRemove}>x</button>
+      </>
+    );
+  },
+  Editing(props, next) {
+    function commit() {
+      onEdit(input.value);
+      next.Reading(props);
+    }
+
+    let input!: HTMLInputElement;
+    return <input ref={input} type="text" value={props.todo.title} onChange={commit} />;
+  },
+};
+
+function TodoItem(props: TodoProps) {
+  // generic will be inferred from the input type
+  const state = createMachine({
+    initial: {
+      type: "Reading",
+      // input is required
+      input: props,
+    },
+    states: todo_states,
+  });
+
+  return <div>{state.value}</div>;
+}
 ```
 
 ## Demo
 
-You can use this template for publishing your demo on CodeSandbox: https://codesandbox.io/s/solid-primitives-demo-template-sz95h
+You may see the working example here: https://primitives.solidjs.community/playground/state-machine/
+
+Source code: https://github.com/solidjs-community/solid-primitives/blob/main/packages/state-machine/dev/index.tsx
 
 ## Changelog
 

--- a/packages/state-machine/README.md
+++ b/packages/state-machine/README.md
@@ -1,0 +1,38 @@
+<p>
+  <img width="100%" src="https://assets.solidjs.com/banner?type=Primitives&background=tiles&project=state-machine" alt="Solid Primitives state-machine">
+</p>
+
+# @solid-primitives/state-machine
+
+[![turborepo](https://img.shields.io/badge/built%20with-turborepo-cc00ff.svg?style=for-the-badge&logo=turborepo)](https://turborepo.org/)
+[![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/state-machine?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-primitives/state-machine)
+[![version](https://img.shields.io/npm/v/@solid-primitives/state-machine?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/state-machine)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
+
+A sample primitive that is made up for templating with the following options:
+
+`createPrimitiveTemplate` - Provides a getter and setter for the primitive.
+
+## Installation
+
+```bash
+npm install @solid-primitives/state-machine
+# or
+yarn add @solid-primitives/state-machine
+# or
+pnpm add @solid-primitives/state-machine
+```
+
+## How to use it
+
+```ts
+const [value, setValue] = createPrimitiveTemplate(false);
+```
+
+## Demo
+
+You can use this template for publishing your demo on CodeSandbox: https://codesandbox.io/s/solid-primitives-demo-template-sz95h
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md)

--- a/packages/state-machine/README.md
+++ b/packages/state-machine/README.md
@@ -9,7 +9,7 @@
 [![version](https://img.shields.io/npm/v/@solid-primitives/state-machine?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/state-machine)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
-A primitive for creating a reactive state machine. For expressing possible states and transitions, and bounding reactive computations to the lifecycle of those states.
+A primitive for creating a reactive state machine. For expressing possible exclusive states and transitions, and bounding reactive computations to the lifecycle of those states.
 
 ## Installation
 
@@ -38,6 +38,8 @@ pnpm add @solid-primitives/state-machine
 - `to` - Array of state names that can be transitioned to from this state. If not provided, any state can be transitioned to from this state.
 
 ```ts
+import { createMachine } from "@solid-primitives/state-machine";
+
 const state = createMachine<{
   idle: {
     value: "foo";
@@ -281,6 +283,35 @@ function TodoItem(props: TodoProps) {
   });
 
   return <div>{state.value}</div>;
+}
+```
+
+### Typing expected state
+
+If you expect a specific state, e.g. in component props, you can use the `MachineState` type:
+
+```ts
+import { MachineState } from "@solid-primitives/state-machine";
+
+// states definition passed to createMachine
+type MyStates = {
+  idle: {
+    value: string;
+  };
+  loading: {
+    value: number;
+  };
+};
+
+type IdleState = MachineState<MyStates, "idle">;
+
+type Props = {
+  state: IdleState;
+};
+
+function MyComponent(props: Props) {
+  props.state.type; // "idle"
+  props.state.value; // string
 }
 ```
 

--- a/packages/state-machine/README.md
+++ b/packages/state-machine/README.md
@@ -195,12 +195,15 @@ type Events = {
 const state = createMachine<{
   red: {
     value: Events;
+    // you can limit the states that can be transitioned to
+    to: ["yellow"];
   };
   yellow: {
     value: Events;
   };
   green: {
     value: Events;
+    to: ["red"];
   };
 }>({
   initial: "red",
@@ -313,6 +316,55 @@ function MyComponent(props: Props) {
   props.state.type; // "idle"
   props.state.value; // string
 }
+```
+
+### Using name references
+
+Using strings as state names is easy, but won't let you use your TypeScript's LSP to its full potential for refactoring and looking up usages.
+
+As an alternative you can make use of `const` variables or TypeScript `enums`:
+
+```ts
+const states = {
+  idle: {/* ... */};
+  loading: {/* ... */};
+};
+
+type States = keyof typeof states;
+
+state.to.idle();
+
+//
+// or with const variables
+//
+
+const IDLE = "idle";
+const LOADING = "loading";
+
+const states = {
+  [IDLE]: {/* ... */};
+  [LOADING]: {/* ... */};
+};
+
+type States = typeof IDLE | typeof LOADING;
+
+state.to(IDLE);
+
+//
+// or with TypeScript enums
+//
+
+enum States {
+  Idle = "idle",
+  Loading = "loading",
+}
+
+const states = {
+  [States.Idle]: {/* ... */};
+  [States.Loading]: {/* ... */};
+};
+
+state.to(States.Idle);
 ```
 
 ## Demo

--- a/packages/state-machine/dev/index.tsx
+++ b/packages/state-machine/dev/index.tsx
@@ -1,0 +1,20 @@
+import { Component, createSignal } from "solid-js";
+
+const App: Component = () => {
+  const [count, setCount] = createSignal(0);
+  const increment = () => setCount(count() + 1);
+
+  return (
+    <div class="box-border flex min-h-screen w-full flex-col items-center justify-center space-y-4 bg-gray-800 p-24 text-white">
+      <div class="wrapper-v">
+        <h4>Counter component</h4>
+        <p class="caption">it's very important...</p>
+        <button class="btn" onClick={increment}>
+          {count()}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default App;

--- a/packages/state-machine/dev/index.tsx
+++ b/packages/state-machine/dev/index.tsx
@@ -1,17 +1,149 @@
-import { Component, createSignal } from "solid-js";
+import { Component, For, JSX, onMount } from "solid-js";
+import { MachineStates, createMachine } from "../src";
+import { createStore } from "solid-js/store";
+
+type Todo = {
+  title: string;
+  done: boolean;
+};
+
+type TodoProps = {
+  todo: Todo;
+  onRemove: () => void;
+  onEdit: (title: string) => void;
+  onToggle: () => void;
+};
+
+const todo_states: MachineStates<{
+  Reading: {
+    input: TodoProps;
+    value: JSX.Element;
+  };
+  Editing: {
+    input: TodoProps;
+    value: JSX.Element;
+  };
+}> = {
+  Reading(props, next) {
+    const { todo, onRemove, onToggle } = props;
+
+    return (
+      <>
+        <input type="checkbox" checked={todo.done} onChange={onToggle} />
+        <div
+          class="px-2"
+          style={{ "text-decoration": todo.done ? "line-through" : "none" }}
+          onDblClick={() => next.Editing(props)}
+        >
+          {todo.title}
+        </div>
+        <button onClick={() => onRemove()}>x</button>
+      </>
+    );
+  },
+  Editing(props, next) {
+    const { todo, onEdit } = props;
+
+    function commit() {
+      onEdit(input.value);
+      next.Reading(props);
+    }
+
+    let input!: HTMLInputElement;
+    return (
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          commit();
+        }}
+      >
+        <input
+          ref={el => {
+            input = el;
+            onMount(() => el.focus());
+          }}
+          type="text"
+          value={todo.title}
+          onBlur={commit}
+        />
+      </form>
+    );
+  },
+};
+
+function DisplayTodo(props: TodoProps) {
+  const state = createMachine({
+    states: todo_states,
+    initial: {
+      type: "Reading",
+      input: props,
+    },
+  });
+
+  return (
+    <div class="group-item flex items-center rounded border border-gray-600 bg-gray-800 px-3 py-2">
+      {state.value}
+    </div>
+  );
+}
 
 const App: Component = () => {
-  const [count, setCount] = createSignal(0);
-  const increment = () => setCount(count() + 1);
+  const [todos, setTodos] = createStore<Todo[]>([
+    { title: "Learn Solid", done: false },
+    { title: "Learn JSX", done: false },
+    { title: "Build a Todo app", done: false },
+  ]);
 
+  function addTodo(title: string) {
+    setTodos(todos.length, { title, done: false });
+  }
+  function removeTodo(index: number) {
+    setTodos(p => {
+      const copy = p.slice();
+      copy.splice(index, 1);
+      return copy;
+    });
+  }
+  function toggleTodo(index: number) {
+    setTodos(index, "done", p => !p);
+  }
+  function editTodo(index: number, title: string) {
+    setTodos(index, "title", title);
+  }
+
+  let input!: HTMLInputElement;
   return (
     <div class="box-border flex min-h-screen w-full flex-col items-center justify-center space-y-4 bg-gray-800 p-24 text-white">
       <div class="wrapper-v">
-        <h4>Counter component</h4>
-        <p class="caption">it's very important...</p>
-        <button class="btn" onClick={increment}>
-          {count()}
-        </button>
+        <div class="m-24">
+          <div>
+            <form
+              class="flex items-center space-x-2"
+              onSubmit={e => {
+                e.preventDefault();
+                if (!input.value.trim()) return;
+                addTodo(input.value);
+                input.value = "";
+              }}
+            >
+              <input class="w-64" placeholder="What needs to be done?" ref={input} />
+              <button>Add Todo</button>
+            </form>
+          </div>
+
+          <div class="mt-4 flex flex-col items-start space-y-2">
+            <For each={todos}>
+              {(todo, i) => (
+                <DisplayTodo
+                  todo={todo}
+                  onRemove={() => removeTodo(i())}
+                  onToggle={() => toggleTodo(i())}
+                  onEdit={title => editTodo(i(), title)}
+                />
+              )}
+            </For>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/packages/state-machine/package.json
+++ b/packages/state-machine/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@solid-primitives/state-machine",
+  "version": "0.0.100",
+  "description": "A template primitive example.",
+  "author": "Your Name <you@youremail.com>",
+  "contributors": [],
+  "license": "MIT",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/state-machine#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solidjs-community/solid-primitives.git"
+  },
+  "bugs": {
+    "url": "https://github.com/solidjs-community/solid-primitives/issues"
+  },
+  "primitive": {
+    "name": "state-machine",
+    "stage": 0,
+    "list": [
+      "createPrimitiveTemplate"
+    ],
+    "category": "Display & Media"
+  },
+  "keywords": [
+    "solid",
+    "primitives"
+  ],
+  "private": false,
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "browser": {},
+  "exports": {
+    "import": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "require": "./dist/index.cjs"
+  },
+  "typesVersions": {},
+  "scripts": {
+    "dev": "jiti ../../scripts/dev.ts",
+    "build": "jiti ../../scripts/build.ts",
+    "vitest": "vitest -c ../../configs/vitest.config.ts",
+    "test": "pnpm run vitest",
+    "test:ssr": "pnpm run vitest --mode ssr"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.7.0"
+  }
+}

--- a/packages/state-machine/package.json
+++ b/packages/state-machine/package.json
@@ -17,13 +17,15 @@
     "name": "state-machine",
     "stage": 0,
     "list": [
-      "createPrimitiveTemplate"
+      "createMachine"
     ],
-    "category": "Display & Media"
+    "category": "State"
   },
   "keywords": [
     "solid",
-    "primitives"
+    "primitives",
+    "state-machine",
+    "state"
   ],
   "private": false,
   "sideEffects": false,

--- a/packages/state-machine/package.json
+++ b/packages/state-machine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/state-machine",
-  "version": "0.0.100",
+  "version": "0.0.1",
   "description": "A template primitive example.",
   "author": "Your Name <you@youremail.com>",
   "contributors": [],

--- a/packages/state-machine/package.json
+++ b/packages/state-machine/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@solid-primitives/state-machine",
   "version": "0.0.1",
-  "description": "A template primitive example.",
-  "author": "Your Name <you@youremail.com>",
+  "description": "A primitive for creating reactive state machines.",
+  "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
   "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/state-machine#readme",

--- a/packages/state-machine/src/index.ts
+++ b/packages/state-machine/src/index.ts
@@ -1,4 +1,4 @@
-import { createMemo, createSignal, type Accessor } from "solid-js";
+import { createMemo, createSignal, type Accessor, untrack } from "solid-js";
 
 /**
  * Used for restricting the user type input in {@link createMachine} generic.
@@ -176,18 +176,21 @@ export function createMachine<T extends StatesBase<keyof T>>(
     EQUALS_OPTIONS,
   );
 
-  const to = (type: keyof T, input: any) => {
+  const to: any = (type: keyof T, input: any) => {
     setPayload({ type, input });
   };
 
   for (const key of Object.keys(states)) {
-    // @ts-expect-error
     to[key as any] = (input: any) => to(key, input);
   }
 
   const memo = createMemo(() => {
     const { type, input } = payload();
-    return { type, value: states[type](input, to as any), to };
+    return {
+      type,
+      value: untrack(() => states[type](input, to)),
+      to,
+    };
   }) as any;
 
   Object.defineProperties(memo, {

--- a/packages/state-machine/src/index.ts
+++ b/packages/state-machine/src/index.ts
@@ -28,8 +28,8 @@ export type StateValue<T extends { value?: any }> = T extends { value: infer Val
  * @example
  * ```ts
  * const states: MachineStates<{
- *   idle: { input: void; value: "foo"; to: ["loading"] };
- *   loading: { input: void; value: "bar"; to: ["idle"] };
+ *   idle: { value: "foo"; to: ["loading"] };
+ *   loading: { value: "bar"; to: ["idle"] };
  * }> = {
  *   idle: () => "foo",
  *   loading(input, next) {
@@ -115,6 +115,8 @@ export type MachineNext<T extends StatesBase<keyof T>, TKey extends keyof T> = {
   ...args: T[K] extends { input: infer Input } ? [to: K, input: Input] : [to: K, input?: undefined]
 ) => void);
 
+const EQUALS_OPTIONS = { equals: (a: { type: any }, b: { type: any }) => a === b };
+
 /**
  * Creates a reactive state machine.
  *
@@ -125,7 +127,7 @@ export type MachineNext<T extends StatesBase<keyof T>, TKey extends keyof T> = {
  * @example
  * ```ts
  * const state = createMachine<{
- *   idle: { input: void; value: "foo"; to: ["loading"] };
+ *   idle: { value: "foo"; to: ["loading"] };
  *   loading: { input: number; value: "bar"; to: ["idle"] };
  * }>({
  *   initial: "idle",
@@ -163,7 +165,7 @@ export function createMachine<T extends StatesBase<keyof T>>(
       type: keyof T;
       input: any;
     },
-    { equals: (a, b) => a.type === b.type },
+    EQUALS_OPTIONS,
   );
 
   const to = (type: keyof T, input: any) => {

--- a/packages/state-machine/src/index.ts
+++ b/packages/state-machine/src/index.ts
@@ -1,0 +1,87 @@
+import { createMemo, createSignal, type Accessor, type SignalOptions } from "solid-js";
+
+export type MachineStatesBase<TStateNames extends PropertyKey> = {
+  [K in TStateNames]: { input: any; value: any; to?: TStateNames[] };
+};
+
+export type MachineStates<TStates extends MachineStatesBase<keyof TStates>> = {
+  [K in keyof TStates]: (
+    input: TStates[K]["input"],
+    next: MachineNext<TStates, K>,
+  ) => TStates[K]["value"];
+};
+
+export type MachineInitial<TStates extends MachineStatesBase<keyof TStates>> = {
+  [K in keyof TStates]:
+    | { type: K; input: TStates[K]["input"] }
+    | (TStates[K]["input"] extends void ? K : never);
+}[keyof TStates];
+
+export type MachineState<
+  TStates extends MachineStatesBase<keyof TStates>,
+  TKey extends keyof TStates,
+> = {
+  [K in keyof TStates]: {
+    readonly type: K;
+    readonly value: TStates[K]["value"];
+    readonly to: MachineNext<TStates, K>;
+  };
+}[TKey];
+
+export type PossibleNextStates<
+  TStates extends MachineStatesBase<keyof TStates>,
+  TKey extends keyof TStates,
+> = Exclude<
+  // @ts-expect-error
+  Extract<keyof TStates, TStates[TKey] extends { to: infer To } ? To[number] : any>,
+  TKey | symbol
+>;
+
+export type MachineNext<
+  TStates extends MachineStatesBase<keyof TStates>,
+  TKey extends keyof TStates,
+> = {
+  readonly [K in PossibleNextStates<TStates, TKey>]: (input: TStates[K]["input"]) => void;
+} & (<K extends PossibleNextStates<TStates, TKey>>(
+  ...args: TStates[K]["input"] extends void
+    ? [to: K, input?: void | undefined]
+    : [to: K, input: TStates[K]["input"]]
+) => void);
+
+const TYPE_EQUALS: SignalOptions<{ type: PropertyKey }> = {
+  equals: (a, b) => a.type === b.type,
+};
+
+/**
+ */
+export function createStateMachine<T extends MachineStatesBase<keyof T>>(options: {
+  states: MachineStates<T>;
+  initial: MachineInitial<T>;
+}): Accessor<MachineState<T, keyof T>> & MachineState<T, keyof T> {
+  const { states, initial } = options;
+
+  const [payload, setPayload] = createSignal<{ type: keyof T; input: any }>(
+      typeof initial === "object"
+        ? { type: initial.type, input: initial.input }
+        : { type: initial as keyof T, input: undefined },
+      TYPE_EQUALS,
+    ),
+    to = (type: any, input?: any) => setPayload({ type, input });
+
+  for (const key of Object.keys(states)) {
+    (to as any)[key] = (input: any) => to(key, input);
+  }
+
+  const memo = createMemo(() => {
+    const { type, input } = payload();
+    return { type, value: states[type](input, to), to };
+  }) as any;
+
+  Object.defineProperties(memo, {
+    type: { get: () => memo().type },
+    value: { get: () => memo().value },
+    to: { value: to },
+  });
+
+  return memo;
+}

--- a/packages/state-machine/src/index.ts
+++ b/packages/state-machine/src/index.ts
@@ -5,8 +5,17 @@ import { createMemo, createSignal, type Accessor } from "solid-js";
  */
 export type StatesBase<TStateNames extends PropertyKey> = {
   [K in TStateNames]: {
+    /**
+     * Value to be passed to the state callback when the machine enters that state.
+     */
     readonly input?: any;
+    /**
+     * Value returned from the state callback.
+     */
     readonly value?: any;
+    /**
+     * Array of state names that can be transitioned to from this state.
+     */
     readonly to?: TStateNames[];
   };
 };

--- a/packages/state-machine/src/index.ts
+++ b/packages/state-machine/src/index.ts
@@ -16,7 +16,7 @@ export type StatesBase<TStateNames extends PropertyKey> = {
     /**
      * Array of state names that can be transitioned to from this state.
      */
-    readonly to?: TStateNames[];
+    readonly to?: TStateNames;
   };
 };
 
@@ -98,8 +98,7 @@ export type MachineState<
 > = MachineStateDiscriminator<T>[K];
 
 type PossibleNextKeys<T extends StatesBase<keyof T>, TKey extends keyof T> = Exclude<
-  // @ts-expect-error
-  Extract<keyof T, T[TKey] extends { to: infer To } ? To[number] : any>,
+  Extract<keyof T, T[TKey] extends { to: infer To } ? To : any>,
   TKey | symbol
 >;
 
@@ -136,8 +135,8 @@ const EQUALS_OPTIONS = { equals: (a: { type: any }, b: { type: any }) => a === b
  * @example
  * ```ts
  * const state = createMachine<{
- *   idle: { value: "foo"; to: ["loading"] };
- *   loading: { input: number; value: "bar"; to: ["idle"] };
+ *   idle: { value: "foo"; to: "loading" };
+ *   loading: { input: number; value: "bar"; to: "idle" };
  * }>({
  *   initial: "idle",
  *   states: {

--- a/packages/state-machine/test/index.test.ts
+++ b/packages/state-machine/test/index.test.ts
@@ -1,14 +1,162 @@
-import { describe, test, expect } from "vitest";
-import { createRoot } from "solid-js";
-import { createPrimitiveTemplate } from "../src";
+import { describe, test, expect, vi } from "vitest";
+import { createMemo, createRoot, onCleanup, untrack } from "solid-js";
+import { createMachine } from "../src";
 
-describe("createPrimitiveTemplate", () => {
-  test("createPrimitiveTemplate return values", () =>
-    createRoot(dispose => {
-      const [value, setValue] = createPrimitiveTemplate(true);
-      expect(value(), "initial value should be true").toBe(true);
-      setValue(false);
-      expect(value(), "value after change should be false").toBe(false);
-      dispose();
+describe("createMachine", () => {
+  test("switches state", () =>
+    createRoot(() => {
+      const state = createMachine<{
+        idle: { value: "foo" };
+        loading: { value: "bar" };
+      }>({
+        initial: "idle",
+        states: {
+          idle: () => "foo",
+          loading: () => "bar",
+        },
+      });
+      const memo = createMemo(() => {
+        // track only the signal
+        const v = state();
+        return untrack(() => ({ ...v }));
+      });
+
+      expect(state.type).toBe("idle");
+      expect(state.value).toBe("foo");
+      expect(state.type).toBe(memo().type);
+      expect(state.value).toBe(memo().value);
+
+      // @ts-expect-error need to check if state is idle
+      state.to.loading();
+
+      expect(state.type).toBe("loading");
+      expect(state.value).toBe("bar");
+      expect(state.type).toBe(memo().type);
+      expect(state.value).toBe(memo().value);
+
+      if (state.type === "loading") {
+        // @ts-expect-error can't go from loading to loading
+        state.to.loading();
+
+        state.to.idle();
+      }
+
+      expect(state.type).toBe("idle");
+      expect(state.value).toBe("foo");
+      expect(state.type).toBe(memo().type);
+      expect(state.value).toBe(memo().value);
     }));
+
+  test("switches state with input", () => {
+    createRoot(() => {
+      const state = createMachine<{
+        idle: { input: string; value: any };
+        loading: { input: number; value: any };
+      }>({
+        initial: {
+          type: "idle",
+          input: "foo",
+        },
+        states: {
+          idle: i => i,
+          loading: i => i,
+        },
+      });
+
+      expect(state.type).toBe("idle");
+      expect(state.value).toBe("foo");
+
+      if (state.type === "idle") {
+        state.to.loading(1);
+      }
+
+      expect(state.type).toBe("loading");
+      expect(state.value).toBe(1);
+
+      if (state.type === "loading") {
+        state.to.idle("a");
+        state.to.idle("b");
+      }
+
+      expect(state.type).toBe("idle");
+      expect(state.value).toBe("b");
+    });
+  });
+
+  test("switches state from the callback", () => {
+    createRoot(() => {
+      const state = createMachine<{
+        idle: { value: "foo" };
+        loading: { value: "bar" };
+      }>({
+        initial: "idle",
+        states: {
+          idle: (input, to) => {
+            to.loading();
+            return "foo";
+          },
+          loading: () => "bar",
+        },
+      });
+
+      expect(state.type).toBe("loading");
+      expect(state.value).toBe("bar");
+
+      if (state.type === "loading") {
+        state.to.idle();
+      }
+
+      expect(state.type).toBe("loading");
+      expect(state.value).toBe("bar");
+    });
+  });
+
+  test("cleanup on switch", () => {
+    createRoot(dispose => {
+      const cleanups = {
+        idle: vi.fn(),
+        loading: vi.fn(),
+      };
+
+      const state = createMachine<{
+        idle: {};
+        loading: {};
+      }>({
+        initial: "idle",
+        states: {
+          idle: () => {
+            onCleanup(cleanups.idle);
+          },
+          loading: () => {
+            onCleanup(cleanups.loading);
+          },
+        },
+      });
+
+      expect(state.type).toBe("idle");
+      expect(cleanups.idle).not.toHaveBeenCalled();
+      expect(cleanups.loading).not.toHaveBeenCalled();
+
+      if (state.type === "idle") {
+        state.to.loading();
+      }
+
+      expect(state.type).toBe("loading");
+      expect(cleanups.idle).toHaveBeenCalledOnce();
+      expect(cleanups.loading).not.toHaveBeenCalled();
+
+      if (state.type === "loading") {
+        state.to.idle();
+      }
+
+      expect(state.type).toBe("idle");
+      expect(cleanups.idle).toHaveBeenCalledOnce();
+      expect(cleanups.loading).toHaveBeenCalledOnce();
+
+      dispose();
+
+      expect(cleanups.idle).toHaveBeenCalledTimes(2);
+      expect(cleanups.loading).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/state-machine/test/index.test.ts
+++ b/packages/state-machine/test/index.test.ts
@@ -79,7 +79,7 @@ describe("createMachine", () => {
       }
 
       expect(state.type).toBe("idle");
-      expect(state.value).toBe("b");
+      expect(state.value).toBe("a");
     });
   });
 

--- a/packages/state-machine/test/index.test.ts
+++ b/packages/state-machine/test/index.test.ts
@@ -1,0 +1,14 @@
+import { describe, test, expect } from "vitest";
+import { createRoot } from "solid-js";
+import { createPrimitiveTemplate } from "../src";
+
+describe("createPrimitiveTemplate", () => {
+  test("createPrimitiveTemplate return values", () =>
+    createRoot(dispose => {
+      const [value, setValue] = createPrimitiveTemplate(true);
+      expect(value(), "initial value should be true").toBe(true);
+      setValue(false);
+      expect(value(), "value after change should be false").toBe(false);
+      dispose();
+    }));
+});

--- a/packages/state-machine/test/server.test.ts
+++ b/packages/state-machine/test/server.test.ts
@@ -1,0 +1,9 @@
+import { describe, test, expect } from "vitest";
+import { createPrimitiveTemplate } from "../src";
+
+describe("createPrimitiveTemplate", () => {
+  test("doesn't break in SSR", () => {
+    const [value, setValue] = createPrimitiveTemplate(true);
+    expect(value(), "initial value should be true").toBe(true);
+  });
+});

--- a/packages/state-machine/test/server.test.ts
+++ b/packages/state-machine/test/server.test.ts
@@ -1,9 +1,19 @@
-import { describe, test, expect } from "vitest";
-import { createPrimitiveTemplate } from "../src";
+import { describe, test } from "vitest";
+import { createRoot } from "solid-js";
+import { createMachine } from "../src";
 
-describe("createPrimitiveTemplate", () => {
-  test("doesn't break in SSR", () => {
-    const [value, setValue] = createPrimitiveTemplate(true);
-    expect(value(), "initial value should be true").toBe(true);
-  });
+describe("createMachine", () => {
+  test("works", () =>
+    createRoot(() => {
+      createMachine<{
+        idle: { value: "foo" };
+        loading: { value: "bar" };
+      }>({
+        initial: "idle",
+        states: {
+          idle: () => "foo",
+          loading: () => "bar",
+        },
+      });
+    }));
 });

--- a/packages/state-machine/tsconfig.json
+++ b/packages/state-machine/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -882,6 +882,12 @@ importers:
         specifier: ^0.2.30
         version: 0.2.30(@solidjs/meta@0.28.6)(@solidjs/router@0.8.2)(solid-js@1.7.9)(solid-start-static@0.2.30)(vite@4.4.8)
 
+  packages/state-machine:
+    dependencies:
+      solid-js:
+        specifier: ^1.7.0
+        version: 1.7.9
+
   packages/static-store:
     dependencies:
       '@solid-primitives/utils':


### PR DESCRIPTION
A primitive for creating a reactive state machine. For expressing possible states and transitions, and bounding reactive computations to the lifecycle of those states.

This takes a bit different and more minimalistic approach to state machines. Maybe you cannot even call it a state machine. But I think it fits well the already very declarative capabilities of solid's reactivity, and utilizes the lifecycle of computations to scope state relevant logic.

I've been using this pattern when defining app logic that could be described using exclusive states, and relying on solid's reactivity one could very easily achieve that. But the biggest issue were types, defining unions of possible states can be very annoying, and usually will be done inconsistently because of that.
This primitive mainly helps with types, while providing slight runtime convenience utilities.

more details and examples in the [README](https://github.com/solidjs-community/solid-primitives/tree/state-machine/packages/state-machine#readme)

The story around nested machines, events, and more is still unfinished, but as a simple primitive it's already very useful.