### PR TITLE
raf: add createMs primitive

### DIFF
--- a/.changeset/dry-tips-kneel.md
+++ b/.changeset/dry-tips-kneel.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/raf": minor
+---
+
+add createMs primitive

--- a/packages/raf/README.md
+++ b/packages/raf/README.md
@@ -84,6 +84,30 @@ function targetFPS(
 ): FrameRequestCallback;
 ```
 
+## createMs
+
+Using createRAF and targetFPS to create a reactive milliseconds counter with configurable frame rate.
+
+It takes the framerate as single argument, either as `number` or `Accessor<number>`.
+
+```ts
+import { createMs } from "@solid-primitives/raf";
+
+const ms = createMs(60);
+
+const MovingRect() {
+  return <rect x="0" y="0" width={1000 / 3000 * Math.min(ms(), 3000)} height="10" />;
+}
+```
+
+#### Defintion
+
+```ts
+function createMs(
+  fps: MaybeAccessor<number>,
+): Accessor<number>;
+```
+
 ## Demo
 
 You may view a working example here: https://codesandbox.io/s/solid-primitives-raf-demo-4xvmjd?file=/src/index.tsx

--- a/packages/raf/README.md
+++ b/packages/raf/README.md
@@ -86,16 +86,20 @@ function targetFPS(
 
 ## createMs
 
-Using createRAF and targetFPS to create a reactive milliseconds counter with configurable frame rate.
+Using createRAF and targetFPS to create a signal giving the passed milliseconds since it was called with a configurable frame rate, with some added methods for more control:
 
-It takes the framerate as single argument, either as `number` or `Accessor<number>`.
+- `reset()`: manually resetting the counter
+- `running()`: returns if the counter is currently setRunning
+- `start()`: restarts the counter if stopped
+- `stop()`: stops the counter if running
 
-```ts
+It takes the framerate as single argument, either as `number` or `Accessor<number>`. It also accepts the limit as an optional second argument, either as `number` or `Accessor<number>`; the counter is reset if the limit is passed.
+
+```tsx
 import { createMs } from "@solid-primitives/raf";
 
-const ms = createMs(60);
-
 const MovingRect() {
+  const ms = createMs(60);
   return <rect x="0" y="0" width={1000 / 3000 * Math.min(ms(), 3000)} height="10" />;
 }
 ```
@@ -105,7 +109,13 @@ const MovingRect() {
 ```ts
 function createMs(
   fps: MaybeAccessor<number>,
-): Accessor<number>;
+  limit?: MaybeAccessor<number>
+): Accessor<number> & { 
+  reset: () => void;
+  running: () => boolean;
+  start: () => void;
+  stop: () => void;
+};
 ```
 
 ## Demo

--- a/packages/raf/package.json
+++ b/packages/raf/package.json
@@ -18,6 +18,7 @@
     "stage": 3,
     "list": [
       "createRAF",
+      "createMs",
       "targetFPS"
     ],
     "category": "Animation"

--- a/packages/raf/src/index.ts
+++ b/packages/raf/src/index.ts
@@ -87,4 +87,24 @@ function targetFPS(
   };
 }
 
-export { createRAF, createRAF as default, targetFPS };
+/**
+ * A primitive that creates a reactive milliseconds signal with a given frame rate to base your animations on.
+ *
+ * ```ts
+ * const ms = createMs(60);
+ * return <rect x="0" y="0" height="10" width={Math.min(100, ms() / 5000)} />
+ * ```
+ */
+function createMs(fps: MaybeAccessor<number>) {
+  const [ms, setMs] = createSignal(0);
+  let initialTs = 0;
+  const [_, start, stop] = createRAF(targetFPS((ts) => {
+    initialTs ||= ts;
+    setMs(ts - initialTs);
+  }, fps));
+  start();
+  onCleanup(stop);
+  return ms;
+}
+
+export { createMs, createRAF, createRAF as default, targetFPS };

--- a/packages/raf/src/index.ts
+++ b/packages/raf/src/index.ts
@@ -69,9 +69,9 @@ function targetFPS(
     typeof fps === "function"
       ? createMemo(() => Math.floor(1000 / fps()))
       : (() => {
-          const newInterval = Math.floor(1000 / fps);
-          return () => newInterval;
-        })();
+        const newInterval = Math.floor(1000 / fps);
+        return () => newInterval;
+      })();
 
   let elapsed = 0;
   let lastRun = 0;
@@ -87,24 +87,48 @@ function targetFPS(
   };
 }
 
+export type MsCounter = (() => number) & {
+  reset: () => void;
+  running: () => boolean;
+  start: () => void;
+  stop: () => void;
+};
+
 /**
- * A primitive that creates a reactive milliseconds signal with a given frame rate to base your animations on.
+ * A primitive that creates a signal counting up milliseconds with a given frame rate to base your animations on.
+ *
+ * @param fps the frame rate, either as Accessor or number
+ * @param limit an optional limit, either as Accessor or number, after which the counter is reset
+ *
+ * @returns an Accessor returning the current number of milliseconds and the following methods:
+ * - `reset()`: manually resetting the counter
+ * - `running()`: returns if the counter is currently setRunning
+ * - `start()`: restarts the counter if stopped
+ * - `stop()`: stops the counter if running
  *
  * ```ts
  * const ms = createMs(60);
+ * createEffect(() => ms() > 500000 ? ms.stop());
  * return <rect x="0" y="0" height="10" width={Math.min(100, ms() / 5000)} />
  * ```
  */
-function createMs(fps: MaybeAccessor<number>) {
+function createMs(fps: MaybeAccessor<number>, limit?: MaybeAccessor<number>): MsCounter {
   const [ms, setMs] = createSignal(0);
   let initialTs = 0;
-  const [_, start, stop] = createRAF(targetFPS((ts) => {
-    initialTs ||= ts;
-    setMs(ts - initialTs);
-  }, fps));
+  const reset = () => {
+    initialTs = 0;
+  };
+  const [running, start, stop] = createRAF(
+    targetFPS(ts => {
+      initialTs ||= ts;
+      const ms = ts - initialTs;
+      setMs(ts - initialTs);
+      if (ms === (typeof limit === "function" ? limit() : limit)) reset();
+    }, fps),
+  );
   start();
   onCleanup(stop);
-  return ms;
+  return Object.assign(ms, { reset, running, start, stop });
 }
 
 export { createMs, createRAF, createRAF as default, targetFPS };

--- a/packages/raf/test/index.test.ts
+++ b/packages/raf/test/index.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest";
+import { createMs, createRAF, targetFPS } from "../src/index.js";
+import { createRoot } from "solid-js";
+
+describe("createRAF", () => {
+  it("calls requestAnimationFrame after start", () => {
+    const raf = vi.spyOn(window, "requestAnimationFrame");
+    createRoot(() => {
+      const [running, start, stop] = createRAF(ts => {
+        expect(typeof ts === "number");
+      });
+      expect(running()).toBe(false);
+      expect(raf).not.toHaveBeenCalled();
+      start();
+      expect(running()).toBe(true);
+      expect(raf).toHaveBeenCalled();
+      stop();
+    });
+  });
+});
+
+describe("targetFPS", () => {
+  it("only calls after a frame", () => {
+    const callback = vi.fn();
+    const fpsFilter = targetFPS(callback, 60);
+    expect(callback).not.toHaveBeenCalled();
+    fpsFilter(1000);
+    expect(callback).toHaveBeenCalledTimes(1);
+    fpsFilter(1017);
+    expect(callback).toHaveBeenCalledTimes(2);
+    fpsFilter(1024);
+    expect(callback).toHaveBeenCalledTimes(2);
+    fpsFilter(1034);
+    expect(callback).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe("createMs", () => {
+  it("yields a timestamp starting at approximately zero", () => {
+    createRoot(() => {
+      const ms = createMs(60);
+      expect(ms()).toBeLessThanOrEqual(3);
+      ms.stop();
+    });
+  });
+});


### PR DESCRIPTION
I recently animated some SVGs and found the pattern helpful to create a milliseconds counter using createRAF and targetFPS, so I want to make this pattern an official primitive.