### PR TITLE
Fix `trackStore` tracking multiple same-object references. (Fixes #582)

### DIFF
--- a/.changeset/beige-suits-add.md
+++ b/.changeset/beige-suits-add.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/deep": patch
+---
+
+Fix `trackStore` tracking multiple same-object references. (Fixes #582)

--- a/packages/deep/test/track.test.ts
+++ b/packages/deep/test/track.test.ts
@@ -3,21 +3,34 @@ import { batch, createEffect, createRoot, createSignal } from "solid-js";
 import { captureStoreUpdates, trackDeep, trackStore } from "../src/index.js";
 import { createStore, reconcile, unwrap } from "solid-js/store";
 
-const fns = {
-  trackDeep: store => () => trackDeep(store),
-  trackStore: store => () => trackStore(store),
-  captureUpdates: captureStoreUpdates,
-} as const satisfies Record<string, (store: any) => () => void>;
-type FnKeys = keyof typeof fns;
+const apis: {
+  name: string
+  fn  : (store: any) => () => void,
+  pojo: boolean,
+}[] = [
+  {
+    name: "trackDeep",
+    fn  : store => () => trackDeep(store),
+    pojo: true,
+  },
+  {
+    name: "trackStore",
+    fn  : store => () => trackStore(store),
+    pojo: false,
+  },
+  {
+    name: "captureUpdates",
+    fn  : captureStoreUpdates,
+    pojo: false,
+  },
+];
 
-const worksWithPOJO: FnKeys[] = ["trackDeep"];
-
-for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[FnKeys]][]) {
-  describe(fnName, () => {
+for (const api of apis) {
+  describe(api.name, () => {
     test("captures property change", () => {
       const [sign, set] = createStore({ a: { "a.b": "thoughts" }, b: "foo" });
 
-      const fn = createFn(sign);
+      const fn = api.fn(sign);
 
       let runs = 0;
       createRoot(() => {
@@ -38,7 +51,7 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
 
     test("multiple effects", () => {
       const [sign, set] = createStore({ a: { "a.b": "thoughts" }, b: "foo" });
-      const fn = createFn(sign);
+      const fn = api.fn(sign);
 
       let runs = 0;
       createRoot(() => {
@@ -63,7 +76,7 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
 
     test("multiple changes", () => {
       const [sign, set] = createStore({ a: { "a.b": "thoughts" }, b: "foo" });
-      const fn = createFn(sign);
+      const fn = api.fn(sign);
 
       let runs = 0;
       createRoot(() => {
@@ -83,7 +96,7 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
 
     test("adding new property", () => {
       const [sign, set] = createStore<any>({ a: { "a.b": "thoughts" } });
-      const fn = createFn(sign);
+      const fn = api.fn(sign);
 
       let runs = 0;
       createRoot(() => {
@@ -100,7 +113,7 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
 
     test("removing property", () => {
       const [sign, set] = createStore({ a: { "a.b": "thoughts" }, b: "foo" as string | undefined });
-      const fn = createFn(sign);
+      const fn = api.fn(sign);
 
       let runs = 0;
       createRoot(() => {
@@ -117,7 +130,7 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
 
     test("changing objects", () => {
       const [sign, set] = createStore({ a: { "a.b": "thoughts" } });
-      const fn = createFn(sign);
+      const fn = api.fn(sign);
 
       let runs = 0;
       createRoot(() => {
@@ -137,7 +150,7 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
 
     test("array reorder", () => {
       const [sign, set] = createStore({ a: [1, 2, 3] });
-      const fn = createFn(sign);
+      const fn = api.fn(sign);
 
       let runs = 0;
       createRoot(() => {
@@ -153,49 +166,123 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
     });
 
     test("circular reference", () => {
-      const [sign, set] = createStore<any>({ a: { "a.b": "thoughts" } });
-      set("a", { "a.a": sign });
-      const fn = createFn(sign);
+      type Ref = {ref: Ref, count: number};
+      const ref: Ref = {ref: null as any, count: 0}
+      ref.ref = ref
 
-      let rootRuns = 0;
+      const [sign, set] = createStore(ref)
+      const fn = api.fn(sign)
+
+      let runs = 0
       createRoot(() => {
         createEffect(() => {
-          fn();
-          rootRuns++;
-        });
-      });
+          fn()
+          runs += 1
+        })
+      })
+      expect(runs).toBe(1)
 
-      let leafRuns = 0;
+      set("count", 1)
+      expect(runs).toBe(2)
+    })
+
+    test("circular reference, two effects", () => {
+      type Ref = {ref: Ref, count: number};
+      const ref: Ref = {ref: null as any, count: 0}
+      ref.ref = ref
+
+      const [sign, set] = createStore(ref)
+      const fn_root = api.fn(sign)
+      const fn_leaf = api.fn(sign.ref)
+
+      let runs_root = 0
+      let runs_leaf = 0
+
       createRoot(() => {
-        const a = sign.a;
-        const fn = createFn(a);
         createEffect(() => {
-          fn();
-          leafRuns++;
-        });
-      });
-      expect(rootRuns).toBe(1);
-      expect(leafRuns).toBe(1);
+          fn_root()
+          runs_root += 1
+        })
+        createEffect(() => {
+          fn_leaf()
+          runs_leaf += 1
+        })
+      })
+      
+      expect(runs_root).toBe(1)
+      expect(runs_leaf).toBe(1)
 
-      set("a", "a.b", "minds");
-      expect(rootRuns).toBe(2);
-      expect(leafRuns).toBe(2);
+      set("count", 1)
+      expect(runs_root).toBe(2)
+      expect(runs_leaf).toBe(2)
+    })
 
-      set("a", "a.a", "a.a.b", "thoughts");
-      expect(rootRuns).toBe(3);
-      expect(leafRuns).toBe(3);
-    });
+    test("multiple references", () => {
+      const obj = {count: 0}
+      const [sign, set] = createStore({a: obj, b: obj})
+
+      const fn = api.fn(sign)
+
+      let runs = 0
+      createRoot(() => {
+        createEffect(() => {
+          fn()
+          runs++
+        })
+      })
+
+      expect(runs).toBe(1)
+
+      set("a", "count", 1)
+      expect(runs).toBe(2)
+
+      set("b", "count", 2)
+      expect(runs).toBe(3)
+    })
+
+    test("multiple references, two effects", () => {
+      const obj = {count: 0}
+      const [sign, set] = createStore({a: obj, b: obj})
+
+      const fn_a = api.fn(sign.a)
+      const fn_b = api.fn(sign.b)
+
+      let runs_a = 0
+      let runs_b = 0
+
+      createRoot(() => {
+        createEffect(() => {
+          fn_a()
+          runs_a++
+        })
+        createEffect(() => {
+          fn_b()
+          runs_b++
+        })
+      })
+
+      expect(runs_a).toBe(1)
+      expect(runs_b).toBe(1)
+
+      set("a", "count", 1)
+      expect(runs_a).toBe(2)
+      expect(runs_b).toBe(2)
+
+      set("b", "count", 2)
+      expect(runs_a).toBe(3)
+      expect(runs_b).toBe(3)
+    })
 
     test("doesn't trigger on unrelated changes", () => {
       const [sign, set] = createStore<any>({ a: { "a.b": "thoughts" } });
-      const fn = createFn(sign);
+      const fn = api.fn(sign);
 
       let runs = 0;
       createRoot(() => {
         createEffect(() => fn);
         const a = sign.a;
         createEffect(() => {
-          createFn(a);
+          api.fn(a);
           runs++;
         });
       });
@@ -207,7 +294,7 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
 
     test("reconcile", () => {
       const [sign, set] = createStore<any>({ a: { "a.b": "thoughts" } });
-      const fn = createFn(sign);
+      const fn = api.fn(sign);
 
       let runs = 0;
       createRoot(() => {
@@ -228,7 +315,7 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
     test("unwrapped", () => {
       const [sign, set] = createStore({ a: { "a.b": "thoughts" } });
       const unwrapped = unwrap(sign);
-      const fn = createFn(unwrapped);
+      const fn = api.fn(unwrapped);
 
       let runs = 0;
       createRoot(() => {
@@ -245,7 +332,7 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
 
     test("traversing POJOs", () => {
       const [sign, set] = createStore({ a: { "a.b": "thoughts" } });
-      const fn = createFn({ sign });
+      const fn = api.fn({ sign });
 
       let runs = 0;
       createRoot(() => {
@@ -257,7 +344,11 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
       expect(runs).toBe(1);
 
       set("a", "a.b", "minds");
-      expect(runs).toBe(worksWithPOJO.includes(fnName) ? 2 : 1);
+      if (api.pojo) {
+        expect(runs).toBe(2);
+      } else {
+        expect(runs).toBe(1);
+      }
     });
 
     test("getters", () => {
@@ -268,7 +359,7 @@ for (const [fnName, createFn] of Object.entries(fns) as [FnKeys, (typeof fns)[Fn
         },
       });
 
-      const fn = createFn(sign);
+      const fn = api.fn(sign);
 
       let runs = 0;
       createRoot(() => {


### PR DESCRIPTION
Seems like I made an error when writing a test.
`set("a", "a.a", "a.a.b", "thoughts")`
instead of
`set("a", "a.a", "a", "a.b", "thoughts")`
which caused me to make a flawed implementation to satisfy the test 🫠
seems to be good now
