### PR TITLE
Fix dev dark mode color

### DIFF
--- a/site/src/root.scss
+++ b/site/src/root.scss
@@ -262,10 +262,6 @@ html.dark .prose {
   --tw-prose-bold: #98a3b1 !important;
 }
 
-html.dark body {
-  color: #000;
-}
-
 html {
   background: var(--page-main-bg);
 


### PR DESCRIPTION
The text color of badges would be black under dark mode in local dev
<img width="675" alt="image" src="https://github.com/solidjs-community/solid-primitives/assets/5362563/e1adb012-f348-4616-b235-608e1fbaa25d">
