### PR TITLE
resource: new primitive createAbortable (makeAbortable + cleanup)

### DIFF
--- a/.changeset/clean-mangos-camp.md
+++ b/.changeset/clean-mangos-camp.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/resource": minor
+---
+
+resource: new primitive createAbortable (makeAbortable + cleanup)

--- a/packages/resource/README.md
+++ b/packages/resource/README.md
@@ -12,8 +12,9 @@
 A collection of composable primitives to augment [`createResource`](https://www.solidjs.com/docs/latest/api#createresource)
 
 - [`createAggregated`](#createaggregated) - wraps the resource to aggregate data instead of overwriting it
-- [`createDeepSignal`](#createdeepsignal) - provides a fine-grained signal for the [resource storage option](https://www.solidjs.com/docs/latest/api#createresource:~:text=Resources%20can%20be%20set%20with%20custom%20defined%20storage)
-- [`makeAbortable`](#makeabortable) - wraps the fetcher to be abortable and auto-abort on re-fetch or timeout
+- [`createDeepSignal`](#createdeepsignal) - provides a fine-grained signal for the [resource storage option](https://docs.solidjs.com/reference/basic-reactivity/create-resource#options)
+- [`makeAbortable`](#makeabortable) - sets up an AbortSignal with auto-abort on re-fetch or timeout
+- [`createAbortable`](#createAbortable) - like `makeAbortable`, but with automatic abort on cleanup
 - [`makeCache`](#makecache) - wraps the fetcher to cache the responses for a certain amount of time
 - [`makeRetrying`](#makeretrying) - wraps the fetcher to retry requests after a delay
 
@@ -68,7 +69,7 @@ Objects and Arrays are re-created on each operation, but the values will be left
 
 ### createDeepSignal
 
-Usually resources in Solid.js are immutable. Every time the resource updates, every subscriber of it is updated. Starting with Solid.js 1.5, `createResource` allows to receive a function returning something akin to a signal in [`options.storage`](https://www.solidjs.com/docs/latest/api#createresource:~:text=Resources%20can%20be%20set%20with%20custom%20defined%20storage). This allows to provide the underlying storage for the resource in order to change its reactivity. This allows to add fine-grained reactivity to resources so that you can subscribe to nested properties and only trigger updates as they actually occur:
+Usually resources in Solid.js are immutable. Every time the resource updates, every subscriber of it is updated. Starting with Solid.js 1.5, `createResource` allows to receive a function returning something akin to a signal in [`options.storage`](https://docs.solidjs.com/reference/basic-reactivity/create-resource#options). This allows to provide the underlying storage for the resource in order to change its reactivity. This allows to add fine-grained reactivity to resources so that you can subscribe to nested properties and only trigger updates as they actually occur:
 
 ```ts
 // this adds fine-grained reactivity to the contents of data():
@@ -91,7 +92,11 @@ Orchestrates AbortController creation and aborting of abortable fetchers, either
 
 ```ts
 // definition
-const [signal: AbortSignal, abort: () => void] = makeAbortable({
+const [
+  signal: AbortSignal,
+  abort: () => void,
+  filterErrors: <E>(err: E) => E instanceof AbortError ? void : E
+] = makeAbortable({
   timeout?: 10000,
   noAutoAbort?: true,
 });
@@ -99,12 +104,17 @@ const [signal: AbortSignal, abort: () => void] = makeAbortable({
 // usage
 const fetcher = (url: string) => fetch(
   url, { signal: signal() }
-).then(r => r.json());
+).then(r => r.json(), filterErrors);
 ```
 
-- The signal function always returns an unaborted signal; if `noAutoAbort` is not set to true, calling it will also abort a previous signal, if present
-- The abort callback will always abort the current signal
+- The `signal` function always returns a signal that is not yet aborted; if `noAutoAbort` is not set to true, calling it will also abort a previous signal, if present
+- The `abort` callback will always abort the current signal
 - If `timeout` is set, the signal will be aborted after that many Milliseconds
+- The `filterErrors` function can be used to filter out abort errors
+
+### createAbortable
+
+This function does exactly the same as `makeAbortable`, but also automatically aborts on cleanup. Only use within a reactive scope.
 
 ### makeCache
 
@@ -240,7 +250,7 @@ const addTodo = todo => {
 
 #### Scroll Restoration
 
-This is already covered in [solid-router](https://github.com/solidjs/solid-router).
+This is already covered in [@solidjs/router](https://github.com/solidjs/solid-router).
 
 #### Polling
 
@@ -248,7 +258,7 @@ Just use an interval with refetch; ideally, also use [`makeAbortable`](#makeabor
 
 ## Demo
 
-You may view a working example of createFileSystem/makeVirtualFileSystem/makeWebAccessFileSystem here:
+You may view a working example of our resource primitives here:
 https://primitives.solidjs.community/playground/resource/
 
 ## Changelog

--- a/packages/resource/package.json
+++ b/packages/resource/package.json
@@ -20,6 +20,7 @@
       "createAggregated",
       "createDeepSignal",
       "makeAbortable",
+      "createAbortable",
       "makeCache",
       "makeRetrying"
     ],

--- a/packages/resource/src/index.ts
+++ b/packages/resource/src/index.ts
@@ -5,6 +5,7 @@ import {
   type ResourceFetcher,
   type ResourceFetcherInfo,
   type Signal,
+  onCleanup,
 } from "solid-js";
 import { createStore, reconcile, unwrap } from "solid-js/store";
 
@@ -60,6 +61,27 @@ export function makeAbortable(
       throw err;
     },
   ];
+}
+
+/**
+ * **Creates and handles an AbortSignal with automated cleanup**
+ * ```ts
+ * const [signal, abort, filterAbortError] =
+ *   createAbortable();
+ * const fetcher = (url) => fetch(url, { signal: signal() })
+ *   .catch(filterAbortError); // filters abort errors
+ * ```
+ * Returns an accessor for the signal and the abort callback.
+ *
+ * Options are optional and include:
+ * - `timeout`: time in Milliseconds after which the fetcher aborts automatically
+ * - `noAutoAbort`: can be set to true to make a new source not automatically abort a previous request
+ */
+
+export function createAbortable(options?: AbortableOptions) {
+  const [signal, abort, filterAbortError] = makeAbortable(options);
+  onCleanup(abort);
+  return [signal, abort, filterAbortError];
 }
 
 const mapEntries = (entries: [key: string, value: any][]) =>


### PR DESCRIPTION
Fixes https://github.com/solidjs-community/solid-primitives/issues/597 by adding createAbortable = makeAbortable + cleanup.