### PR TITLE
websocket: fix heartbeat reconnect

### DIFF
--- a/.changeset/eighty-sheep-travel.md
+++ b/.changeset/eighty-sheep-travel.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/websocket": minor
+---
+
+bugfix: setup heartbeat after reconnect

--- a/packages/websocket/src/index.ts
+++ b/packages/websocket/src/index.ts
@@ -195,12 +195,13 @@ export const makeHeartbeatWS = (
     clearTimers();
     pongtimer = setTimeout(ws.reconnect, options.wait || 1500);
   };
-  ws.addEventListener("close", clearTimers);
   const receiveMessage = () => {
     clearTimers();
     pingtimer = setTimeout(() => ws.send(options.message || "ping"), options.interval || 1000);
   };
+  ws.addEventListener("close", clearTimers);
   ws.addEventListener("message", receiveMessage);
-  setTimeout(receiveMessage, options.interval || 1000);
+  ws.addEventListener("open", () => setTimeout(receiveMessage, options.interval || 1000));
   return ws;
 };
+


### PR DESCRIPTION
Unfortunately, I forgot to set up the heartbeat after the reconnect. By moving this setup into the open event, it will be repeated for a reconnected web socket connection. This resolves [issue#528](https://github.com/solidjs-community/solid-primitives/issues/528).