### PR TITLE
fix: makeSearchRegex Memory leak (due to empty capture)

### DIFF
--- a/.changeset/selfish-eagles-train.md
+++ b/.changeset/selfish-eagles-train.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/marker": minor
+---
+
+fix memory leak

--- a/packages/marker/src/index.ts
+++ b/packages/marker/src/index.ts
@@ -16,7 +16,7 @@ export function makeSearchRegex(search: string): RegExp {
   return search
     ? new RegExp(
         // join words `|` to match any of them
-        search.replace(SPLIT_WORDS_REGEX, "|"),
+        search.trim().replace(SPLIT_WORDS_REGEX, "|"),
         "gi",
       )
     : NEVER_REGEX;


### PR DESCRIPTION
Fixes https://github.com/solidjs-community/solid-primitives/issues/681

Background: the - was removed after trimming, but it left the space at the end, so we got an empty capture, which caused memory leaks. Trimming the sanitized search string again fixes the issue.