### PR TITLE
Make `props` argument optional

### DIFF
--- a/packages/pagination/src/index.ts
+++ b/packages/pagination/src/index.ts
@@ -268,26 +268,29 @@ export type _E = JSX.Element;
  * @method `end` is a boolean indicator for end of the page
  * @method `setEnd` allows to manually change the end
  */
-export function createInfiniteScroll<T>(fetcher: (page: number) => Promise<T[]>): [
+export function createInfiniteScroll<T, C extends number | string>(
+  fetcher: (page: C) => Promise<T[]>,
+  getNextCursorValue: (pages: Accessor<T[]>, cursorValue?: C) => C,
+): [
   pages: Accessor<T[]>,
   loader: (el: Element) => void,
   options: {
-    page: Accessor<number>;
-    setPage: Setter<number>;
+    cursor: Accessor<C>;
+    setCursor: Setter<C>;
     setPages: Setter<T[]>;
     end: Accessor<boolean>;
     setEnd: Setter<boolean>;
   },
 ] {
   const [pages, setPages] = createSignal<T[]>([]);
-  const [page, setPage] = createSignal(0);
+  const [cursor, setCursor] = createSignal(getNextCursorValue(pages));
   const [end, setEnd] = createSignal(false);
 
   let add: (el: Element) => void = noop;
   if (!isServer) {
     const io = new IntersectionObserver(e => {
       if (e.length > 0 && e[0]!.isIntersecting && !end() && !contents.loading) {
-        setPage(p => p + 1);
+        setCursor(p => getNextCursorValue(pages, p));
       }
     });
     onCleanup(() => io.disconnect());
@@ -297,7 +300,7 @@ export function createInfiniteScroll<T>(fetcher: (page: number) => Promise<T[]>)
     };
   }
 
-  const [contents] = createResource(page, fetcher);
+  const [contents] = createResource(cursor, fetcher);
 
   createComputed(() => {
     const content = contents.latest;
@@ -312,8 +315,8 @@ export function createInfiniteScroll<T>(fetcher: (page: number) => Promise<T[]>)
     pages,
     add,
     {
-      page: page,
-      setPage: setPage,
+      cursor: cursor,
+      setCursor: setCursor,
       setPages: setPages,
       end: end,
       setEnd: setEnd,

--- a/packages/pagination/src/index.ts
+++ b/packages/pagination/src/index.ts
@@ -270,7 +270,7 @@ export type _E = JSX.Element;
  */
 export function createInfiniteScroll<T>(fetcher: (page: number) => Promise<T[]>): [
   pages: Accessor<T[]>,
-  loader: Directive,
+  loader: (el: Element) => void,
   options: {
     page: Accessor<number>;
     setPage: Setter<number>;

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -13,7 +13,7 @@ export type Values<O extends Object> = O[keyof O];
 
 export type Noop = (...a: any[]) => void;
 
-export type Directive<P = true> = (el: Element, props?: Accessor<P>) => void;
+export type Directive<P = true> = (el: Element, props: Accessor<P>) => void;
 
 /**
  * Infers the type of the array elements

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -13,7 +13,7 @@ export type Values<O extends Object> = O[keyof O];
 
 export type Noop = (...a: any[]) => void;
 
-export type Directive<P = true> = (el: Element, props: Accessor<P>) => void;
+export type Directive<P = true> = (el: Element, props?: Accessor<P>) => void;
 
 /**
  * Infers the type of the array elements


### PR DESCRIPTION
The signature for the `Directive` doesn't allow it to be used as a ref as shown in the docs. If the props are optional then the function signature matches.

![image](https://github.com/solidjs-community/solid-primitives/assets/133859854/c53fbc5c-9041-4885-844d-d12a59f1b461)
