### PR TITLE
Remove unused type exports in utils

### DIFF
--- a/.changeset/curly-beds-explode.md
+++ b/.changeset/curly-beds-explode.md
@@ -1,0 +1,6 @@
+---
+"@solid-primitives/jsx-tokenizer": patch
+"@solid-primitives/utils": patch
+---
+
+Remove unused type exports in utils (`ResolvedJSXElement` and `ResolvedChildren`)

--- a/packages/jsx-tokenizer/src/index.ts
+++ b/packages/jsx-tokenizer/src/index.ts
@@ -1,6 +1,6 @@
-import { Accessor, Component, createComponent, createMemo, JSX, DEV } from "solid-js";
+import { Accessor, Component, createComponent, createMemo, JSX, DEV, ResolvedJSXElement } from "solid-js";
 import { isServer } from "solid-js/web";
-import type { ResolvedJSXElement, NoInfer, Many } from "@solid-primitives/utils";
+import type { NoInfer, Many } from "@solid-primitives/utils";
 import { asArray } from "@solid-primitives/utils";
 
 /** @internal $TYPE is only used for type inference */

--- a/packages/refs/src/index.ts
+++ b/packages/refs/src/index.ts
@@ -2,8 +2,6 @@ import { chain, arrayEquals } from "@solid-primitives/utils";
 import { Accessor, children, createComputed, createMemo, JSX, onCleanup, untrack } from "solid-js";
 import { isServer } from "solid-js/web";
 
-export type { ResolvedChildren, ResolvedJSXElement } from "@solid-primitives/utils";
-
 /**
  * Type for the `ref` prop
  */

--- a/packages/refs/src/index.ts
+++ b/packages/refs/src/index.ts
@@ -2,6 +2,9 @@ import { chain, arrayEquals } from "@solid-primitives/utils";
 import { Accessor, children, createComputed, createMemo, JSX, onCleanup, untrack } from "solid-js";
 import { isServer } from "solid-js/web";
 
+// TODO delete in next major version
+export type { ResolvedChildren, ResolvedJSXElement } from "solid-js/types/reactive/signal.js";
+
 /**
  * Type for the `ref` prop
  */

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -2,6 +2,12 @@ import type { Accessor, Setter } from "solid-js";
 
 export type { EffectOptions, OnOptions } from "solid-js";
 
+// export types can be deleted in the next major
+export type {
+  ResolvedJSXElement,
+  ResolvedChildren,
+} from "solid-js/types/reactive/signal.js";
+
 /**
  * Can be single or in an array
  */

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -2,12 +2,6 @@ import type { Accessor, Setter } from "solid-js";
 
 export type { EffectOptions, OnOptions } from "solid-js";
 
-// export types that aren't exported by solid-js main module
-export type {
-  ResolvedJSXElement,
-  ResolvedChildren,
-} from "../node_modules/solid-js/types/reactive/signal.js";
-
 /**
  * Can be single or in an array
  */

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -2,7 +2,7 @@ import type { Accessor, Setter } from "solid-js";
 
 export type { EffectOptions, OnOptions } from "solid-js";
 
-// export types can be deleted in the next major
+// TODO delete in next major version
 export type {
   ResolvedJSXElement,
   ResolvedChildren,


### PR DESCRIPTION
This commit removes the ResolvedJSXElement and ResolvedChildren type exports from the types.ts file in the utils package. These types were previously imported from the solid-js library but are no longer needed
because now they are properly exported by solid-js.

This may break existing code, but only the imports and nothing else therefore a simple changelog entry should do the trick.

Please consider merging, because my build fails due to this import, because this import doesn't work always when using `pnpm`