### PR TITLE
Fix package.json homepages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "solid-primitives",
   "private": true,
   "description": "A collection of high-quality, community contributed building blocks.",
+  "homepage": "https://primitives.solidjs.community/",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/active-element/package.json
+++ b/packages/active-element/package.json
@@ -7,7 +7,7 @@
     "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/active-element#readme",
+  "homepage": "https://primitives.solidjs.community/package/active-element",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive that makes managing analytics a lot easier.",
   "author": "David Di Biase <dave.dibiase@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/analytics",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/analytics#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/analytics"

--- a/packages/audio/package.json
+++ b/packages/audio/package.json
@@ -4,7 +4,7 @@
   "description": "Primitives to manage audio and single sounds.",
   "author": "David Di Biase <dave.dibiase@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/audio",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/audio#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/audio/package.json
+++ b/packages/audio/package.json
@@ -4,7 +4,7 @@
   "description": "Primitives to manage audio and single sounds.",
   "author": "David Di Biase <dave.dibiase@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/audio#readme",
+  "homepage": "https://primitives.solidjs.community/package/audio",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/autofocus/package.json
+++ b/packages/autofocus/package.json
@@ -5,7 +5,7 @@
   "author": "jer3m01 <jer3m01@jer3m01.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/autofocus#readme",
+  "homepage": "https://primitives.solidjs.community/package/autofocus",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/bounds/package.json
+++ b/packages/bounds/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/bounds#readme",
+  "homepage": "https://primitives.solidjs.community/package/bounds",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/broadcast-channel/package.json
+++ b/packages/broadcast-channel/package.json
@@ -5,7 +5,7 @@
   "author": "Caleb Taylor <aquaductape@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/broadcast-channel#readme",
+  "homepage": "https://primitives.solidjs.community/package/broadcast-channel",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/clipboard/package.json
+++ b/packages/clipboard/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/clipboard#readme",
+  "homepage": "https://primitives.solidjs.community/package/clipboard",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/clipboard/package.json
+++ b/packages/clipboard/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/clipboard",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/clipboard#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/connectivity/package.json
+++ b/packages/connectivity/package.json
@@ -8,7 +8,7 @@
     "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/utils#readme",
+  "homepage": "https://primitives.solidjs.community/package/connectivity",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/context/package.json
+++ b/packages/context/package.json
@@ -4,7 +4,7 @@
   "description": "Primitives simplifying or extending the SolidJS Context API",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/context#readme",
+  "homepage": "https://primitives.solidjs.community/package/context",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/controlled-props/package.json
+++ b/packages/controlled-props/package.json
@@ -5,7 +5,7 @@
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/controlled-props",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/controlled-props#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/controlled-props/package.json
+++ b/packages/controlled-props/package.json
@@ -5,7 +5,7 @@
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/controlled-props#readme",
+  "homepage": "https://primitives.solidjs.community/package/controlled-props",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/cursor/package.json
+++ b/packages/cursor/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/cursor#readme",
+  "homepage": "https://primitives.solidjs.community/package/cursor",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -4,7 +4,7 @@
   "description": "Collection of reactive primitives and utility functions, providing easier ways to deal with dates in SolidJS",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/date",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/date#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/date/package.json
+++ b/packages/date/package.json
@@ -4,7 +4,7 @@
   "description": "Collection of reactive primitives and utility functions, providing easier ways to deal with dates in SolidJS",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/date#readme",
+  "homepage": "https://primitives.solidjs.community/package/date",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/deep/package.json
+++ b/packages/deep/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/deep#readme",
+  "homepage": "https://primitives.solidjs.community/package/deep",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/destructure/package.json
+++ b/packages/destructure/package.json
@@ -4,7 +4,7 @@
   "description": "Primitives for destructuring reactive objects – like props or stores – or signals of them into a separate accessors updated individually.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/destructure#readme",
+  "homepage": "https://primitives.solidjs.community/package/destructure",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/devices/package.json
+++ b/packages/devices/package.json
@@ -7,7 +7,7 @@
     "Mohan <mohanavel15@protonmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/devices#readme",
+  "homepage": "https://primitives.solidjs.community/package/devices",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/event-bus/package.json
+++ b/packages/event-bus/package.json
@@ -4,7 +4,7 @@
   "description": "A collection of SolidJS primitives providing various features of a pubsub/event-emitter/event-bus.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/event-bus#readme",
+  "homepage": "https://primitives.solidjs.community/package/event-bus",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/event-dispatcher/package.json
+++ b/packages/event-dispatcher/package.json
@@ -5,7 +5,7 @@
   "author": "Aylo Srd <aylo.srd@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/event-dispatcher#readme",
+  "homepage": "https://primitives.solidjs.community/package/event-dispatcher",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/event-listener/package.json
+++ b/packages/event-listener/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/event-listener#readme",
+  "homepage": "https://primitives.solidjs.community/package/event-listener",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/event-listener/package.json
+++ b/packages/event-listener/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/event-listener",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/event-listener#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/event-props/package.json
+++ b/packages/event-props/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive to manage events in a reactive way.",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/event-props",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/event-props#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/event-props/package.json
+++ b/packages/event-props/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive to manage events in a reactive way.",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/event-props#readme",
+  "homepage": "https://primitives.solidjs.community/package/event-props",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive that wraps fetch requests",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/fetch",
+  "homepage": "https://primitives.solidjs.community/package/fetch",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/filesystem/package.json
+++ b/packages/filesystem/package.json
@@ -5,7 +5,7 @@
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/filesystem#readme",
+  "homepage": "https://primitives.solidjs.community/package/filesystem",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/flux-store/package.json
+++ b/packages/flux-store/package.json
@@ -5,7 +5,7 @@
   "author": "Zalexios <zalexios@outlook.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/flux-store#readme",
+  "homepage": "https://primitives.solidjs.community/package/flux-store",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/fullscreen/package.json
+++ b/packages/fullscreen/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive that wraps the fullscreen API.",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/fetch",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/fullscreen#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/fullscreen/package.json
+++ b/packages/fullscreen/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive that wraps the fullscreen API.",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/fullscreen#readme",
+  "homepage": "https://primitives.solidjs.community/package/fullscreen",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/geolocation/package.json
+++ b/packages/geolocation/package.json
@@ -4,7 +4,7 @@
   "description": "Primitives to query geolocation and observe changes.",
   "author": "David Di Biase <dave.dibiase@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/geolocation#readme",
+  "homepage": "https://primitives.solidjs.community/package/geolocation",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/geolocation/package.json
+++ b/packages/geolocation/package.json
@@ -4,7 +4,7 @@
   "description": "Primitives to query geolocation and observe changes.",
   "author": "David Di Biase <dave.dibiase@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/geolocation",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/geolocation#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/gestures/package.json
+++ b/packages/gestures/package.json
@@ -4,6 +4,11 @@
   "description": "Directives to react to gestures",
   "author": "Moshe Uminer",
   "license": "MIT",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/gestures#readme", 
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solidjs-community/solid-primitives.git"
+  },
   "keywords": [
     "gesture",
     "gestures",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -8,7 +8,7 @@
     "Alex Ryapolov"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/graphql",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/graphql#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/graphql"

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -8,7 +8,7 @@
     "Alex Ryapolov"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/graphql#readme",
+  "homepage": "https://primitives.solidjs.community/package/graphql",
   "repository": {
     "type": "git",
     "url": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/graphql"

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/history#readme",
+  "homepage": "https://primitives.solidjs.community/package/history",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -9,7 +9,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/i18n#readme",
+  "homepage": "https://primitives.solidjs.community/package/i18n",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -9,7 +9,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/i18n",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/i18n#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/idle/package.json
+++ b/packages/idle/package.json
@@ -5,7 +5,7 @@
   "author": "Aylo Srd <aylo.srd@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/idle#readme",
+  "homepage": "https://primitives.solidjs.community/package/idle",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/immutable/package.json
+++ b/packages/immutable/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/immutable#readme",
+  "homepage": "https://primitives.solidjs.community/package/immutable",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/input-mask/package.json
+++ b/packages/input-mask/package.json
@@ -5,7 +5,7 @@
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/input-mask#readme",
+  "homepage": "https://primitives.solidjs.community/package/input-mask",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/intersection-observer/package.json
+++ b/packages/intersection-observer/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/intersection-observer",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/intersection-observer#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/intersection-observer/package.json
+++ b/packages/intersection-observer/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/intersection-observer#readme",
+  "homepage": "https://primitives.solidjs.community/package/intersection-observer",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/jsx-tokenizer/package.json
+++ b/packages/jsx-tokenizer/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/jsx-tokenizer#readme",
+  "homepage": "https://primitives.solidjs.community/package/jsx-tokenizer",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnwski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/keyboard#readme",
+  "homepage": "https://primitives.solidjs.community/package/keyboard",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/keyed/package.json
+++ b/packages/keyed/package.json
@@ -4,7 +4,7 @@
   "description": "Control Flow primitives and components that require specifying explicit keys to identify or rerender elements.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/keyed#readme",
+  "homepage": "https://primitives.solidjs.community/package/keyed",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/lifecycle/package.json
+++ b/packages/lifecycle/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/lifecycle#readme",
+  "homepage": "https://primitives.solidjs.community/package/lifecycle",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -4,7 +4,7 @@
   "description": "The Map & WeakMap data structures as a reactive signals.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/utils#readme",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/map#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/map/package.json
+++ b/packages/map/package.json
@@ -4,7 +4,7 @@
   "description": "The Map & WeakMap data structures as a reactive signals.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/map#readme",
+  "homepage": "https://primitives.solidjs.community/package/map",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/marker/package.json
+++ b/packages/marker/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/marker#readme",
+  "homepage": "https://primitives.solidjs.community/package/marker",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/masonry/package.json
+++ b/packages/masonry/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/masonry#readme",
+  "homepage": "https://primitives.solidjs.community/package/masonry",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -13,7 +13,7 @@
     "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/media",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/media#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -13,7 +13,7 @@
     "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/media#readme",
+  "homepage": "https://primitives.solidjs.community/package/media",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/memo/package.json
+++ b/packages/memo/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/memo#readme",
+  "homepage": "https://primitives.solidjs.community/package/memo",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/mouse/package.json
+++ b/packages/mouse/package.json
@@ -4,7 +4,7 @@
   "description": "A collection of Solid Primitives, that capture current mouse cursor position, and help to deal with common related usecases.",
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/mouse#readme",
+  "homepage": "https://primitives.solidjs.community/package/mouse",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/mutable/package.json
+++ b/packages/mutable/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/mutable#readme",
+  "homepage": "https://primitives.solidjs.community/package/mutable",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/mutation-observer/package.json
+++ b/packages/mutation-observer/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive providing the ability to watch for changes made to the DOM tree.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/mutation-observer",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/mutation-observer#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/mutation-observer/package.json
+++ b/packages/mutation-observer/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive providing the ability to watch for changes made to the DOM tree.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/mutation-observer#readme",
+  "homepage": "https://primitives.solidjs.community/package/mutation-observer",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/page-visibility/package.json
+++ b/packages/page-visibility/package.json
@@ -8,7 +8,7 @@
     "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/page-visibility",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/page-visibility#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/page-visibility/package.json
+++ b/packages/page-visibility/package.json
@@ -8,7 +8,7 @@
     "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/page-visibility#readme",
+  "homepage": "https://primitives.solidjs.community/package/page-visibility",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -8,7 +8,7 @@
     "Mohan <mohanavel15@protonmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/pagination#readme",
+  "homepage": "https://primitives.solidjs.community/package/pagination",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/permission/package.json
+++ b/packages/permission/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive that wraps permission queries",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/permission#readme",
+  "homepage": "https://primitives.solidjs.community/package/permission",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/permission/package.json
+++ b/packages/permission/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive that wraps permission queries",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/permission",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/permission#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/platform/package.json
+++ b/packages/platform/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/platform#readme",
+  "homepage": "https://primitives.solidjs.community/package/platform",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/pointer/package.json
+++ b/packages/pointer/package.json
@@ -4,7 +4,7 @@
   "description": "A collection of primitives, giving you a nicer API to handle pointer events in a reactive context.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/pointer#readme",
+  "homepage": "https://primitives.solidjs.community/package/pointer",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/presence/package.json
+++ b/packages/presence/package.json
@@ -4,7 +4,7 @@
   "description": "Utility to animate the presence of an element based on the existence of data or lack thereof.",
   "author": "Ethan Standel <ethan@standel.io>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/presence#readme",
+  "homepage": "https://primitives.solidjs.community/package/presence",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/promise/package.json
+++ b/packages/promise/package.json
@@ -4,7 +4,7 @@
   "description": "Promised one-time watch for changes. Await a reactive condition.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/promise#readme",
+  "homepage": "https://primitives.solidjs.community/package/promise",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/promise/package.json
+++ b/packages/promise/package.json
@@ -4,7 +4,7 @@
   "description": "Promised one-time watch for changes. Await a reactive condition.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/utils#readme",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/promise#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/props/package.json
+++ b/packages/props/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/props",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/props#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/props/package.json
+++ b/packages/props/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/props#readme",
+  "homepage": "https://primitives.solidjs.community/package/props",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/raf/package.json
+++ b/packages/raf/package.json
@@ -8,7 +8,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/raf#readme",
+  "homepage": "https://primitives.solidjs.community/package/raf",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/raf/package.json
+++ b/packages/raf/package.json
@@ -8,7 +8,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/raf",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/raf#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/range/package.json
+++ b/packages/range/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/range#readme",
+  "homepage": "https://primitives.solidjs.community/package/range",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/refs/package.json
+++ b/packages/refs/package.json
@@ -4,7 +4,7 @@
   "description": "Library of primitives, components and directives for SolidJS that help managing references to JSX elements.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/refs#readme",
+  "homepage": "https://primitives.solidjs.community/package/refs",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/resize-observer/package.json
+++ b/packages/resize-observer/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/resize-observer#readme",
+  "homepage": "https://primitives.solidjs.community/package/resize-observer",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/resize-observer/package.json
+++ b/packages/resize-observer/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/resize-observer",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/resize-observer#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/resource/package.json
+++ b/packages/resource/package.json
@@ -5,7 +5,7 @@
   "author": "Alex <alex.lohr@goto.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/resource#readme",
+  "homepage": "https://primitives.solidjs.community/package/resource",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/rootless/package.json
+++ b/packages/rootless/package.json
@@ -4,7 +4,7 @@
   "description": "A collection of helpers that aim to simplify using reactive primitives outside of reactive roots, and managing disposal of reactive roots.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/rootless#readme",
+  "homepage": "https://primitives.solidjs.community/package/rootless",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/scheduled/package.json
+++ b/packages/scheduled/package.json
@@ -8,7 +8,7 @@
     "Jonathan Frere <jonathan.frere@esveo.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/scheduled#readme",
+  "homepage": "https://primitives.solidjs.community/package/scheduled",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/script-loader/package.json
+++ b/packages/script-loader/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/script-loader#readme",
+  "homepage": "https://primitives.solidjs.community/package/script-loader",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/script-loader/package.json
+++ b/packages/script-loader/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/script",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/script-loader#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/scroll/package.json
+++ b/packages/scroll/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/scroll#readme",
+  "homepage": "https://primitives.solidjs.community/package/scroll",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/scroll/package.json
+++ b/packages/scroll/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/scroll",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/scroll#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/selection/package.json
+++ b/packages/selection/package.json
@@ -5,7 +5,7 @@
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/selection#readme",
+  "homepage": "https://primitives.solidjs.community/package/selection",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/set/package.json
+++ b/packages/set/package.json
@@ -4,7 +4,7 @@
   "description": "The Set & WeakSet data structures as a reactive signals.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/utils#readme",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/set#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/set/package.json
+++ b/packages/set/package.json
@@ -4,7 +4,7 @@
   "description": "The Set & WeakSet data structures as a reactive signals.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/set#readme",
+  "homepage": "https://primitives.solidjs.community/package/set",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/share/package.json
+++ b/packages/share/package.json
@@ -8,7 +8,7 @@
     "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/share#readme",
+  "homepage": "https://primitives.solidjs.community/package/share",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/share/package.json
+++ b/packages/share/package.json
@@ -8,7 +8,7 @@
     "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/share",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/share#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/signal-builders/package.json
+++ b/packages/signal-builders/package.json
@@ -4,7 +4,7 @@
   "description": "A collection of chainable and composable reactive signal calculations, aka Signal Builders.",
   "author": "Your Name <you@youremail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/signal-builders#readme",
+  "homepage": "https://primitives.solidjs.community/package/signal-builders",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/start/package.json
+++ b/packages/start/package.json
@@ -7,7 +7,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/start#readme",
+  "homepage": "https://primitives.solidjs.community/package/start",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/state-machine/package.json
+++ b/packages/state-machine/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/state-machine#readme",
+  "homepage": "https://primitives.solidjs.community/package/state-machine",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/static-store/package.json
+++ b/packages/static-store/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/static-store#readme",
+  "homepage": "https://primitives.solidjs.community/package/static-store",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -7,7 +7,7 @@
     "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/storage#readme",
+  "homepage": "https://primitives.solidjs.community/package/storage",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -7,7 +7,7 @@
     "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/storage",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/storage#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive that gets a user media stream from microphone, camera or screen",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/stream#readme",
+  "homepage": "https://primitives.solidjs.community/package/stream",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive that gets a user media stream from microphone, camera or screen",
   "author": "Alex Lohr <alex.lohr@logmein.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/stream",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/stream#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -7,7 +7,7 @@
     "Tom Pichaud <dev.tompichaud@icloud.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/styles#readme",
+  "homepage": "https://primitives.solidjs.community/package/styles",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/timer/package.json
+++ b/packages/timer/package.json
@@ -8,7 +8,7 @@
     "Damian Tarnawski <gthetarnav@gmail.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/timer#readme",
+  "homepage": "https://primitives.solidjs.community/package/timer",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/transition-group/package.json
+++ b/packages/transition-group/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/transition-group#readme",
+  "homepage": "https://primitives.solidjs.community/package/transition-group",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/trigger/package.json
+++ b/packages/trigger/package.json
@@ -5,7 +5,7 @@
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/trigger#readme",
+  "homepage": "https://primitives.solidjs.community/package/trigger",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/tween/package.json
+++ b/packages/tween/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive that creates tween functions",
   "author": "Ryan Carniato <ryancarniato@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/tween#readme",
+  "homepage": "https://primitives.solidjs.community/package/tween",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/tween/package.json
+++ b/packages/tween/package.json
@@ -4,7 +4,7 @@
   "description": "Primitive that creates tween functions",
   "author": "Ryan Carniato <ryancarniato@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/tween",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/tween#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -4,7 +4,7 @@
   "description": "Primitives for uploading files.",
   "author": "Rustam Ashurmatov <rr.ashurmatov.21@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/upload",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/upload#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/upload/package.json
+++ b/packages/upload/package.json
@@ -4,7 +4,7 @@
   "description": "Primitives for uploading files.",
   "author": "Rustam Ashurmatov <rr.ashurmatov.21@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/upload#readme",
+  "homepage": "https://primitives.solidjs.community/package/upload",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -7,7 +7,7 @@
     "Alex Lohr <alex.lohr@logmein.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/websocket#readme",
+  "homepage": "https://primitives.solidjs.community/package/websocket",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/websocket/package.json
+++ b/packages/websocket/package.json
@@ -7,7 +7,7 @@
     "Alex Lohr <alex.lohr@logmein.com>"
   ],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/websocket",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/websocket#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -4,7 +4,7 @@
   "description": "Primitives that support creating Web Workers.",
   "author": "David Di Biase <dave.dibiase@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/workers#readme",
+  "homepage": "https://primitives.solidjs.community/package/workers",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -4,7 +4,7 @@
   "description": "Primitives that support creating Web Workers.",
   "author": "David Di Biase <dave.dibiase@gmail.com>",
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/workers",
+  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/workers#readme",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"

--- a/template/package.json
+++ b/template/package.json
@@ -5,7 +5,7 @@
   "author": "Your Name <you@youremail.com>",
   "contributors": [],
   "license": "MIT",
-  "homepage": "https://github.com/solidjs-community/solid-primitives/tree/main/packages/template-primitive#readme",
+  "homepage": "https://primitives.solidjs.community/package/template-primitive",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/solidjs-community/solid-primitives.git"


### PR DESCRIPTION
As agreed on Discord, this PR fixes all `homepage` fields in packages to point to the correct package on `primitives.solidjs.community`.