### PR TITLE
`createWritableMemo` fix for reassigning previous memo value after computation

### DIFF
--- a/packages/memo/src/index.ts
+++ b/packages/memo/src/index.ts
@@ -191,7 +191,7 @@ export function createWritableMemo<T>(
   options?: MemoOptions<T | undefined>,
 ): [signal: Accessor<T>, setter: Setter<T>] {
   let combined: Accessor<T> = () => value as T;
-  const [signal, setSignal] = createSignal(value as T),
+  const [signal, setSignal] = createSignal(value as T, { equals: false }),
     memo = createMemo(
       callbackWith(fn, () => combined()),
       value,

--- a/packages/memo/src/index.ts
+++ b/packages/memo/src/index.ts
@@ -191,7 +191,7 @@ export function createWritableMemo<T>(
   options?: MemoOptions<T | undefined>,
 ): [signal: Accessor<T>, setter: Setter<T>] {
   let combined: Accessor<T> = () => value as T;
-  const [signal, setSignal] = createSignal(value as T, { equals: false }),
+  const [signal, setSignal] = createSignal(value as T, EQUALS_FALSE_OPTIONS),
     memo = createMemo(
       callbackWith(fn, () => combined()),
       value,

--- a/packages/memo/test/writable.test.ts
+++ b/packages/memo/test/writable.test.ts
@@ -87,4 +87,36 @@ describe("createWritableMemo", () => {
       dispose();
     });
   });
+
+  test("memo can be reassigned to default inner signal", () => {
+    createRoot(dispose => {
+      const [signal, setSignal] = createSignal(1);
+      const [memo, setMemo] = createWritableMemo<number | undefined>(() => signal() * 2);
+
+      setMemo(2);
+      expect(memo()).toBe(2);
+      setSignal(2);
+      expect(memo()).toBe(4);
+      setMemo(2);
+      expect(memo()).toBe(2);
+
+      dispose();
+    });
+  });
+
+  test("memo can be reassigned to previous inner signal value", () => {
+    createRoot(dispose => {
+      const [signal, setSignal] = createSignal(1);
+      const [memo, setMemo] = createWritableMemo<number | undefined>(() => signal() * 2);
+
+      setMemo(2);
+      expect(memo()).toBe(2);
+      setSignal(2);
+      expect(memo()).toBe(4);
+      setMemo(2);
+      expect(memo()).toBe(2);
+
+      dispose();
+    });
+  });
 });

--- a/packages/memo/test/writable.test.ts
+++ b/packages/memo/test/writable.test.ts
@@ -90,15 +90,12 @@ describe("createWritableMemo", () => {
 
   test("memo can be reassigned to default inner signal", () => {
     createRoot(dispose => {
-      const [signal, setSignal] = createSignal(1);
+      const [signal] = createSignal(1);
       const [memo, setMemo] = createWritableMemo<number | undefined>(() => signal() * 2);
 
-      setMemo(2);
       expect(memo()).toBe(2);
-      setSignal(2);
-      expect(memo()).toBe(4);
-      setMemo(2);
-      expect(memo()).toBe(2);
+      setMemo(undefined);
+      expect(memo()).toBe(undefined);
 
       dispose();
     });
@@ -107,7 +104,7 @@ describe("createWritableMemo", () => {
   test("memo can be reassigned to previous inner signal value", () => {
     createRoot(dispose => {
       const [signal, setSignal] = createSignal(1);
-      const [memo, setMemo] = createWritableMemo<number | undefined>(() => signal() * 2);
+      const [memo, setMemo] = createWritableMemo(() => signal() * 2);
 
       setMemo(2);
       expect(memo()).toBe(2);


### PR DESCRIPTION
resolves #592
resolves #633