### PR TITLE
Add triggerIdle function to manually trigger idle state - Fixes #503

### DIFF
--- a/.changeset/twenty-bikes-cheer.md
+++ b/.changeset/twenty-bikes-cheer.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/idle": minor
+---
+
+Add triggerIdle function to manually trigger idle state - Fixes #503

--- a/packages/idle/README.md
+++ b/packages/idle/README.md
@@ -53,6 +53,7 @@ To interact with the timers, `createIdleTimer` provides:
 
 - **isIdle** and **isPrompted**: `Accessor<boolean>`; these two accessors report the user status. They do not concur.
 - **start**, **stop** and **reset**: `() => void`; allow rispectively to start and stop the timers, and to reset them. `start` and `reset`, create a custom `manualstart` and `manualreset` event, that will be passed to the `onIdle` and `onPrompt` callbacks if no oher activity occurs (there's another custom event, `mount`, created when timers start automatically). Finally `stop` and `reset` don't trigger `onActive`.
+- **triggerIdle**: `() => void`; manually sets `isIdle` to true, and triggers the `onIdle` callback, passing a custom `manualidle` event. It doesn't trigger `onActive` or `onPrompt`. 
 
 ### Configuration options
 

--- a/packages/idle/dev/index.tsx
+++ b/packages/idle/dev/index.tsx
@@ -14,7 +14,7 @@ const divStyle = {
 };
 
 const App: Component = () => {
-  const { isIdle, isPrompted, start, stop, reset } = createIdleTimer({
+  const { isIdle, isPrompted, start, stop, reset, triggerIdle } = createIdleTimer({
     onActive: evt => console.log("this event re-activated me ⚡ => ", evt),
     onIdle: evt => console.log("last event before I went to sleep 😴 => ", evt),
     idleTimeout: 3_000,
@@ -28,6 +28,7 @@ const App: Component = () => {
           <button onClick={stop}>stop</button>
           <button onClick={start}>start</button>
           <button onClick={reset}>reset</button>
+          <button onClick={triggerIdle}>trigger idle</button>
         </>
       }
     >

--- a/packages/idle/src/types.ts
+++ b/packages/idle/src/types.ts
@@ -2,21 +2,87 @@ import { Accessor } from "solid-js";
 
 export type EventTypeName = keyof HTMLElementEventMap | keyof DocumentEventMap;
 
+/**
+ * An option object to initialize the timer.
+ */
 export interface IdleTimerOptions {
+  /**
+   * The DOM events that will be listened to in order to monitor the user's activity.
+   * @default ['mousemove', 'keydown', 'wheel', 'resize', 'mousedown', 'pointerdown', 'touchstart', 'touchmove', 'visibilitychange']
+   */
   events?: EventTypeName[];
+  /**
+   * DOM element to which the event listeners will be attached.
+   * @default document
+   */
   element?: HTMLElement;
+  /**
+   * Time of user's inactivity in milliseconds before the idle status changes to idle. 
+   * This time is extended by the promptTimeout option.
+   * @default 900000 (15 minutes)
+   */
   idleTimeout?: number;
+  /**
+   * To meet the typical use case when we want to prompt the user to check if they are still active, an additional timer starts running right after the idleTimeout expires. 
+   * In this time slot, the user is in the prompt phase, whose duration is decided by promptTimeout.
+   * onActive is not fired in this phase, which cn only be interrupted by the methods reset, stop, pause, triggerIdle.
+   * @default 0
+  */
   promptTimeout?: number;
+  /**
+   * Requires the event-listeners to be bound manually by using the start method, instead of on mount.
+   * @default false
+   */
   startManually?: boolean;
+  /**
+   * Callback triggered when the user status passes to idle. When invoked, the last event fired before the prompt phase will be passed as a parameter.
+   * @param {Event} lastEvt - the last event fired before the prompt phase. Events fired in the prompt phase will not count.
+   * @returns {void}
+   * @default () => {}
+   */
   onIdle?: (lastEvt: Event) => void;
+  /**
+   * Callback called when the user resumes activity after having been idle (resuming from prompt phase doesn't trigger `onActive`).
+   * @param {Event} activyEvt - the last event fired before the prompt phase.
+   * @returns {void}
+   * @default () => {}
+   */
   onActive?: (activyEvt: Event) => void;
+  /**
+   * Callback triggered when the idleTimeout timer expires, before declaring the idle status, onPrompt callback is fired, starting the prompt timer.
+   * @param {Event} promptEvt - the last event fired before the prompt phase.
+   * @returns {void}
+   * @default () => {}
+   */
   onPrompt?: (promptEvt: Event) => void;
 }
 
-export interface IdleTimerReturn {
+/**
+ * The instance of the idle timer
+ */
+export interface IdleTimer {
+  /**
+   * Shows when the user is idle
+   */
   isIdle: Accessor<boolean>;
+  /**
+   * Tells whether onPrompt has been called or not, and consequently if the promptTimeout countdown has started
+   */
   isPrompted: Accessor<boolean>;
+  /**
+   * Resets timers, doesn't trigger onActive
+   */
   reset: () => void;
+  /**
+   * Adds listeners and starts timers, doesn't trigger onActive
+   */
   start: () => void;
+  /**
+   * Removes listeners and cleans up the timers, doesn't trigger onActive.
+   */
   stop: () => void;
+  /**
+   * Set the idle status to idle and trigger the onIdle callback. Doesn't trigger onActive or onPrompt.
+   */
+  triggerIdle: () => void;
 }

--- a/packages/idle/src/types.ts
+++ b/packages/idle/src/types.ts
@@ -86,3 +86,10 @@ export interface IdleTimer {
    */
   triggerIdle: () => void;
 }
+
+/**
+ * @deprecated 
+ * IdleTimerReturn has been renamed to IdleTimer for clarity and coherence. 
+ * Please use IdleTimer instead.
+ */
+export type IdleTimerReturn = IdleTimer;

--- a/packages/idle/test/index.test.ts
+++ b/packages/idle/test/index.test.ts
@@ -10,6 +10,7 @@ beforeEach(() => {
 
 afterAll(() => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
 });
 
 describe("createIdleTimer", () => {
@@ -75,6 +76,57 @@ describe("createIdleTimer", () => {
     ).toBe(false);
 
     timer.dispose();
+  });
+
+  test("triggerIdle should set isIdle to true, call onIdle, and attach the event listener", () => {
+    const element = document.createElement("div");
+    const handleIdle = vi.fn();
+    const handleActive = vi.fn();
+    const handlePrompt = vi.fn();
+
+    const timer = createRoot(dispose => {
+      const timer = createIdleTimer({
+        element,
+        events: ["click"],
+        idleTimeout: 10,
+        onActive: handleActive,
+        onIdle: handleIdle,
+        onPrompt: handlePrompt,
+        startManually: true,
+      });
+
+      return { ...timer, dispose };
+    });
+
+    expect(timer.isIdle(), "user is not idle yet").toBe(false);
+
+    timer.triggerIdle();
+
+    expect(timer.isIdle(), "user is now idle").toBe(true);
+    expect(handleIdle, "onIdle should have been called").toHaveBeenCalled();
+    expect(
+      handleIdle.mock.calls[0][0].type,
+      "onIdle's parmeter should be a custom manualidle event",
+    ).toEqual("manualidle");
+    expect(handlePrompt, "onPrompt should not have been called").not.toHaveBeenCalled();
+    expect(handleActive, "onActive should not have been called").not.toHaveBeenCalled();
+
+    element.click();
+    expect(timer.isIdle(), "listenes should still be working and user is not idle anymore").toBe(
+      false,
+    );
+    expect(handleActive, "onActive should have been called").toHaveBeenCalled();
+
+    vi.advanceTimersByTime(15);
+    expect(
+      timer.isIdle(),
+      "the primitive's flow has not changed, user is idle again after idle timeout expires",
+    ).toBe(true);
+
+    timer.stop();
+    timer.dispose();
+
+    [handleActive, handleIdle, handlePrompt].forEach(fn => fn.mockRestore());
   });
 
   test("configuration options shall work", () => {


### PR DESCRIPTION
This pull request addresses the issue [#503](https://github.com/solidjs-community/solid-primitives/issues/503).

Currently, the `createIdleTimer` primitive does not provide a way to manually trigger the idle state. This pull request adds a new method called `triggerIdle` to the IdleTimer instance returned this primitive. The `triggerIdle` function sets the `isIdle` state to true, triggers the `onIdle` callback bypassing the prompt phase, and attaches listeners to the specified events that will call the `onActive` function if triggered. 

JSDoc and type definition were improved for better understanding and clarity.

cc. @itamarsch
