### PR TITLE
Add full ssr cookie support to storage package

### DIFF
--- a/packages/storage/README.md
+++ b/packages/storage/README.md
@@ -9,7 +9,8 @@
 [![size](https://img.shields.io/npm/v/@solid-primitives/storage?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/storage)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-3.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
-Creates a primitive to reactively access both synchronous and asynchronous persistent storage APIs similar to `localStorage`.
+Creates a primitive to reactively access both synchronous and asynchronous persistent storage APIs similar
+to `localStorage`.
 
 ## Installation
 
@@ -24,8 +25,8 @@ yarn add @solid-primitives/storage
 `makePersisted` allows you to persist a signal or store in any synchronous or asynchronous Storage API:
 
 ```ts
-const [signal, setSignal] = makePersisted(createSignal("initial"), { storage: sessionStorage });
-const [store, setStore] = makePersisted(createStore({ test: true }), { name: "testing" });
+const [signal, setSignal] = makePersisted(createSignal("initial"), {storage: sessionStorage});
+const [store, setStore] = makePersisted(createStore({test: true}), {name: "testing"});
 type PersistedOptions<Type, StorageOptions> = {
   // localStorage is default
   storage?: Storage | StorageWithOptions | AsyncStorage | AsyncStorageWithOptions,
@@ -45,35 +46,64 @@ type PersistedOptions<Type, StorageOptions> = {
 - initial values of signals or stores are not persisted, so they can be safely changed
 - values persisted in asynchronous storage APIs will not overwrite already changed signals or stores
 - setting a persisted signal to undefined or null will remove the item from the storage
-- to use `makePersisted` with other state management APIs, you need some adapter that will project your API to either the output of `createSignal` or `createStore`
+- to use `makePersisted` with other state management APIs, you need some adapter that will project your API to either
+  the output of `createSignal` or `createStore`
 
 ### Using `makePersisted` with resources
 
-Instead of wrapping the resource itself, it is far simpler to use the `storage` option of the resource to provide a persisted signal or [deep signal](../resource/#createdeepsignal):
+Instead of wrapping the resource itself, it is far simpler to use the `storage` option of the resource to provide a
+persisted signal or [deep signal](../resource/#createdeepsignal):
 
 ```ts
-const [resource] = createResource(fetcher, { storage: makePersisted(createSignal()) });
+const [resource] = createResource(fetcher, {storage: makePersisted(createSignal())});
 ```
 
-If you are using an asynchronous storage to persist the state of a resource, it might receive an update due to being initialized from the storage before or after the fetcher resolved. If the initialization resolves after the fetcher, its result is discarded not to overwrite more current data.
+If you are using an asynchronous storage to persist the state of a resource, it might receive an update due to being
+initialized from the storage before or after the fetcher resolved. If the initialization resolves after the fetcher, its
+result is discarded not to overwrite more current data.
 
 ### Different storage APIs
 
-In the browser, we already have `localStorage`, which persists values for the same hostname indefinitely, and `sessionStorage`, which does the same for the duration of the browser session, but loses persistence after closing the browser.
+#### LocalStorage, SessionStorage
 
-As another storage, `cookieStorage` from this package can be used, which is a `localStorage`-like API to set cookies. It will work in the browser and also allows reading cookies on solid-start. Using it in the server without solid-start will not cause errors (unless you are using stackblitz), but instead emit a warning message. You can also supply your own implementations of `cookieStorage._read(key)` and `cookieStorage._write(key, value, options)` if neither of those fit your need.
+In the browser, we already have `localStorage`, which persists values for the same hostname indefinitely,
+and `sessionStorage`, which does the same for the duration of the browser session, but loses persistence after closing
+the browser.
 
-If you are not using solid-start or are using stackblitz and want to use cookieStorage on the server, you can supply optional getRequest (either something like useRequest from solid-start or a function that returns the current request) and setCookie options.
+#### CookieStorage
 
-There is also [`localForage`](https://localforage.github.io/localForage/), which uses `IndexedDB`, `WebSQL` or `localStorage` to provide an asynchronous Storage API that can ideally store much more than the few Megabytes that are available in most browsers.
+As another storage, `cookieStorage` from this package can be used, which is a `localStorage`-like API to set cookies. It
+will work in the browser and on solid-start, by parsing the `Cookie` and `Set-Cookie` header and altering
+the `Set-Cookie` header. Using it in the server without solid-start will not cause errors (unless
+you are using stackblitz), but instead emit a warning message. You can also supply your own implementations
+of `cookieStorage._read(key, options)` and `cookieStorage._write(key, value, options)` if neither of those fit your
+need.
+
+If you are not using solid-start or are using stackblitz and want to use cookieStorage on the server, you can supply
+optional `getRequest` (either something like useRequest from solid-start or a function that returns the current request)
+and `setCookie` options.
+
+When you are using vite and solid-start you want to always provide the `useRequest` function from solid start to
+the `getRequest` option, because of a technical limitation of vite.
+
+> Please mind that `cookieStorage` **doesn't care** about the path and domain when reading cookies. This might cause issues when using
+> multiple cookies with the same key, but different path or domain.
+
+#### IndexedDB, WebSQL
+
+There is also [`localForage`](https://localforage.github.io/localForage/), which uses `IndexedDB`, `WebSQL`
+or `localStorage` to provide an asynchronous Storage API that can ideally store much more than the few Megabytes that
+are available in most browsers.
 
 ---
 
 ### Deprecated primitives:
 
-The previous implementation proved to be confusing and cumbersome for most people who just wanted to persist their signals and stores, so they are now deprecated.
+The previous implementation proved to be confusing and cumbersome for most people who just wanted to persist their
+signals and stores, so they are now deprecated.
 
-`createStorage` is meant to wrap any `localStorage`-like API to be as accessible as a [Solid Store](https://www.solidjs.com/docs/latest/api#createstore). The main differences are
+`createStorage` is meant to wrap any `localStorage`-like API to be as accessible as
+a [Solid Store](https://www.solidjs.com/docs/latest/api#createstore). The main differences are
 
 - that this store is persisted in whatever API is used,
 - that you can only use the topmost layer of the object and
@@ -83,8 +113,11 @@ The previous implementation proved to be confusing and cumbersome for most peopl
 const [store, setStore, {
   remove: (key: string) => void;
   clear: () => void;
-  toJSON: () => ({ [key: string]: string });
-}] = createStorage({ api: sessionStorage, prefix: 'my-app' });
+  toJSON: () => ({[key: string]: string
+})
+;
+}]
+= createStorage({api: sessionStorage, prefix: 'my-app'});
 
 setStore('key', 'value');
 store.key; // 'value'
@@ -93,16 +126,19 @@ store.key; // 'value'
 The props object support the following parameters:
 
 `api`
-: An array of or a single `localStorage`-like storage API; default will be `localStorage` if it exists; an empty array or no API will not throw an error, but only ever get `null` and not actually persist anything
+: An array of or a single `localStorage`-like storage API; default will be `localStorage` if it exists; an empty array
+or no API will not throw an error, but only ever get `null` and not actually persist anything
 
 `prefix`
 : A string that will be prefixed every key inside the API on set and get operations
 
 `serializer / deserializer`
-: A set of function to filter the input and output; the `serializer` takes an arbitrary object and returns a string, e.g. `JSON.stringify`, whereas the `deserializer` takes a string and returns the requested object again.
+: A set of function to filter the input and output; the `serializer` takes an arbitrary object and returns a string,
+e.g. `JSON.stringify`, whereas the `deserializer` takes a string and returns the requested object again.
 
 `options`
-: For APIs that support options as third argument in the `getItem` and `setItem` method (see helper type `StorageWithOptions<O>`), you can add options they will receive on every operation.
+: For APIs that support options as third argument in the `getItem` and `setItem` method (see helper
+type `StorageWithOptions<O>`), you can add options they will receive on every operation.
 
 ---
 
@@ -118,7 +154,9 @@ createCookieStorage();
 
 #### Asynchronous storage APIs
 
-In case you have APIs that persist data on the server or via `ServiceWorker` in a [`CookieStore`](https://wicg.github.io/cookie-store/#CookieStore), you can wrap them into an asynchronous storage (`AsyncStorage` or `AsyncStorageWithOptions` API) and use them with `createAsyncStorage`:
+In case you have APIs that persist data on the server or via `ServiceWorker` in
+a [`CookieStore`](https://wicg.github.io/cookie-store/#CookieStore), you can wrap them into an asynchronous
+storage (`AsyncStorage` or `AsyncStorageWithOptions` API) and use them with `createAsyncStorage`:
 
 ```ts
 type CookieStoreOptions = {
@@ -144,36 +182,58 @@ const CookieStoreAPI: AsyncStorageWithOptions<CookieStoreOptions> = {
     const all = await cookieStore.getAll();
     return Object.keys(all)[index];
   }
-});
+}
+)
+;
 
 const [cookies, setCookie, {
-    remove: (key: string) => void;
-    clear: () => void;
-    toJSON: () => ({ [key: string]: string });
-}] = createAsyncStorage({ api: CookieStoreAPI, prefix: 'my-app', sync: false });
+  remove: (key: string) => void;
+  clear: () => void;
+  toJSON: () => ({[key: string]: string
+})
+;
+}]
+= createAsyncStorage({api: CookieStoreAPI, prefix: 'my-app', sync: false});
 
 await setStore('key', 'value');
 await store.key; // 'value'
 ```
 
-It works exactly like a synchronous storage, with the exception that you have to `await` every single return value. Once the `CookieStore` API becomes more prevalent, we will integrate support out of the box.
+It works exactly like a synchronous storage, with the exception that you have to `await` every single return value. Once
+the `CookieStore` API becomes more prevalent, we will integrate support out of the box.
 
 If you cannot use `document.cookie`, you can overwrite the entry point using the following tuple:
 
 ```ts
-import { cookieStorage } from '@solid-primitives/storage';
+import {cookieStorage} from '@solid-primitives/storage';
 
-cookieStorage._cookies = [object: { [name: string]: CookieProxy }, name: string];
+cookieStorage._cookies = [object
+:
+{
+  [name
+:
+  string
+]:
+  CookieProxy
+}
+,
+name: string
+]
+;
 ```
 
 If you need to abstract an API yourself, you can use a getter and a setter:
 
 ```ts
 const CookieAbstraction = {
-  get cookie() { return myCookieJar.toString() }
+  get cookie() {
+    return myCookieJar.toString()
+  }
   set cookie(cookie) {
     const data = {};
-    cookie.replace(/([^=]+)=(?:([^;]+);?)/g, (_, key, value) => { data[key] = value });
+    cookie.replace(/([^=]+)=(?:([^;]+);?)/g, (_, key, value) => {
+      data[key] = value
+    });
     myCookieJar.set(data);
   }
 }
@@ -182,10 +242,11 @@ cookieStorage._cookies = [CookieAbstraction, 'cookie'];
 
 ---
 
-`createStorageSignal` is meant for those cases when you only need to conveniently access a single value instead of full access to the storage API:
+`createStorageSignal` is meant for those cases when you only need to conveniently access a single value instead of full
+access to the storage API:
 
 ```ts
-const [value, setValue] = createStorageSignal("value", { api: cookieStorage });
+const [value, setValue] = createStorageSignal("value", {api: cookieStorage});
 
 setValue("value");
 value(); // 'value'
@@ -199,12 +260,15 @@ As a convenient additional method, you can also use `createCookieStorageSignal(k
 
 The properties of your `createStorage`/`createAsyncStorage`/`createStorageSignal` props are:
 
-- `api`: the (synchronous or asynchronous) [Storage-like API](https://developer.mozilla.org/de/docs/Web/API/Web_Storage_API), default is `localStorage`
+- `api`: the (synchronous or
+  asynchronous) [Storage-like API](https://developer.mozilla.org/de/docs/Web/API/Web_Storage_API), default
+  is `localStorage`
 - `deserializer` (optional): a `deserializer` or parser for the stored data
 - `serializer` (optional): a `serializer` or string converter for the stored data
 - `options` (optional): default options for the set-call of Storage-like API, if supported
 - `prefix` (optional): a prefix for the Storage keys
-- `sync` (optional): if set to false, [event synchronization](https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent) is disabled
+- `sync` (optional): if set to
+  false, [event synchronization](https://developer.mozilla.org/en-US/docs/Web/API/StorageEvent) is disabled
 
 ### Tools
 

--- a/packages/storage/src/cookies.ts
+++ b/packages/storage/src/cookies.ts
@@ -50,9 +50,7 @@ try {
 } catch (e) {
   useRequest = () => {
     // eslint-disable-next-line no-console
-    console.warn(
-      "It seems you attempt to use cookieStorage on the server without having solid-start installed",
-    );
+    console.warn("It seems you attempt to use cookieStorage on the server without having solid-start installed or use vite.");
     return {
       request: {headers: {get: () => ""}} as unknown as Request,
     } as unknown as PageEvent;
@@ -72,7 +70,7 @@ try {
  *   httpOnly?: boolean;
  *   maxAge?: number;
  *   sameSite?: "None" | "Lax" | "Strict";
- *   getRequest?: () => Request | () => PageEvent // (useRequest from solid-start)
+ *   getRequest?: () => Request | () => PageEvent // useRequest from solid-start, vite users must pass the "useRequest" from "solid-start/server" function manually
  *   setCookie?: (key, value, options) => void // set cookie on the server
  * };
  * ```

--- a/packages/storage/src/cookies.ts
+++ b/packages/storage/src/cookies.ts
@@ -152,7 +152,7 @@ export const cookieStorage: StorageWithOptions<CookieOptions> = addClearMethod({
     return length;
   },
   get length() {
-    throw new Error("CookieStorage.length is not supported, use CookieStorage.getLength() instead");
+    return this.getLength
   }
 });
 

--- a/packages/storage/src/cookies.ts
+++ b/packages/storage/src/cookies.ts
@@ -19,7 +19,7 @@ type CookieProperties = {
   sameSite?: "None" | "Lax" | "Strict";
 }
 
-const cookiePropertyKeys: (keyof CookieProperties)[] = ["domain", "expires", "path", "secure", "httpOnly", "maxAge", "sameSite"];
+const cookiePropertyKeys = ["domain", "expires", "path", "secure", "httpOnly", "maxAge", "sameSite"] as const;
 
 
 function serializeCookieOptions(options?: CookieOptions) {
@@ -28,9 +28,8 @@ function serializeCookieOptions(options?: CookieOptions) {
   }
   let memo = "";
   for (const key in options) {
-    if (!options.hasOwnProperty(key) || !cookiePropertyKeys.includes(key as keyof CookieProperties)) {
+    if (!cookiePropertyKeys.includes(key as keyof CookieProperties))
       continue;
-    }
 
     const value = options[key as keyof CookieProperties];
     memo +=
@@ -88,7 +87,7 @@ export const cookieStorage: StorageWithOptions<CookieOptions> = addClearMethod({
       if (eventOrRequest.responseHeaders) // Check if we really got a pageEvent
       {
         const responseHeaders = eventOrRequest.responseHeaders as Headers;
-        result += responseHeaders.get("Set-Cookie")?.split(",").map(cookie => !cookie.match(`\\w*\\s*=\\s*[^;]+`)).join(";") ?? "";
+        result += responseHeaders.get("Set-Cookie")?.split(",").map(cookie => !cookie.match(/\\w*\\s*=\\s*[^;]+/)).join(";") ?? "";
       }
       return `${result};${request?.headers?.get("Cookie") ?? ""}`; // because first cookie will be preferred we don't have to worry about duplicates
     }
@@ -111,9 +110,8 @@ export const cookieStorage: StorageWithOptions<CookieOptions> = addClearMethod({
     : (key: string, value: string, options?: CookieOptions) => {
       document.cookie = `${key}=${value}${serializeCookieOptions(options)}`;
     },
-  getItem: (key: string, options?: CookieOptions) => {
-    return deserializeCookieOptions(cookieStorage._read(options), key)
-  },
+  getItem: (key: string, options?: CookieOptions) =>
+    deserializeCookieOptions(cookieStorage._read(options), key),
   setItem: (key: string, value: string, options?: CookieOptions) => {
     const oldValue = isServer ? cookieStorage.getItem(key, options) : null;
     cookieStorage._write(key, value, options);

--- a/packages/storage/src/cookies.ts
+++ b/packages/storage/src/cookies.ts
@@ -150,7 +150,7 @@ export const cookieStorage: StorageWithOptions<CookieOptions> = addClearMethod({
     return length;
   },
   get length() {
-    return this.getLength
+    return this.getLength()
   }
 });
 

--- a/packages/storage/src/cookies.ts
+++ b/packages/storage/src/cookies.ts
@@ -91,7 +91,7 @@ export const cookieStorage: StorageWithOptions<CookieOptions> = addClearMethod({
       .match("(^|;)\\s*" + key + "\\s*=\\s*([^;]+)")
       ?.pop() ?? null,
   setItem: (key: string, value: string, options?: CookieOptions) => {
-    const oldValue = cookieStorage.getItem(key);
+    const oldValue = isServer ? cookieStorage.getItem(key) : null;
     cookieStorage._write(key, value, options);
     if (!isServer) {
       // Storage events are only required on client when using multiple tabs

--- a/packages/storage/src/persisted.ts
+++ b/packages/storage/src/persisted.ts
@@ -1,8 +1,8 @@
+import type {Setter, Signal} from "solid-js";
 import {createUniqueId, untrack} from "solid-js";
+import type {SetStoreFunction, Store} from "solid-js/store";
 import {reconcile} from "solid-js/store";
-import type {Accessor, Setter, Signal} from "solid-js";
-import type {Store, SetStoreFunction} from "solid-js/store";
-import type {StorageWithOptions, AsyncStorage, AsyncStorageWithOptions} from "./types.js";
+import type {AsyncStorage, AsyncStorageWithOptions, StorageWithOptions} from "./types.js";
 
 export type PersistenceBaseOptions<T> = {
   name?: string;
@@ -10,14 +10,13 @@ export type PersistenceBaseOptions<T> = {
   deserialize?: (data: string) => T;
 }
 
-export type PersistenceOptions<T, O extends Record<string, any> = {}> = PersistenceBaseOptions<T> & (
-  {
-    storage?: Storage | AsyncStorage;
-  } |
+export type PersistenceOptions<T, O extends Record<string, any>> =
+  PersistenceBaseOptions<T> & (
   {
     storage: StorageWithOptions<O> | AsyncStorageWithOptions<O>;
     storageOptions: O;
-  });
+  } |
+  { storage?: Storage | AsyncStorage; })
 
 /**
  * Persists a signal, store or similar API

--- a/packages/storage/src/persisted.ts
+++ b/packages/storage/src/persisted.ts
@@ -1,6 +1,6 @@
 import {createUniqueId, untrack} from "solid-js";
 import {reconcile} from "solid-js/store";
-import type {Accessor, Setter} from "solid-js";
+import type {Accessor, Setter, Signal} from "solid-js";
 import type {Store, SetStoreFunction} from "solid-js/store";
 import type {StorageWithOptions, AsyncStorage, AsyncStorageWithOptions} from "./types.js";
 
@@ -19,41 +19,132 @@ export type PersistenceOptions<T, O extends Record<string, any> = {}> = Persiste
     storageOptions: O;
   });
 
-/*
+/**
  * Persists a signal, store or similar API
- * ```ts
- * const [getter, setter] = makePersisted(createSignal("data"), options);
- * const options = {
- *   storage: cookieStorage,  // can be any synchronous or asynchronous storage
- *   storageOptions: { ... }, // for storages with options, otherwise not needed
- *   name: "solid-data",      // optional
- *   autoRemove: true,       // optional, removes key from storage when value is set to null or undefined
- *   serialize: (value: string) => value, // optional
- *   deserialize: (data: string) => data, // optional
- * };
- * ```
- * Can be used with `createSignal` or `createStore`. The initial value from the storage will overwrite the initial value of the signal or store unless overwritten. Overwriting a signal with `null` or `undefined` will remove the item from the storage.
+ *  ```ts
+ *  const [getter, setter] = makePersisted(createSignal("data"), options);
+ *  const options = {
+ *    storage: cookieStorage,  // can be any synchronous or asynchronous storage
+ *    storageOptions: { ... }, // for storages with options, otherwise not needed
+ *    name: "solid-data",      // optional
+ *    serialize: (value: string) => value, // optional
+ *    deserialize: (data: string) => data, // optional
+ *  };
+ *  ```
+ *  Can be used with `createSignal` or `createStore`. The initial value from the storage will overwrite the initial
+ *  value of the signal or store unless overwritten. Overwriting a signal with `null` or `undefined` will remove the
+ *  item from the storage.
+ *
+ * @param {Signal<T> | [get: Store<T>, set: SetStoreFunction<T>]} signal - The signal or store to be persisted.
+ * @param {PersistenceOptions<T, O>} options - The options for persistence.
+ * @returns {Signal<T> | [get: Store<T>, set: SetStoreFunction<T>]} - The persisted signal or store.
  */
 export function makePersisted<T>(
   signal: [Accessor<T>, Setter<T>],
   options?: PersistenceOptions<T>,
 ): [Accessor<T>, Setter<T>];
+
+
+/**
+ * Persists a signal, store or similar API
+ *  ```ts
+ *  const [getter, setter] = makePersisted(createSignal("data"), options);
+ *  const options = {
+ *    storage: cookieStorage,  // can be any synchronous or asynchronous storage
+ *    storageOptions: { ... }, // for storages with options, otherwise not needed
+ *    name: "solid-data",      // optional
+ *    serialize: (value: string) => value, // optional
+ *    deserialize: (data: string) => data, // optional
+ *  };
+ *  ```
+ *  Can be used with `createSignal` or `createStore`. The initial value from the storage will overwrite the initial
+ *  value of the signal or store unless overwritten. Overwriting a signal with `null` or `undefined` will remove the
+ *  item from the storage.
+ *
+ * @param {Signal<T> | [get: Store<T>, set: SetStoreFunction<T>]} signal - The signal or store to be persisted.
+ * @param {PersistenceOptions<T, O>} options - The options for persistence.
+ * @returns {Signal<T> | [get: Store<T>, set: SetStoreFunction<T>]} - The persisted signal or store.
+ */
 export function makePersisted<T, O extends Record<string, any>>(
-  signal: [Accessor<T>, Setter<T>],
+  signal: Signal<T>,
   options: PersistenceOptions<T, O>,
-): [Accessor<T>, Setter<T>];
+): Signal<T>;
+
+/**
+ * Persists a signal, store or similar API
+ *  ```ts
+ *  const [getter, setter] = makePersisted(createSignal("data"), options);
+ *  const options = {
+ *    storage: cookieStorage,  // can be any synchronous or asynchronous storage
+ *    storageOptions: { ... }, // for storages with options, otherwise not needed
+ *    name: "solid-data",      // optional
+ *    serialize: (value: string) => value, // optional
+ *    deserialize: (data: string) => data, // optional
+ *  };
+ *  ```
+ *  Can be used with `createSignal` or `createStore`. The initial value from the storage will overwrite the initial
+ *  value of the signal or store unless overwritten. Overwriting a signal with `null` or `undefined` will remove the
+ *  item from the storage.
+ *
+ * @param {Signal<T> | [get: Store<T>, set: SetStoreFunction<T>]} signal - The signal or store to be persisted.
+ * @param {PersistenceOptions<T, O>} options - The options for persistence.
+ * @returns {Signal<T> | [get: Store<T>, set: SetStoreFunction<T>]} - The persisted signal or store.
+ */
 export function makePersisted<T>(
-  signal: [Store<T>, SetStoreFunction<T>],
+  signal: [get: Store<T>, set: SetStoreFunction<T>],
   options?: PersistenceOptions<T>,
-): [Store<T>, SetStoreFunction<T>];
+): [get: Store<T>, set: SetStoreFunction<T>];
+
+/**
+ * Persists a signal, store or similar API
+ *  ```ts
+ *  const [getter, setter] = makePersisted(createSignal("data"), options);
+ *  const options = {
+ *    storage: cookieStorage,  // can be any synchronous or asynchronous storage
+ *    storageOptions: { ... }, // for storages with options, otherwise not needed
+ *    name: "solid-data",      // optional
+ *    serialize: (value: string) => value, // optional
+ *    deserialize: (data: string) => data, // optional
+ *  };
+ *  ```
+ *  Can be used with `createSignal` or `createStore`. The initial value from the storage will overwrite the initial
+ *  value of the signal or store unless overwritten. Overwriting a signal with `null` or `undefined` will remove the
+ *  item from the storage.
+ *
+ * @param {Signal<T> | [get: Store<T>, set: SetStoreFunction<T>]} signal - The signal or store to be persisted.
+ * @param {PersistenceOptions<T, O>} options - The options for persistence.
+ * @returns {Signal<T> | [get: Store<T>, set: SetStoreFunction<T>]} - The persisted signal or store.
+ */
 export function makePersisted<T, O extends Record<string, any>>(
-  signal: [Store<T>, SetStoreFunction<T>],
+  signal: [get: Store<T>, set: SetStoreFunction<T>],
   options: PersistenceOptions<T, O>,
-): [Store<T>, SetStoreFunction<T>];
+): [get: Store<T>, set: SetStoreFunction<T>];
+
+
+/**
+ * Persists a signal, store or similar API
+ *  ```ts
+ *  const [getter, setter] = makePersisted(createSignal("data"), options);
+ *  const options = {
+ *    storage: cookieStorage,  // can be any synchronous or asynchronous storage
+ *    storageOptions: { ... }, // for storages with options, otherwise not needed
+ *    name: "solid-data",      // optional
+ *    serialize: (value: string) => value, // optional
+ *    deserialize: (data: string) => data, // optional
+ *  };
+ *  ```
+ *  Can be used with `createSignal` or `createStore`. The initial value from the storage will overwrite the initial
+ *  value of the signal or store unless overwritten. Overwriting a signal with `null` or `undefined` will remove the
+ *  item from the storage.
+ *
+ * @param {Signal<T> | [get: Store<T>, set: SetStoreFunction<T>]} signal - The signal or store to be persisted.
+ * @param {PersistenceOptions<T, O>} options - The options for persistence.
+ * @returns {Signal<T> | [get: Store<T>, set: SetStoreFunction<T>]} - The persisted signal or store.
+ */
 export function makePersisted<T, O extends Record<string, any> = {}>(
-  signal: [Accessor<T>, Setter<T>] | [Store<T>, SetStoreFunction<T>],
+  signal: Signal<T> | [get: Store<T>, set: SetStoreFunction<T>],
   options: PersistenceOptions<T, O> = {},
-): [Accessor<T>, Setter<T>] | [Store<T>, SetStoreFunction<T>] {
+): Signal<T> | [get: Store<T>, set: SetStoreFunction<T>] {
   const storage = options.storage || globalThis.localStorage;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!storage) {
@@ -81,7 +172,7 @@ export function makePersisted<T, O extends Record<string, any> = {}>(
       ? (value?: T | ((prev: T) => T)) => {
         const output = (signal[1] as Setter<T>)(value as any);
 
-        if (value != null)
+        if (value)
           storage.setItem(name, serialize(output), storageOptions);
         else
           storage.removeItem(name, storageOptions);

--- a/packages/storage/src/persisted.ts
+++ b/packages/storage/src/persisted.ts
@@ -1,4 +1,4 @@
-import type {Setter, Signal} from "solid-js";
+import type {Accessor, Setter, Signal} from "solid-js";
 import {createUniqueId, untrack} from "solid-js";
 import type {SetStoreFunction, Store} from "solid-js/store";
 import {reconcile} from "solid-js/store";
@@ -40,7 +40,7 @@ export type PersistenceOptions<T, O extends Record<string, any>> =
  */
 export function makePersisted<T>(
   signal: [Accessor<T>, Setter<T>],
-  options?: PersistenceOptions<T>,
+  options?: PersistenceOptions<T,{}>,
 ): [Accessor<T>, Setter<T>];
 
 
@@ -91,7 +91,7 @@ export function makePersisted<T, O extends Record<string, any>>(
  */
 export function makePersisted<T>(
   signal: [get: Store<T>, set: SetStoreFunction<T>],
-  options?: PersistenceOptions<T>,
+  options?: PersistenceOptions<T,{}>,
 ): [get: Store<T>, set: SetStoreFunction<T>];
 
 /**

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -1,12 +1,13 @@
 export type StorageWithOptions<O> = {
-  clear: () => void;
+  clear: (options?: O) => void;
   getItem: (key: string, options?: O) => string | null;
-  getAll?: () => { [key: string]: any };
+  getAll?: (options?: O) => { [key: string]: any };
   setItem: (key: string, value: string, options?: O) => void;
-  removeItem: (key: string) => void;
-  key: (index: number) => string | null;
+  removeItem: (key: string, options?: O) => void;
+  key: (index: number, options?: O) => string | null;
+  getLength: (options?: O) => number | undefined;
   readonly length: number | undefined;
-  [key: string]: any;
+  [name: string]: any;
 };
 
 export type StorageDeserializer<T, O> = (value: string, key: string, options?: O) => T;

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -7,7 +7,7 @@ export type StorageWithOptions<O> = {
   key: (index: number, options?: O) => string | null;
   getLength?: (options?: O) => number | undefined;
   readonly length: number | undefined;
-  [name: string]: any;
+  [key: string]: any;
 };
 
 export type StorageDeserializer<T, O> = (value: string, key: string, options?: O) => T;

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -5,7 +5,7 @@ export type StorageWithOptions<O> = {
   setItem: (key: string, value: string, options?: O) => void;
   removeItem: (key: string, options?: O) => void;
   key: (index: number, options?: O) => string | null;
-  getLength: (options?: O) => number | undefined;
+  getLength?: (options?: O) => number | undefined;
   readonly length: number | undefined;
   [name: string]: any;
 };


### PR DESCRIPTION
Before there were issues when just setting a cookie using storage api on server and you set a custom setCookie it fails when it tries to raise an Event on server, because the URL api is only available on the client.

Additionally i have added full support for the "Set-Cookie" header so that when the server sets a cookie this automatically gets passed to the client. This only works if a PageEvent is returned by getRequest, because i obviously have to access the responseHeaders. I tried to make everything as backwards compatible as possible.

There is one thing to think about in the future, cookies are not only identified by their key, but by the combination of key, path and domain. The code currently and before assumed that key is the only primary identifier.

Now the StorageOptions should be passed to every storage method, when possible, because cookiestorage requires the getRequest method to access responseHeaders on vite. This is a known limitation of vite that we cannot dynamically import libraries therefore vite users (as me) must set the getRequest option manually. This is documented!

When reading cookies responseHeaders is obviously also checked so that the server can set the cookie without having to deal with a wrong get value.