### PR TITLE
Fix ReactiveMap iterators tracking

### DIFF
--- a/.changeset/angry-planes-shout.md
+++ b/.changeset/angry-planes-shout.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/set": patch
+---
+
+Fix ReactiveSet iterators tracking

--- a/.changeset/fresh-panthers-nail.md
+++ b/.changeset/fresh-panthers-nail.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/map": patch
+---
+
+Fix ReactiveMap iterators tracking

--- a/packages/map/src/index.ts
+++ b/packages/map/src/index.ts
@@ -43,19 +43,26 @@ export class ReactiveMap<K, V> extends Map<K, V> {
     return super.size;
   }
 
-  keys(): IterableIterator<K> {
+  *keys(): IterableIterator<K> {
+    for (const key of super.keys()) {
+      this.#keyTriggers.track(key);
+      yield key;
+    }
     this.#keyTriggers.track($KEYS);
-    return super.keys();
   }
-  values(): IterableIterator<V> {
+  *values(): IterableIterator<V> {
+    for (const [key, v] of super.entries()) {
+      this.#valueTriggers.track(key);
+      yield v;
+    }
     this.#keyTriggers.track($KEYS);
-    for (const v of super.keys()) this.#valueTriggers.track(v);
-    return super.values();
   }
-  entries(): IterableIterator<[K, V]> {
+  *entries(): IterableIterator<[K, V]> {
+    for (const entry of super.entries()) {
+      this.#valueTriggers.track(entry[0]);
+      yield entry;
+    }
     this.#keyTriggers.track($KEYS);
-    for (const v of super.keys()) this.#valueTriggers.track(v);
-    return super.entries();
   }
 
   // writes
@@ -99,7 +106,10 @@ export class ReactiveMap<K, V> extends Map<K, V> {
   // callback
   forEach(callbackfn: (value: V, key: K, map: this) => void) {
     this.#keyTriggers.track($KEYS);
-    super.forEach((value, key) => callbackfn(value, key, this));
+    for (const [key, v] of super.entries()) {
+      this.#valueTriggers.track(key);
+      callbackfn(v, key, this);
+    }
   }
 
   [Symbol.iterator](): IterableIterator<[K, V]> {

--- a/packages/set/src/index.ts
+++ b/packages/set/src/index.ts
@@ -23,10 +23,43 @@ export class ReactiveSet<T> extends Set<T> {
     if (values) for (const v of values) super.add(v);
   }
 
+  // reads
+  get size(): number {
+    this.#triggers.track($KEYS);
+    return super.size;
+  }
   has(v: T): boolean {
     this.#triggers.track(v);
     return super.has(v);
   }
+
+  *keys(): IterableIterator<T> {
+    for (const key of super.keys()) {
+      this.#triggers.track(key);
+      yield key;
+    }
+    this.#triggers.track($KEYS);
+  }
+  values(): IterableIterator<T> {
+    return this.keys();
+  }
+  *entries(): IterableIterator<[T, T]> {
+    for (const key of super.keys()) {
+      this.#triggers.track(key);
+      yield [key, key];
+    }
+    this.#triggers.track($KEYS);
+  }
+
+  [Symbol.iterator](): IterableIterator<T> {
+    return this.values();
+  }
+  forEach(callbackfn: (value: T, value2: T, set: this) => void) {
+    this.#triggers.track($KEYS);
+    super.forEach(callbackfn as any);
+  }
+
+  // writes
   add(v: T): this {
     if (!super.has(v)) {
       super.add(v);
@@ -55,29 +88,6 @@ export class ReactiveSet<T> extends Set<T> {
         this.#triggers.dirty($KEYS);
       });
     }
-  }
-  forEach(callbackfn: (value: T, value2: T, set: this) => void) {
-    this.#triggers.track($KEYS);
-    super.forEach(callbackfn as any);
-  }
-  values(): IterableIterator<T> {
-    this.#triggers.track($KEYS);
-    return super.values();
-  }
-  keys(): IterableIterator<T> {
-    return this.values();
-  }
-  entries(): IterableIterator<[T, T]> {
-    this.#triggers.track($KEYS);
-    return super.entries();
-  }
-  get size(): number {
-    this.#triggers.track($KEYS);
-    return super.size;
-  }
-
-  [Symbol.iterator](): IterableIterator<T> {
-    return this.values();
   }
 }
 


### PR DESCRIPTION
- `.forEach()` wasn't tracking changes to values, only keys

- `.keys()`, `.entries()` and `.values()` was tracking any changes to keys, even if the key was not seen
	Also some were iterating the map twice

- Same for `ReactiveSet`