### PR TITLE
fix(workers): export missing types from definitions

### DIFF
--- a/.changeset/short-buckets-visit.md
+++ b/.changeset/short-buckets-visit.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/workers": minor
+---
+
+fix(workers): export missing types from definitions

--- a/packages/workers/src/index.ts
+++ b/packages/workers/src/index.ts
@@ -1,7 +1,9 @@
 import { Accessor, Setter, createEffect, on, onCleanup } from "solid-js";
 import { isServer } from "solid-js/web";
+import type { PostMessageOptions, WorkerCallbacks, WorkerExports, WorkerMessage } from "./types.js";
+import { KILL, RPC, cjs, setup } from "./utils.js";
 
-import { cjs, setup, KILL, RPC } from "./utils.js";
+export type * from "./types.js";
 
 /**
  * Creates a very basic WebWorker based on provided code.

--- a/packages/workers/src/types.d.ts
+++ b/packages/workers/src/types.d.ts
@@ -1,8 +1,8 @@
-declare type WorkerSignal = number;
+export type WorkerSignal = number;
 
-declare type WorkerCallbacks = Map<string, [succes: Function, error: Function]>;
+export type WorkerCallbacks = Map<string, [succes: Function, error: Function]>;
 
-declare type WorkerMessage = {
+export type WorkerMessage = {
   type: WorkerSignal;
   id?: string;
   error?: string;
@@ -12,13 +12,13 @@ declare type WorkerMessage = {
   params?: any;
 };
 
-declare type WorkerExports = [
+export type WorkerExports = [
   worker: Worker,
   start: () => void,
   stop: () => void,
   exports?: Set<string>,
 ];
 
-declare interface PostMessageOptions {
+export interface PostMessageOptions {
   transfer?: any[] | undefined;
 }

--- a/packages/workers/src/utils.ts
+++ b/packages/workers/src/utils.ts
@@ -1,3 +1,5 @@
+import type { WorkerSignal, WorkerCallbacks, WorkerMessage } from "./types.js";
+
 export const KILL: WorkerSignal = 0;
 export const RPC: WorkerSignal = 1;
 


### PR DESCRIPTION
Hey all, this is my first PR to solid which is very exciting!

- Closes #594
- Is there anything to reconsider or change in here?

`types.d.ts` wasn't part of the entry point `index.ts` during the bundling process.
By importing and exporting the types from `index.d.ts` via `index.ts`, it will now bundle these types in the declaration file.

Here's the compiled types file in the relative `dist` directory:

```ts
import { Accessor, Setter } from 'solid-js';

type WorkerSignal = number;

type WorkerCallbacks = Map<string, [succes: Function, error: Function]>;

type WorkerMessage = {
  type: WorkerSignal;
  id?: string;
  error?: string;
  method?: string;
  signal?: string | number;
  result?: string;
  params?: any;
};

type WorkerExports = [
  worker: Worker,
  start: () => void,
  stop: () => void,
  exports?: Set<string>,
];

interface PostMessageOptions {
  transfer?: any[] | undefined;
}

/**
 * Creates a very basic WebWorker based on provided code.
 *
 * @param Functions A set of functions to expose via the worker.
 * @param options Web worker options to control the instance.
 * @returns An array with worker, start and stop methods
 */
declare function createWorker(...args: (Function | object)[]): WorkerExports;
/**
 * Creates a worker pool that round-robins work between worker sets.
 *
 * @param number Amount of workers to establish in the pool.
 * @param Functions A set of functions to expose via the worker.
 * @param options Web worker options to control the instance.
 * @returns An array with worker, start and stop methods
 */
declare const createWorkerPool: (concurrency?: number, ...args: (Function | object)[]) => WorkerExports;
type WorkerInstruction = {
    func: Function;
    input?: Accessor<any>;
    output?: Setter<any>;
    concurrency?: number;
};
/**
 * Creates a complex worker that reads inputs and provides outputs.
 *
 * @param args An instruction list of controls for the worker.
 * @returns Basic start and stop functions
 */
declare const createSignaledWorker: (...args: WorkerInstruction[]) => [start: () => void, stop: () => void];

export { type PostMessageOptions, type WorkerCallbacks, type WorkerExports, type WorkerInstruction, type WorkerMessage, type WorkerSignal, createSignaledWorker, createWorker, createWorkerPool };
```