### PR TITLE
Add back the return statement to withOptions

### DIFF
--- a/.changeset/stale-llamas-repair.md
+++ b/.changeset/stale-llamas-repair.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/storage": minor
+---
+
+Add back the return statement to withOptions

--- a/packages/storage/src/tools.ts
+++ b/packages/storage/src/tools.ts
@@ -36,7 +36,7 @@ export const addWithOptionsMethod = <
         if (typeof storage[key] === "function") {
           (wrapped as any)[key] = (...args: Parameters<(typeof storage)[typeof key]>) => {
             args[storage[key].length - 1] = options;
-            storage[key](...args);
+            return storage[key](...args);
           };
         }
         return wrapped;


### PR DESCRIPTION
The `return` statement was removed by mistake in pull https://github.com/solidjs-community/solid-primitives/pull/606

This caused `makePersisted` to use the default value on the server side.

This PR adds back the implicit `return` statement.