### PR TITLE
Update `start` README with Examples Section for `createUserTheme`

### DIFF
--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -95,9 +95,11 @@ import {
 import Counter from "./components/Counter";
 import "./root.css";
 import { createUserTheme } from '~/primitives/start';
+
 export default function Root() {
-  const [theme, setTheme] = createUserTheme("dark-light-theme", "dark");
+  const [theme, setTheme] = createUserTheme("dark-light-theme", { defaultValue: "dark" });
   const toggleTheme = () => setTheme(currentTheme => currentTheme === "dark" ? "light" : "dark");
+
   return (
     // Set data-theme when using libraries like Daisyui:
     <Html lang="en" data-theme={theme()}>
@@ -116,9 +118,7 @@ export default function Root() {
               "light-variant": theme() === "light",
             }}
           />
-          <button
-            onClick={toggleTheme}
-          >
+          <button onClick={toggleTheme}>
             <span>Toggle Theme</span>
           </button>
         </div>
@@ -149,7 +149,6 @@ body.dark {
   background-color: black;
   color: aliceblue;
 }
-
 body.light {
   background-color: aliceblue;
   color: black;
@@ -158,11 +157,9 @@ body.light {
 .dark span {
   color: #b1d4ff;
 }
-
 .light span {
   color: #003677;
 }
-
 ```
 
 ### `Counter.css`

--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -79,7 +79,6 @@ This is the main entry file for SolidStart demonstrating usage of the `createUse
 - Provides additional examples on using variant classes to style components.
 
 ```tsx
-// @refresh reload
 import { Suspense } from "solid-js";
 import {
   A,
@@ -95,7 +94,7 @@ import {
 } from "solid-start";
 import Counter from "./components/Counter";
 import "./root.css";
-import { createUserTheme } from "./start_primitive/index";
+import { createUserTheme } from '~/primitives/start';
 export default function Root() {
   const [theme, setTheme] = createUserTheme("dark-light-theme", "dark");
   const toggleTheme = () => setTheme(currentTheme => currentTheme === "dark" ? "light" : "dark");
@@ -107,16 +106,12 @@ export default function Root() {
         <Meta charset="utf-8" />
         <Meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      <Body
-        classList={{
-          // Apply theme as css class to body:
-          [theme()]: true,
-        }}
-      >
+      // Apply theme as a class to the Body element:
+      <Body class={theme()}>
         <div>
           <Counter
             classList={{
-              // Within components conditionally apply css classes:
+              // Within components apply theme-dependent classes/variants:
               "dark-variant": theme() !== "light",
               "light-variant": theme() === "light",
             }}

--- a/packages/start/README.md
+++ b/packages/start/README.md
@@ -66,6 +66,122 @@ const [theme, setTheme] = createUserTheme("cookieName", {
 theme(); // => "light" | "dark"
 ```
 
+
+## Examples
+
+### `root.tsx`
+
+This is the main entry file for SolidStart demonstrating usage of the `createUserTheme` function.
+- Initializes the theme with the `createUserTheme` function.
+- Toggles between the "dark" and "light" themes using a button.
+- Sets the `data-theme` attribute adding compatibility between `createUserTheme` and libraries like [DaisyUI](https://daisyui.com/).
+- Includes a clean implementation of theming through a `Body` class.
+- Provides additional examples on using variant classes to style components.
+
+```tsx
+// @refresh reload
+import { Suspense } from "solid-js";
+import {
+  A,
+  Body,
+  ErrorBoundary,
+  FileRoutes,
+  Head,
+  Html,
+  Meta,
+  Routes,
+  Scripts,
+  Title,
+} from "solid-start";
+import Counter from "./components/Counter";
+import "./root.css";
+import { createUserTheme } from "./start_primitive/index";
+export default function Root() {
+  const [theme, setTheme] = createUserTheme("dark-light-theme", "dark");
+  const toggleTheme = () => setTheme(currentTheme => currentTheme === "dark" ? "light" : "dark");
+  return (
+    // Set data-theme when using libraries like Daisyui:
+    <Html lang="en" data-theme={theme()}>
+      <Head>
+        <Title>SolidStart - Bare</Title>
+        <Meta charset="utf-8" />
+        <Meta name="viewport" content="width=device-width, initial-scale=1" />
+      </Head>
+      <Body
+        classList={{
+          // Apply theme as css class to body:
+          [theme()]: true,
+        }}
+      >
+        <div>
+          <Counter
+            classList={{
+              // Within components conditionally apply css classes:
+              "dark-variant": theme() !== "light",
+              "light-variant": theme() === "light",
+            }}
+          />
+          <button
+            onClick={toggleTheme}
+          >
+            <span>Toggle Theme</span>
+          </button>
+        </div>
+        <Scripts />
+      </Body>
+    </Html>
+  );
+}
+
+```
+
+### `root.css`
+
+Here is an absolute basic CSS file to demonstrate styling with the themes.
+- The `body` selector has general styles.
+- The `.dark` and `.light` classes provide specific styles for each theme.
+- The `.dark span` and `.light span` selectors show how to style specific elements based on the theme.
+
+```css
+body {
+  font-family: Gordita, Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans",
+    "Helvetica Neue", sans-serif;
+  height: "100vh";
+  width: "100vh";
+}
+
+body.dark {
+  background-color: black;
+  color: aliceblue;
+}
+
+body.light {
+  background-color: aliceblue;
+  color: black;
+}
+
+.dark span {
+  color: #b1d4ff;
+}
+
+.light span {
+  color: #003677;
+}
+
+```
+
+### `Counter.css`
+
+Continuation of the basic CSS scoped to the component using variant classes.
+```css
+.dark-variant {
+  border: 2px solid #569cf3;
+}
+
+.light-variant {
+  border: 2px solid #05ff22;
+}
+```
 ## Demo
 
 You can view a demo of this primitive here: <https://codesandbox.io/p/sandbox/amazing-easley-wqk38i?file=%2Fsrc%2Fstart_primitive%2Findex.ts%3A36%2C20>


### PR DESCRIPTION
Added an Examples section to the `README.md` file that includes code snippets from `root.tsx`, `root.css` and `Counter.css`.