### PR TITLE
storage: fix ssr handling

### DIFF
--- a/.changeset/lovely-singers-rescue.md
+++ b/.changeset/lovely-singers-rescue.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/storage": minor
+---
+
+fix ssr handling

--- a/packages/storage/src/persisted.ts
+++ b/packages/storage/src/persisted.ts
@@ -69,12 +69,12 @@ export function makePersisted<
   T = SignalType<S>,
 >(signal: S, options: PersistenceOptions<T, O> = {} as PersistenceOptions<T, O>): S {
   const storage = options.storage || globalThis.localStorage;
+  const name = options.name || `storage-${createUniqueId()}`;
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!storage) {
     return signal;
   }
   const storageOptions = (options as unknown as { storageOptions: O }).storageOptions;
-  const name = options.name || `storage-${createUniqueId()}`;
   const serialize: (data: T) => string = options.serialize || JSON.stringify.bind(JSON);
   const deserialize: (data: string) => T = options.deserialize || JSON.parse.bind(JSON);
   const init = storage.getItem(name, storageOptions);


### PR DESCRIPTION
Fixes https://github.com/solidjs-community/solid-primitives/issues/652 - we only called `createUniqueId()` if no name, but a storage was given. In case of SSR without a defined storage, `createUniqueId()` would only be called in the client, which would lead to a hydration mismatch. Calling it before returning the signal/store in case no storage was given should fix this issue.