### PR TITLE
Headless virtual list

### DIFF
--- a/.changeset/unlucky-cars-yell.md
+++ b/.changeset/unlucky-cars-yell.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/virtual": minor
+---
+
+Add a headless virtual list primitive: `createVirtualList` in #702

--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -24,34 +24,30 @@ pnpm add @solid-primitives/virtual
 
 ## How to use it
 
+### `createVirtualList`
+
 `createVirtualList` is a headless utility for constructing your own virtualized list components with maximum flexibility.
 
 ```tsx
 function MyComp(): JSX.Element {
-  const [rootElement, setRootElement] = createSignal() as Signal<HTMLDivElement>;
-
   const items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
   const rootHeight = 20;
   const rowHeight = 10;
   const overscanCount = 5;
 
-  const { onScroll, containerHeight, viewerTop, visibleItems } = createVirtualList({
-    // accessor for the element to use as the root of the virtualized list
-    rootElement,
-    // the list of items
+  const [{ containerHeight, viewerTop, visibleItems }, onScroll] = createVirtualList({
+    // the list of items - can be a signal
     items,
-    // the height of the root element of the virtualizedList
+    // the height of the root element of the virtualizedList - can be a signal
     rootHeight,
-    // the height of individual rows in the virtualizedList
+    // the height of individual rows in the virtualizedList - can be a signal
     rowHeight,
-    // the number of elements to render both before and after the visible section of the list, so passing 5 will render 5 items before the list, and 5 items after. Defaults to 1, cannot be set to zero. This is necessary to hide the blank space around list items when scrolling
+    // the number of elements to render both before and after the visible section of the list, so passing 5 will render 5 items before the list, and 5 items after. Defaults to 1, cannot be set to zero. This is necessary to hide the blank space around list items when scrolling - can be a signal
     overscanCount,
   });
 
   return (
     <div
-      // outermost container must be set as the root
-      ref={setRootElement}
       style={{
         overflow: "auto",
         // root element's height must be rootHeight
@@ -85,6 +81,8 @@ function MyComp(): JSX.Element {
   );
 }
 ```
+
+### `<VirtualList />`
 
 `<VirtualList />` is a basic, unstyled virtual list component you can drop into projects without modification.
 

--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -27,6 +27,8 @@ pnpm add @solid-primitives/virtual
 <VirtualList
   // the list of items (of course, to for this component to be useful, the list would need to be much bigger than shown here)
   each={[0, 1, 2, 3, 4, 5, 6, 7]}
+  // the optional fallback to display if the list of items is empty
+  fallback={<div>No items</div>}
   // the number of elements to render both before and after the visible section of the list, so passing 5 will render 5 items before the list, and 5 items after. Defaults to 1, cannot be set to zero. This is necessary to hide the blank space around list items when scrolling
   overscanCount={5}
   // the height of the root element of the virtualizedList itself
@@ -48,7 +50,7 @@ Note that the component only handles vertical lists where the number of items is
 
 ## Demo
 
-You can see the VirtualizedList in action in the following sandbox: https://primitives.solidjs.community/playground/virtual
+You can see the VirtualList in action in the following sandbox: https://primitives.solidjs.community/playground/virtual
 
 ## Changelog
 

--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -9,7 +9,8 @@
 [![version](https://img.shields.io/npm/v/@solid-primitives/virtual?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/virtual)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
-A basic [virtualized list](https://www.patterns.dev/vanilla/virtual-lists/) component for improving performance when rendering very large lists
+A headless `createVirtualList` utility function for [virtualized lists](https://www.patterns.dev/vanilla/virtual-lists/) and a basic, unstyled `VirtualList` component (which uses the utility).
+Virtual lists are useful for improving performance when rendering very large lists.
 
 ## Installation
 
@@ -23,6 +24,70 @@ pnpm add @solid-primitives/virtual
 
 ## How to use it
 
+`createVirtualList` is a headless utility for constructing your own virtualized list components with maximum flexibility.
+
+```tsx
+function MyComp(): JSX.Element {
+  const [rootElement, setRootElement] = createSignal() as Signal<HTMLDivElement>;
+
+  const items = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const rootHeight = 20;
+  const rowHeight = 10;
+  const overscanCount = 5;
+
+  const { onScroll, containerHeight, viewerTop, visibleItems } = createVirtualList({
+    // accessor for the element to use as the root of the virtualized list
+    rootElement,
+    // the list of items
+    items,
+    // the height of the root element of the virtualizedList
+    rootHeight,
+    // the height of individual rows in the virtualizedList
+    rowHeight,
+    // the number of elements to render both before and after the visible section of the list, so passing 5 will render 5 items before the list, and 5 items after. Defaults to 1, cannot be set to zero. This is necessary to hide the blank space around list items when scrolling
+    overscanCount,
+  });
+
+  return (
+    <div
+      // outermost container must be set as the root
+      ref={setRootElement}
+      style={{
+        overflow: "auto",
+        // root element's height must be rootHeight
+        height: `${rootHeight}px`,
+      }}
+      // outermost container must use onScroll
+      onScroll={onScroll}
+    >
+      <div
+        style={{
+          position: "relative",
+          width: "100%",
+          // list container element's height must be set to containerHeight()
+          height: `${containerHeight()}px`,
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            // viewer element's top must be set to viewerTop()
+            top: `${viewerTop()}px`,
+          }}
+        >
+          {/* only visibleItems() are ultimately rendered */}
+          <For fallback={"no items"} each={visibleItems()}>
+            {item => <div>{item}</div>}
+          </For>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+`<VirtualList />` is a basic, unstyled virtual list component you can drop into projects without modification.
+
 ```tsx
 <VirtualList
   // the list of items (of course, to for this component to be useful, the list would need to be much bigger than shown here)
@@ -35,8 +100,6 @@ pnpm add @solid-primitives/virtual
   rootHeight={20}
   // the height of individual rows in the virtualizedList
   rowHeight={10}
-  // the class applied to the root element of the virtualizedList
-  class={"my-class-name"}
 >
   {
     // the flowComponent that will be used to transform the items into rows in the list
@@ -45,7 +108,7 @@ pnpm add @solid-primitives/virtual
 </VirtualList>
 ```
 
-The tests describe the component's exact behavior and how overscanCount handles the start/end of the list in more detail.
+The tests describe the exact behavior and how overscanCount handles the start/end of the list in more detail.
 Note that the component only handles vertical lists where the number of items is known and the height of an individual item is fixed.
 
 ## Demo

--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -9,8 +9,8 @@
 [![version](https://img.shields.io/npm/v/@solid-primitives/virtual?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/virtual)
 [![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
 
-A headless `createVirtualList` utility function for [virtualized lists](https://www.patterns.dev/vanilla/virtual-lists/) and a basic, unstyled `VirtualList` component (which uses the utility).
-Virtual lists are useful for improving performance when rendering very large lists.
+- [`createVirtualList`](#createvirtuallist) - A headless utility function for [virtualized lists](https://www.patterns.dev/vanilla/virtual-lists/)
+- [`VirtualList`](#virtuallist) - a basic, unstyled component based on `createVirtualList`
 
 ## Installation
 

--- a/packages/virtual/dev/index.tsx
+++ b/packages/virtual/dev/index.tsx
@@ -22,7 +22,7 @@ const App: Component = () => {
           <DemoControl
             label="Number of rows"
             max={100_000}
-            min={1}
+            min={0}
             name="rowCount"
             setValue={setListLength}
             value={listLength()}
@@ -66,6 +66,7 @@ const App: Component = () => {
 
       <VirtualList
         each={items.slice(0, listLength())}
+fallback={<div>no items</div>}
         overscanCount={overscanCount()}
         rootHeight={rootHeight()}
         rowHeight={rowHeight()}

--- a/packages/virtual/dev/index.tsx
+++ b/packages/virtual/dev/index.tsx
@@ -64,16 +64,17 @@ const App: Component = () => {
         View the devtools console for log of items being added and removed from the visible list
       </div>
 
-      <VirtualList
-        each={items.slice(0, listLength())}
-fallback={<div>no items</div>}
-        overscanCount={overscanCount()}
-        rootHeight={rootHeight()}
-        rowHeight={rowHeight()}
-        class="bg-white text-gray-800"
-      >
-        {item => <VirtualListItem item={item} height={rowHeight()} />}
-      </VirtualList>
+      <div class="bg-white text-gray-800">
+        <VirtualList
+          each={items.slice(0, listLength())}
+          fallback={<div>no items</div>}
+          overscanCount={overscanCount()}
+          rootHeight={rootHeight()}
+          rowHeight={rowHeight()}
+        >
+          {item => <VirtualListItem item={item} height={rowHeight()} />}
+        </VirtualList>
+      </div>
     </div>
   );
 };

--- a/packages/virtual/package.json
+++ b/packages/virtual/package.json
@@ -17,6 +17,7 @@
     "name": "virtual",
     "stage": 0,
     "list": [
+      "createVirutalList",
       "VirtualList"
     ],
     "category": "UI Patterns"
@@ -53,6 +54,9 @@
     "vitest": "vitest -c ../../configs/vitest.config.ts",
     "test": "pnpm run vitest",
     "test:ssr": "pnpm run vitest --mode ssr"
+  },
+  "dependencies": {
+    "@solid-primitives/utils": "workspace:^"
   },
   "peerDependencies": {
     "solid-js": "^1.6.12"

--- a/packages/virtual/src/index.tsx
+++ b/packages/virtual/src/index.tsx
@@ -1,6 +1,5 @@
 import { For, createSignal } from "solid-js";
 import type { Accessor, JSX } from "solid-js";
-import type { DOMElement } from "solid-js/jsx-runtime";
 import { access } from "@solid-primitives/utils";
 import type { MaybeAccessor } from "@solid-primitives/utils";
 
@@ -58,7 +57,7 @@ export function createVirtualList<T extends readonly any[]>({
     }),
     e => {
       // @ts-expect-error
-      setOffset(e.target?.scrollTop);
+      if (e.target?.scrollTop !== undefined) setOffset(e.target.scrollTop);
     },
   ];
 }

--- a/packages/virtual/src/index.tsx
+++ b/packages/virtual/src/index.tsx
@@ -1,72 +1,109 @@
 import { For, createSignal } from "solid-js";
-import type { Accessor, JSX } from "solid-js";
+import type { Accessor, JSX, Signal } from "solid-js";
 
 /**
- * A basic virtualized list (see https://www.patterns.dev/vanilla/virtual-lists/) component for improving performance when rendering very large lists
+ * A headless virtualized list (see https://www.patterns.dev/vanilla/virtual-lists/) utility for constructing your own virtualized list components with maximum flexibility.
+ *
+ * @param rootElement accessor for the element to use as the root of the virtualized list
+ * @param items the list of items
+ * @param rootHeight the height of the root element of the virtualizedList
+ * @param rowHeight the height of individual rows in the virtualizedList
+ * @param overscanCount the number of elements to render both before and after the visible section of the list, so passing 5 will render 5 items before the list, and 5 items after. Defaults to 1, cannot be set to zero. This is necessary to hide the blank space around list items when scrolling
+ * @returns an object whose properties are used by the list's components
+ */
+export function createVirtualList<T extends readonly any[]>({
+  rootElement,
+  items,
+  rootHeight,
+  rowHeight,
+  overscanCount,
+}: {
+  rootElement: Accessor<Element>;
+  items: T | undefined | null | false;
+  rootHeight: number;
+  rowHeight: number;
+  overscanCount?: number;
+}): {
+  onScroll: VoidFunction;
+  containerHeight: () => number;
+  viewerTop: () => number;
+  visibleItems: () => readonly T[];
+} {
+  items = items || ([] as any as T);
+  overscanCount = overscanCount || 1;
+
+  const [offset, setOffset] = createSignal(0);
+
+  const getFirstIdx = () => Math.max(0, Math.floor(offset() / rowHeight) - overscanCount);
+
+  const getLastIdx = () =>
+    Math.min(
+      items.length,
+      Math.floor(offset() / rowHeight) + Math.ceil(rootHeight / rowHeight) + overscanCount,
+    );
+
+  return {
+    onScroll: () => {
+      setOffset(rootElement().scrollTop);
+    },
+    containerHeight: () => items.length * rowHeight,
+    viewerTop: () => getFirstIdx() * rowHeight,
+    visibleItems: () => items.slice(getFirstIdx(), getLastIdx()),
+  };
+}
+
+/**
+ * A basic, unstyled virtualized list (see https://www.patterns.dev/vanilla/virtual-lists/) component you can drop into projects without modification
  *
  * @param children the flowComponent that will be used to transform the items into rows in the list
- * @param class the class applied to the root element of the virtualizedList
  * @param each the list of items
  * @param fallback the optional fallback to display if the list of items to display is empty
  * @param overscanCount the number of elements to render both before and after the visible section of the list, so passing 5 will render 5 items before the list, and 5 items after. Defaults to 1, cannot be set to zero. This is necessary to hide the blank space around list items when scrolling
  * @param rootHeight the height of the root element of the virtualizedList itself
  * @param rowHeight the height of individual rows in the virtualizedList
- * @return virtualized list component
+ * @returns virtualized list component
  */
 export function VirtualList<T extends readonly any[], U extends JSX.Element>(props: {
   children: (item: T[number], index: Accessor<number>) => U;
-  class?: string;
   each: T | undefined | null | false;
   fallback?: JSX.Element;
   overscanCount?: number;
   rootHeight: number;
   rowHeight: number;
 }): JSX.Element {
-  let rootElement!: HTMLDivElement;
+  const [rootElement, setRootElement] = createSignal() as Signal<HTMLDivElement>;
 
-  const [offset, setOffset] = createSignal(0);
-  const items = () => props.each || ([] as any as T);
-
-  const getFirstIdx = () =>
-    Math.max(0, Math.floor(offset() / props.rowHeight) - (props.overscanCount || 1));
-
-  const getLastIdx = () =>
-    Math.min(
-      items().length,
-      Math.floor(offset() / props.rowHeight) +
-        Math.ceil(props.rootHeight / props.rowHeight) +
-        (props.overscanCount || 1),
-    );
+  const { onScroll, containerHeight, viewerTop, visibleItems } = createVirtualList({
+    rootElement,
+    items: props.each,
+    rootHeight: props.rootHeight,
+    rowHeight: props.rowHeight,
+    overscanCount: props.overscanCount,
+  });
 
   return (
     <div
-      ref={rootElement}
+      ref={setRootElement}
       style={{
         overflow: "auto",
         height: `${props.rootHeight}px`,
       }}
-      class={props.class}
-      onScroll={() => {
-        setOffset(rootElement.scrollTop);
-      }}
+      onScroll={onScroll}
     >
       <div
         style={{
           position: "relative",
           width: "100%",
-          height: `${items().length * props.rowHeight}px`,
+          height: `${containerHeight()}px`,
         }}
       >
         <div
           style={{
             position: "absolute",
-            top: `${getFirstIdx() * props.rowHeight}px`,
+            top: `${viewerTop()}px`,
           }}
         >
-          <For
-            fallback={props.fallback}
-            each={items().slice(getFirstIdx(), getLastIdx()) as any as T}
-          >
+          <For fallback={props.fallback} each={visibleItems() as unknown as T}>
             {props.children}
           </For>
         </div>

--- a/packages/virtual/src/index.tsx
+++ b/packages/virtual/src/index.tsx
@@ -15,7 +15,7 @@ type VirtualListReturn<T extends readonly any[]> = [
   {
     containerHeight: Accessor<number>;
     viewerTop: Accessor<number>;
-    visibleItems: Accessor<readonly T[]>;
+    visibleItems: Accessor<T>;
   },
   onScroll: (
     e: Event & {
@@ -58,7 +58,7 @@ export function createVirtualList<T extends readonly any[]>({
     {
       containerHeight: () => items.length * rowHeight,
       viewerTop: () => getFirstIdx() * rowHeight,
-      visibleItems: () => items.slice(getFirstIdx(), getLastIdx()),
+      visibleItems: () => items.slice(getFirstIdx(), getLastIdx()) as unknown as T,
     },
     e => {
       setOffset(e.target.scrollTop);
@@ -117,7 +117,7 @@ export function VirtualList<T extends readonly any[], U extends JSX.Element>(
             top: `${viewerTop()}px`,
           }}
         >
-          <For fallback={props.fallback} each={visibleItems() as unknown as T}>
+          <For fallback={props.fallback} each={visibleItems()}>
             {props.children}
           </For>
         </div>

--- a/packages/virtual/src/index.tsx
+++ b/packages/virtual/src/index.tsx
@@ -12,11 +12,11 @@ type VirtualListConfig<T extends readonly any[]> = {
 };
 
 type VirtualListReturn<T extends readonly any[]> = [
-  {
-    containerHeight: Accessor<number>;
-    viewerTop: Accessor<number>;
-    visibleItems: Accessor<T>;
-  },
+  Accessor<{
+    containerHeight: number;
+    viewerTop: number;
+    visibleItems: T;
+  }>,
   onScroll: (
     e: Event & {
       target: DOMElement;
@@ -55,11 +55,11 @@ export function createVirtualList<T extends readonly any[]>({
     );
 
   return [
-    {
-      containerHeight: () => items.length * rowHeight,
-      viewerTop: () => getFirstIdx() * rowHeight,
-      visibleItems: () => items.slice(getFirstIdx(), getLastIdx()) as unknown as T,
-    },
+    () => ({
+      containerHeight: items.length * rowHeight,
+      viewerTop: getFirstIdx() * rowHeight,
+      visibleItems: items.slice(getFirstIdx(), getLastIdx()) as unknown as T,
+    }),
     e => {
       setOffset(e.target.scrollTop);
     },
@@ -89,7 +89,7 @@ type VirtualListProps<T extends readonly any[], U extends JSX.Element> = {
 export function VirtualList<T extends readonly any[], U extends JSX.Element>(
   props: VirtualListProps<T, U>,
 ): JSX.Element {
-  const [{ containerHeight, viewerTop, visibleItems }, onScroll] = createVirtualList({
+  const [virtual, onScroll] = createVirtualList({
     items: props.each,
     rootHeight: props.rootHeight,
     rowHeight: props.rowHeight,
@@ -108,16 +108,16 @@ export function VirtualList<T extends readonly any[], U extends JSX.Element>(
         style={{
           position: "relative",
           width: "100%",
-          height: `${containerHeight()}px`,
+          height: `${virtual().containerHeight}px`,
         }}
       >
         <div
           style={{
             position: "absolute",
-            top: `${viewerTop()}px`,
+            top: `${virtual().viewerTop}px`,
           }}
         >
-          <For fallback={props.fallback} each={visibleItems()}>
+          <For fallback={props.fallback} each={virtual().visibleItems}>
             {props.children}
           </For>
         </div>

--- a/packages/virtual/src/index.tsx
+++ b/packages/virtual/src/index.tsx
@@ -17,11 +17,7 @@ type VirtualListReturn<T extends readonly any[]> = [
     viewerTop: number;
     visibleItems: T;
   }>,
-  onScroll: (
-    e: Event & {
-      target: DOMElement;
-    },
-  ) => void,
+  onScroll: (e: Event) => void,
 ];
 
 /**
@@ -61,7 +57,8 @@ export function createVirtualList<T extends readonly any[]>({
       visibleItems: items.slice(getFirstIdx(), getLastIdx()) as unknown as T,
     }),
     e => {
-      setOffset(e.target.scrollTop);
+      // @ts-expect-error
+      setOffset(e.target?.scrollTop);
     },
   ];
 }
@@ -90,10 +87,10 @@ export function VirtualList<T extends readonly any[], U extends JSX.Element>(
   props: VirtualListProps<T, U>,
 ): JSX.Element {
   const [virtual, onScroll] = createVirtualList({
-    items: props.each,
-    rootHeight: props.rootHeight,
-    rowHeight: props.rowHeight,
-    overscanCount: props.overscanCount,
+    items: () => props.each,
+    rootHeight: () => props.rootHeight,
+    rowHeight: () => props.rowHeight,
+    overscanCount: () => props.overscanCount || 1,
   });
 
   return (

--- a/packages/virtual/src/index.tsx
+++ b/packages/virtual/src/index.tsx
@@ -7,6 +7,7 @@ import type { Accessor, JSX } from "solid-js";
  * @param children the flowComponent that will be used to transform the items into rows in the list
  * @param class the class applied to the root element of the virtualizedList
  * @param each the list of items
+ * @param fallback the optional fallback to display if the list of items to display is empty
  * @param overscanCount the number of elements to render both before and after the visible section of the list, so passing 5 will render 5 items before the list, and 5 items after. Defaults to 1, cannot be set to zero. This is necessary to hide the blank space around list items when scrolling
  * @param rootHeight the height of the root element of the virtualizedList itself
  * @param rowHeight the height of individual rows in the virtualizedList
@@ -14,9 +15,9 @@ import type { Accessor, JSX } from "solid-js";
  */
 export function VirtualList<T extends readonly any[], U extends JSX.Element>(props: {
   children: (item: T[number], index: Accessor<number>) => U;
-  fallback?: JSX.Element;
   class?: string;
   each: T | undefined | null | false;
+  fallback?: JSX.Element;
   overscanCount?: number;
   rootHeight: number;
   rowHeight: number;

--- a/packages/virtual/test/index.test.tsx
+++ b/packages/virtual/test/index.test.tsx
@@ -24,7 +24,7 @@ describe("VirtualList", () => {
     const dispose = render(
       () => (
         <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10}>
-          {item => <div id={"item-" + item} style={{ height: "100px" }} />}
+          {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
       root,
@@ -42,7 +42,7 @@ describe("VirtualList", () => {
     const dispose = render(
       () => (
         <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10} class={SELECTOR_CLASS_NAME}>
-          {item => <div id={"item-" + item} style={{ height: "100px" }} />}
+          {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
       root,
@@ -99,7 +99,7 @@ describe("VirtualList", () => {
     const dispose = render(
       () => (
         <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10} class={SELECTOR_CLASS_NAME}>
-          {item => <div id={"item-" + item} style={{ height: "100px" }} />}
+          {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
       root,
@@ -128,7 +128,7 @@ describe("VirtualList", () => {
           overscanCount={2}
           class={SELECTOR_CLASS_NAME}
         >
-          {item => <div id={"item-" + item} style={{ height: "100px" }} />}
+          {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
       root,
@@ -154,7 +154,7 @@ describe("VirtualList", () => {
     const dispose = render(
       () => (
         <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10} class={SELECTOR_CLASS_NAME}>
-          {item => <div id={"item-" + item} style={{ height: "100px" }} />}
+          {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
       root,
@@ -184,7 +184,7 @@ describe("VirtualList", () => {
           overscanCount={0}
           class={SELECTOR_CLASS_NAME}
         >
-          {item => <div id={"item-" + item} style={{ height: "100px" }} />}
+          {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
       root,

--- a/packages/virtual/test/index.test.tsx
+++ b/packages/virtual/test/index.test.tsx
@@ -22,100 +22,100 @@ function getScrollContainer() {
 
 describe("createVirtualList", () => {
   test("returns containerHeight representing the size of the list container element within the root", () => {
-    const [{ containerHeight }] = createVirtualList({
+    const [virtual] = createVirtualList({
       items: TEST_LIST,
       rootHeight: 20,
       rowHeight: 10,
     });
 
-    expect(containerHeight()).toEqual(10_000);
+    expect(virtual().containerHeight).toEqual(10_000);
   });
 
   test("returns viewerTop representing the location of the list viewer element within the list container", () => {
-    const [{ viewerTop }] = createVirtualList({
+    const [virtual] = createVirtualList({
       items: TEST_LIST,
       rootHeight: 20,
       rowHeight: 10,
     });
 
-    expect(viewerTop()).toEqual(0);
+    expect(virtual().viewerTop).toEqual(0);
   });
 
   test("returns visibleList representing the subset of items to render", () => {
-    const [{ visibleItems }] = createVirtualList({
+    const [virtual] = createVirtualList({
       items: TEST_LIST,
       rootHeight: 20,
       rowHeight: 10,
     });
 
-    expect(visibleItems()).toEqual([0, 1, 2]);
+    expect(virtual().visibleItems).toEqual([0, 1, 2]);
   });
 
   test("returns onScroll which sets viewerTop and visibleItems based on rootElement's scrolltop", () => {
     const el = document.createElement("div");
 
-    const [{ viewerTop, visibleItems }, onScroll] = createVirtualList({
+    const [virtual, onScroll] = createVirtualList({
       items: TEST_LIST,
       rootHeight: 20,
       rowHeight: 10,
     });
 
-    expect(visibleItems()).toEqual([0, 1, 2]);
-    expect(viewerTop()).toEqual(0);
+    expect(virtual().visibleItems).toEqual([0, 1, 2]);
+    expect(virtual().viewerTop).toEqual(0);
 
     el.scrollTop += 10;
 
     // no change until onScroll is called
-    expect(visibleItems()).toEqual([0, 1, 2]);
-    expect(viewerTop()).toEqual(0);
+    expect(virtual().visibleItems).toEqual([0, 1, 2]);
+    expect(virtual().viewerTop).toEqual(0);
 
     onScroll(TARGETED_SCROLL_EVENT(el));
 
-    expect(visibleItems()).toEqual([0, 1, 2, 3]);
-    expect(viewerTop()).toEqual(0);
+    expect(virtual().visibleItems).toEqual([0, 1, 2, 3]);
+    expect(virtual().viewerTop).toEqual(0);
 
     el.scrollTop += 10;
     onScroll(TARGETED_SCROLL_EVENT(el));
 
-    expect(visibleItems()).toEqual([1, 2, 3, 4]);
-    expect(viewerTop()).toEqual(10);
+    expect(virtual().visibleItems).toEqual([1, 2, 3, 4]);
+    expect(virtual().viewerTop).toEqual(10);
 
     el.scrollTop -= 10;
     onScroll(TARGETED_SCROLL_EVENT(el));
 
-    expect(visibleItems()).toEqual([0, 1, 2, 3]);
-    expect(viewerTop()).toEqual(0);
+    expect(virtual().visibleItems).toEqual([0, 1, 2, 3]);
+    expect(virtual().viewerTop).toEqual(0);
 
     el.scrollTop -= 10;
     onScroll(TARGETED_SCROLL_EVENT(el));
 
-    expect(visibleItems()).toEqual([0, 1, 2]);
-    expect(viewerTop()).toEqual(0);
+    expect(virtual().visibleItems).toEqual([0, 1, 2]);
+    expect(virtual().viewerTop).toEqual(0);
   });
 
   test("onScroll handles reaching the bottom of the list", () => {
     const el = document.createElement("div");
 
-    const [{ viewerTop, visibleItems }, onScroll] = createVirtualList({
+    const [virtual, onScroll] = createVirtualList({
       items: TEST_LIST,
       rootHeight: 20,
       rowHeight: 10,
     });
 
-    expect(visibleItems()).toEqual([0, 1, 2]);
-    expect(viewerTop()).toEqual(0);
+    expect(virtual().visibleItems).toEqual([0, 1, 2]);
+    expect(virtual().viewerTop).toEqual(0);
 
     el.scrollTop += 9_980;
     onScroll(TARGETED_SCROLL_EVENT(el));
 
-    expect(visibleItems()).toEqual([997, 998, 999]);
-    expect(viewerTop()).toEqual(9_970);
+    expect(virtual().visibleItems).toEqual([997, 998, 999]);
+    expect(virtual().viewerTop).toEqual(9_970);
   });
 
   test("visibleList takes `overscanCount` into account", () => {
     const el = document.createElement("div");
 
-    const [{ visibleItems }, onScroll] = createVirtualList({
+    const [virtual, onScroll] = createVirtualList({
       items: TEST_LIST,
       rootHeight: 20,
       rowHeight: 10,
@@ -125,39 +125,39 @@ describe("createVirtualList", () => {
     el.scrollTop += 100;
     onScroll(TARGETED_SCROLL_EVENT(el));
 
-    expect(visibleItems()).toEqual([8, 9, 10, 11, 12, 13]);
+    expect(virtual().visibleItems).toEqual([8, 9, 10, 11, 12, 13]);
   });
 
   test("overscanCount defaults to 1 if undefined or zero", () => {
-    const [{ visibleItems: visibleItemsUndefined }] = createVirtualList({
+    const [virtualUndefined] = createVirtualList({
       items: TEST_LIST,
       rootHeight: 20,
       rowHeight: 10,
     });
 
-    expect(visibleItemsUndefined()).toEqual([0, 1, 2]);
+    expect(virtualUndefined().visibleItems).toEqual([0, 1, 2]);
 
-    const [{ visibleItems: visibleItemsZero }] = createVirtualList({
+    const [virtualZero] = createVirtualList({
       items: TEST_LIST,
       rootHeight: 20,
       rowHeight: 10,
       overscanCount: 0,
     });
 
-    expect(visibleItemsZero()).toEqual([0, 1, 2]);
+    expect(virtualZero().visibleItems).toEqual([0, 1, 2]);
   });
 
   test("handles empty list", () => {
-    const [{ containerHeight, viewerTop, visibleItems }] = createVirtualList({
+    const [virtual] = createVirtualList({
       items: [],
       rootHeight: 20,
       rowHeight: 10,
       overscanCount: 0,
     });
 
-    expect(containerHeight()).toEqual(0);
-    expect(viewerTop()).toEqual(0);
-    expect(visibleItems()).toEqual([]);
+    expect(virtual().containerHeight).toEqual(0);
+    expect(virtual().viewerTop).toEqual(0);
+    expect(virtual().visibleItems).toEqual([]);
   });
 });
 

--- a/packages/virtual/test/index.test.tsx
+++ b/packages/virtual/test/index.test.tsx
@@ -1,22 +1,177 @@
 import { describe, test, expect } from "vitest";
-import { VirtualList } from "../src/index.jsx";
 import { render } from "solid-js/web";
+import { createSignal } from "solid-js";
+
+import { createVirtualList, VirtualList } from "../src/index.jsx";
 
 const TEST_LIST = Array.from({ length: 1000 }, (_, i) => i);
 
-const SELECTOR_CLASS_NAME = "scroll-container-selector";
-
 const SCROLL_EVENT = new Event("scroll");
 
-let root = document.createElement("div");
+const ROOT = document.createElement("div");
 
 function getScrollContainer() {
-  const scrollContainer = root.querySelector("." + SELECTOR_CLASS_NAME);
+  const scrollContainer = ROOT.querySelector("div");
   if (scrollContainer === null) {
-    throw "." + SELECTOR_CLASS_NAME + " was not found";
+    throw "scrollContainer not found";
   }
   return scrollContainer;
 }
+
+describe("createVirtualList", () => {
+  const [rootElement] = createSignal(ROOT);
+
+  test("returns containerHeight representing the size of the list container element within the root", () => {
+    const { containerHeight } = createVirtualList({
+      rootElement,
+      items: TEST_LIST,
+      rootHeight: 20,
+      rowHeight: 10,
+    });
+
+    expect(containerHeight()).toEqual(10_000);
+  });
+
+  test("returns viewerTop representing the location of the list viewer element within the list container", () => {
+    const { viewerTop } = createVirtualList({
+      rootElement,
+      items: TEST_LIST,
+      rootHeight: 20,
+      rowHeight: 10,
+    });
+
+    expect(viewerTop()).toEqual(0);
+  });
+
+  test("returns visibleList representing the subset of items to render", () => {
+    const { visibleItems } = createVirtualList({
+      rootElement,
+      items: TEST_LIST,
+      rootHeight: 20,
+      rowHeight: 10,
+    });
+
+    expect(visibleItems()).toEqual([0, 1, 2]);
+  });
+
+  test("returns onScroll which sets viewerTop and visibleItems based on rootElement's scrolltop", () => {
+    const el = document.createElement("div");
+    const [rootElement] = createSignal(el);
+
+    const { onScroll, viewerTop, visibleItems } = createVirtualList({
+      rootElement,
+      items: TEST_LIST,
+      rootHeight: 20,
+      rowHeight: 10,
+    });
+
+    expect(visibleItems()).toEqual([0, 1, 2]);
+    expect(viewerTop()).toEqual(0);
+
+    el.scrollTop += 10;
+
+    // no change until onScroll is called
+    expect(visibleItems()).toEqual([0, 1, 2]);
+    expect(viewerTop()).toEqual(0);
+
+    onScroll();
+
+    expect(visibleItems()).toEqual([0, 1, 2, 3]);
+    expect(viewerTop()).toEqual(0);
+
+    el.scrollTop += 10;
+    onScroll();
+
+    expect(visibleItems()).toEqual([1, 2, 3, 4]);
+    expect(viewerTop()).toEqual(10);
+
+    el.scrollTop -= 10;
+    onScroll();
+
+    expect(visibleItems()).toEqual([0, 1, 2, 3]);
+    expect(viewerTop()).toEqual(0);
+
+    el.scrollTop -= 10;
+    onScroll();
+
+    expect(visibleItems()).toEqual([0, 1, 2]);
+    expect(viewerTop()).toEqual(0);
+  });
+
+  test("onScroll handles reaching the bottom of the list", () => {
+    const el = document.createElement("div");
+    const [rootElement] = createSignal(el);
+
+    const { onScroll, viewerTop, visibleItems } = createVirtualList({
+      rootElement,
+      items: TEST_LIST,
+      rootHeight: 20,
+      rowHeight: 10,
+    });
+
+    expect(visibleItems()).toEqual([0, 1, 2]);
+    expect(viewerTop()).toEqual(0);
+
+    el.scrollTop += 9_980;
+    onScroll();
+
+    expect(visibleItems()).toEqual([997, 998, 999]);
+    expect(viewerTop()).toEqual(9_970);
+  });
+
+  test("visibleList takes `overscanCount` into account", () => {
+    const el = document.createElement("div");
+    const [rootElement] = createSignal(el);
+
+    const { visibleItems, onScroll } = createVirtualList({
+      rootElement,
+      items: TEST_LIST,
+      rootHeight: 20,
+      rowHeight: 10,
+      overscanCount: 2,
+    });
+
+    el.scrollTop += 100;
+    onScroll();
+
+    expect(visibleItems()).toEqual([8, 9, 10, 11, 12, 13]);
+  });
+
+  test("overscanCount defaults to 1 if undefined or zero", () => {
+    const { visibleItems: visibleItemsUndefined } = createVirtualList({
+      rootElement,
+      items: TEST_LIST,
+      rootHeight: 20,
+      rowHeight: 10,
+    });
+
+    expect(visibleItemsUndefined()).toEqual([0, 1, 2]);
+
+    const { visibleItems: visibleItemsZero } = createVirtualList({
+      rootElement,
+      items: TEST_LIST,
+      rootHeight: 20,
+      rowHeight: 10,
+      overscanCount: 0,
+    });
+
+    expect(visibleItemsZero()).toEqual([0, 1, 2]);
+  });
+
+  test("handles empty list", () => {
+    const { containerHeight, viewerTop, visibleItems } = createVirtualList({
+      rootElement,
+      items: [],
+      rootHeight: 20,
+      rowHeight: 10,
+      overscanCount: 0,
+    });
+
+    expect(containerHeight()).toEqual(0);
+    expect(viewerTop()).toEqual(0);
+    expect(visibleItems()).toEqual([]);
+  });
+});
 
 describe("VirtualList", () => {
   test("renders a subset of the items", () => {
@@ -26,13 +181,13 @@ describe("VirtualList", () => {
           {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
-      root,
+      ROOT,
     );
 
-    expect(root.querySelector("#item-0")).not.toBeNull();
-    expect(root.querySelector("#item-1")).not.toBeNull();
-    expect(root.querySelector("#item-2")).not.toBeNull();
-    expect(root.querySelector("#item-3")).toBeNull();
+    expect(ROOT.querySelector("#item-0")).not.toBeNull();
+    expect(ROOT.querySelector("#item-1")).not.toBeNull();
+    expect(ROOT.querySelector("#item-2")).not.toBeNull();
+    expect(ROOT.querySelector("#item-3")).toBeNull();
 
     dispose();
   });
@@ -40,57 +195,57 @@ describe("VirtualList", () => {
   test("renders the correct subset of the items based on scrolling", () => {
     const dispose = render(
       () => (
-        <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10} class={SELECTOR_CLASS_NAME}>
+        <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10}>
           {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
-      root,
+      ROOT,
     );
 
     const scrollContainer = getScrollContainer();
 
     scrollContainer.dispatchEvent(SCROLL_EVENT);
 
-    expect(root.querySelector("#item-0")).not.toBeNull();
-    expect(root.querySelector("#item-1")).not.toBeNull();
-    expect(root.querySelector("#item-2")).not.toBeNull();
-    expect(root.querySelector("#item-3")).toBeNull();
+    expect(ROOT.querySelector("#item-0")).not.toBeNull();
+    expect(ROOT.querySelector("#item-1")).not.toBeNull();
+    expect(ROOT.querySelector("#item-2")).not.toBeNull();
+    expect(ROOT.querySelector("#item-3")).toBeNull();
 
     scrollContainer.scrollTop += 10;
     scrollContainer.dispatchEvent(SCROLL_EVENT);
 
-    expect(root.querySelector("#item-0")).not.toBeNull();
-    expect(root.querySelector("#item-1")).not.toBeNull();
-    expect(root.querySelector("#item-2")).not.toBeNull();
-    expect(root.querySelector("#item-3")).not.toBeNull();
-    expect(root.querySelector("#item-4")).toBeNull();
+    expect(ROOT.querySelector("#item-0")).not.toBeNull();
+    expect(ROOT.querySelector("#item-1")).not.toBeNull();
+    expect(ROOT.querySelector("#item-2")).not.toBeNull();
+    expect(ROOT.querySelector("#item-3")).not.toBeNull();
+    expect(ROOT.querySelector("#item-4")).toBeNull();
 
     scrollContainer.scrollTop += 10;
     scrollContainer.dispatchEvent(SCROLL_EVENT);
 
-    expect(root.querySelector("#item-0")).toBeNull();
-    expect(root.querySelector("#item-1")).not.toBeNull();
-    expect(root.querySelector("#item-2")).not.toBeNull();
-    expect(root.querySelector("#item-3")).not.toBeNull();
-    expect(root.querySelector("#item-4")).not.toBeNull();
-    expect(root.querySelector("#item-5")).toBeNull();
+    expect(ROOT.querySelector("#item-0")).toBeNull();
+    expect(ROOT.querySelector("#item-1")).not.toBeNull();
+    expect(ROOT.querySelector("#item-2")).not.toBeNull();
+    expect(ROOT.querySelector("#item-3")).not.toBeNull();
+    expect(ROOT.querySelector("#item-4")).not.toBeNull();
+    expect(ROOT.querySelector("#item-5")).toBeNull();
 
     scrollContainer.scrollTop -= 10;
     scrollContainer.dispatchEvent(SCROLL_EVENT);
 
-    expect(root.querySelector("#item-0")).not.toBeNull();
-    expect(root.querySelector("#item-1")).not.toBeNull();
-    expect(root.querySelector("#item-2")).not.toBeNull();
-    expect(root.querySelector("#item-3")).not.toBeNull();
-    expect(root.querySelector("#item-4")).toBeNull();
+    expect(ROOT.querySelector("#item-0")).not.toBeNull();
+    expect(ROOT.querySelector("#item-1")).not.toBeNull();
+    expect(ROOT.querySelector("#item-2")).not.toBeNull();
+    expect(ROOT.querySelector("#item-3")).not.toBeNull();
+    expect(ROOT.querySelector("#item-4")).toBeNull();
 
     scrollContainer.scrollTop -= 10;
     scrollContainer.dispatchEvent(SCROLL_EVENT);
 
-    expect(root.querySelector("#item-0")).not.toBeNull();
-    expect(root.querySelector("#item-1")).not.toBeNull();
-    expect(root.querySelector("#item-2")).not.toBeNull();
-    expect(root.querySelector("#item-3")).toBeNull();
+    expect(ROOT.querySelector("#item-0")).not.toBeNull();
+    expect(ROOT.querySelector("#item-1")).not.toBeNull();
+    expect(ROOT.querySelector("#item-2")).not.toBeNull();
+    expect(ROOT.querySelector("#item-3")).toBeNull();
 
     dispose();
   });
@@ -98,11 +253,11 @@ describe("VirtualList", () => {
   test("renders the correct subset of the items for the end of the list", () => {
     const dispose = render(
       () => (
-        <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10} class={SELECTOR_CLASS_NAME}>
+        <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10}>
           {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
-      root,
+      ROOT,
     );
 
     const scrollContainer = getScrollContainer();
@@ -110,11 +265,11 @@ describe("VirtualList", () => {
     scrollContainer.scrollTop += 9_980;
     scrollContainer.dispatchEvent(SCROLL_EVENT);
 
-    expect(root.querySelector("#item-996")).toBeNull();
-    expect(root.querySelector("#item-997")).not.toBeNull();
-    expect(root.querySelector("#item-998")).not.toBeNull();
-    expect(root.querySelector("#item-999")).not.toBeNull();
-    expect(root.querySelector("#item-1000")).toBeNull();
+    expect(ROOT.querySelector("#item-996")).toBeNull();
+    expect(ROOT.querySelector("#item-997")).not.toBeNull();
+    expect(ROOT.querySelector("#item-998")).not.toBeNull();
+    expect(ROOT.querySelector("#item-999")).not.toBeNull();
+    expect(ROOT.querySelector("#item-1000")).toBeNull();
 
     dispose();
   });
@@ -122,17 +277,11 @@ describe("VirtualList", () => {
   test("renders `overscanCount` rows above and below the visible rendered items", () => {
     const dispose = render(
       () => (
-        <VirtualList
-          each={TEST_LIST}
-          rootHeight={20}
-          rowHeight={10}
-          overscanCount={2}
-          class={SELECTOR_CLASS_NAME}
-        >
+        <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10} overscanCount={2}>
           {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
-      root,
+      ROOT,
     );
 
     const scrollContainer = getScrollContainer();
@@ -140,70 +289,14 @@ describe("VirtualList", () => {
     scrollContainer.scrollTop += 100;
     scrollContainer.dispatchEvent(SCROLL_EVENT);
 
-    expect(root.querySelector("#item-7")).toBeNull();
-    expect(root.querySelector("#item-8")).not.toBeNull();
-    expect(root.querySelector("#item-9")).not.toBeNull();
-    expect(root.querySelector("#item-10")).not.toBeNull();
-    expect(root.querySelector("#item-11")).not.toBeNull();
-    expect(root.querySelector("#item-12")).not.toBeNull();
-    expect(root.querySelector("#item-13")).not.toBeNull();
-    expect(root.querySelector("#item-14")).toBeNull();
-
-    dispose();
-  });
-
-  test("overscanCount defaults to 1 if undefined", () => {
-    const dispose = render(
-      () => (
-        <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10} class={SELECTOR_CLASS_NAME}>
-          {item => <div id={"item-" + item} style={{ height: "10px" }} />}
-        </VirtualList>
-      ),
-      root,
-    );
-
-    const scrollContainer = getScrollContainer();
-
-    scrollContainer.scrollTop += 100;
-    scrollContainer.dispatchEvent(SCROLL_EVENT);
-
-    expect(root.querySelector("#item-8")).toBeNull();
-    expect(root.querySelector("#item-9")).not.toBeNull();
-    expect(root.querySelector("#item-10")).not.toBeNull();
-    expect(root.querySelector("#item-11")).not.toBeNull();
-    expect(root.querySelector("#item-12")).not.toBeNull();
-    expect(root.querySelector("#item-13")).toBeNull();
-
-    dispose();
-  });
-
-  test("overscanCount defaults to 1 if set to zero", () => {
-    const dispose = render(
-      () => (
-        <VirtualList
-          each={TEST_LIST}
-          rootHeight={20}
-          rowHeight={10}
-          overscanCount={0}
-          class={SELECTOR_CLASS_NAME}
-        >
-          {item => <div id={"item-" + item} style={{ height: "10px" }} />}
-        </VirtualList>
-      ),
-      root,
-    );
-
-    const scrollContainer = getScrollContainer();
-
-    scrollContainer.scrollTop += 100;
-    scrollContainer.dispatchEvent(SCROLL_EVENT);
-
-    expect(root.querySelector("#item-8")).toBeNull();
-    expect(root.querySelector("#item-9")).not.toBeNull();
-    expect(root.querySelector("#item-10")).not.toBeNull();
-    expect(root.querySelector("#item-11")).not.toBeNull();
-    expect(root.querySelector("#item-12")).not.toBeNull();
-    expect(root.querySelector("#item-13")).toBeNull();
+    expect(ROOT.querySelector("#item-7")).toBeNull();
+    expect(ROOT.querySelector("#item-8")).not.toBeNull();
+    expect(ROOT.querySelector("#item-9")).not.toBeNull();
+    expect(ROOT.querySelector("#item-10")).not.toBeNull();
+    expect(ROOT.querySelector("#item-11")).not.toBeNull();
+    expect(ROOT.querySelector("#item-12")).not.toBeNull();
+    expect(ROOT.querySelector("#item-13")).not.toBeNull();
+    expect(ROOT.querySelector("#item-14")).toBeNull();
 
     dispose();
   });
@@ -211,11 +304,11 @@ describe("VirtualList", () => {
   test("renders when list is empty", () => {
     const dispose = render(
       () => (
-        <VirtualList each={[]} rootHeight={20} rowHeight={10} class={SELECTOR_CLASS_NAME}>
+        <VirtualList each={[]} rootHeight={20} rowHeight={10}>
           {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
-      root,
+      ROOT,
     );
 
     expect(getScrollContainer()).not.toBeNull();
@@ -226,22 +319,16 @@ describe("VirtualList", () => {
   test("renders when list is empty with optional fallback", () => {
     const dispose = render(
       () => (
-        <VirtualList
-          each={[]}
-          fallback={<div id="fallback" />}
-          rootHeight={20}
-          rowHeight={10}
-          class={SELECTOR_CLASS_NAME}
-        >
+        <VirtualList each={[]} fallback={<div id="fallback" />} rootHeight={20} rowHeight={10}>
           {item => <div id={"item-" + item} style={{ height: "10px" }} />}
         </VirtualList>
       ),
-      root,
+      ROOT,
     );
 
     expect(getScrollContainer()).not.toBeNull();
 
-    expect(root.querySelector("#fallback")).not.toBeNull();
+    expect(ROOT.querySelector("#fallback")).not.toBeNull();
 
     dispose();
   });

--- a/packages/virtual/test/index.test.tsx
+++ b/packages/virtual/test/index.test.tsx
@@ -207,4 +207,42 @@ describe("VirtualList", () => {
 
     dispose();
   });
+
+  test("renders when list is empty", () => {
+    const dispose = render(
+      () => (
+        <VirtualList each={[]} rootHeight={20} rowHeight={10} class={SELECTOR_CLASS_NAME}>
+          {item => <div id={"item-" + item} style={{ height: "10px" }} />}
+        </VirtualList>
+      ),
+      root,
+    );
+
+    expect(getScrollContainer()).not.toBeNull();
+
+    dispose();
+  });
+
+  test("renders when list is empty with optional fallback", () => {
+    const dispose = render(
+      () => (
+        <VirtualList
+          each={[]}
+          fallback={<div id="fallback" />}
+          rootHeight={20}
+          rowHeight={10}
+          class={SELECTOR_CLASS_NAME}
+        >
+          {item => <div id={"item-" + item} style={{ height: "10px" }} />}
+        </VirtualList>
+      ),
+      root,
+    );
+
+    expect(getScrollContainer()).not.toBeNull();
+
+    expect(root.querySelector("#fallback")).not.toBeNull();
+
+    dispose();
+  });
 });

--- a/packages/virtual/test/index.test.tsx
+++ b/packages/virtual/test/index.test.tsx
@@ -10,17 +10,16 @@ const SCROLL_EVENT = new Event("scroll");
 
 let root = document.createElement("div");
 
-function get_scroll_continer() {
-  const scroll_container = root.querySelector("." + SELECTOR_CLASS_NAME);
-  if (scroll_container == null) {
+function getScrollContainer() {
+  const scrollContainer = root.querySelector("." + SELECTOR_CLASS_NAME);
+  if (scrollContainer === null) {
     throw "." + SELECTOR_CLASS_NAME + " was not found";
   }
-  return scroll_container;
+  return scrollContainer;
 }
 
 describe("VirtualList", () => {
   test("renders a subset of the items", () => {
-    let root = document.createElement("div");
     const dispose = render(
       () => (
         <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10}>
@@ -38,7 +37,7 @@ describe("VirtualList", () => {
     dispose();
   });
 
-  test("scrolling renders the correct subset of the items", () => {
+  test("renders the correct subset of the items based on scrolling", () => {
     const dispose = render(
       () => (
         <VirtualList each={TEST_LIST} rootHeight={20} rowHeight={10} class={SELECTOR_CLASS_NAME}>
@@ -47,17 +46,18 @@ describe("VirtualList", () => {
       ),
       root,
     );
-    const scroll_container = get_scroll_continer();
 
-    scroll_container.dispatchEvent(SCROLL_EVENT);
+    const scrollContainer = getScrollContainer();
+
+    scrollContainer.dispatchEvent(SCROLL_EVENT);
 
     expect(root.querySelector("#item-0")).not.toBeNull();
     expect(root.querySelector("#item-1")).not.toBeNull();
     expect(root.querySelector("#item-2")).not.toBeNull();
     expect(root.querySelector("#item-3")).toBeNull();
 
-    scroll_container.scrollTop += 10;
-    scroll_container.dispatchEvent(SCROLL_EVENT);
+    scrollContainer.scrollTop += 10;
+    scrollContainer.dispatchEvent(SCROLL_EVENT);
 
     expect(root.querySelector("#item-0")).not.toBeNull();
     expect(root.querySelector("#item-1")).not.toBeNull();
@@ -65,8 +65,8 @@ describe("VirtualList", () => {
     expect(root.querySelector("#item-3")).not.toBeNull();
     expect(root.querySelector("#item-4")).toBeNull();
 
-    scroll_container.scrollTop += 10;
-    scroll_container.dispatchEvent(SCROLL_EVENT);
+    scrollContainer.scrollTop += 10;
+    scrollContainer.dispatchEvent(SCROLL_EVENT);
 
     expect(root.querySelector("#item-0")).toBeNull();
     expect(root.querySelector("#item-1")).not.toBeNull();
@@ -75,8 +75,8 @@ describe("VirtualList", () => {
     expect(root.querySelector("#item-4")).not.toBeNull();
     expect(root.querySelector("#item-5")).toBeNull();
 
-    scroll_container.scrollTop -= 10;
-    scroll_container.dispatchEvent(SCROLL_EVENT);
+    scrollContainer.scrollTop -= 10;
+    scrollContainer.dispatchEvent(SCROLL_EVENT);
 
     expect(root.querySelector("#item-0")).not.toBeNull();
     expect(root.querySelector("#item-1")).not.toBeNull();
@@ -84,8 +84,8 @@ describe("VirtualList", () => {
     expect(root.querySelector("#item-3")).not.toBeNull();
     expect(root.querySelector("#item-4")).toBeNull();
 
-    scroll_container.scrollTop -= 10;
-    scroll_container.dispatchEvent(SCROLL_EVENT);
+    scrollContainer.scrollTop -= 10;
+    scrollContainer.dispatchEvent(SCROLL_EVENT);
 
     expect(root.querySelector("#item-0")).not.toBeNull();
     expect(root.querySelector("#item-1")).not.toBeNull();
@@ -104,10 +104,11 @@ describe("VirtualList", () => {
       ),
       root,
     );
-    const scroll_container = get_scroll_continer();
 
-    scroll_container.scrollTop += 9_980;
-    scroll_container.dispatchEvent(SCROLL_EVENT);
+    const scrollContainer = getScrollContainer();
+
+    scrollContainer.scrollTop += 9_980;
+    scrollContainer.dispatchEvent(SCROLL_EVENT);
 
     expect(root.querySelector("#item-996")).toBeNull();
     expect(root.querySelector("#item-997")).not.toBeNull();
@@ -118,7 +119,7 @@ describe("VirtualList", () => {
     dispose();
   });
 
-  test("renders `overScan` rows above and below the visible rendered items", () => {
+  test("renders `overscanCount` rows above and below the visible rendered items", () => {
     const dispose = render(
       () => (
         <VirtualList
@@ -133,10 +134,11 @@ describe("VirtualList", () => {
       ),
       root,
     );
-    const scroll_container = get_scroll_continer();
 
-    scroll_container.scrollTop += 100;
-    scroll_container.dispatchEvent(SCROLL_EVENT);
+    const scrollContainer = getScrollContainer();
+
+    scrollContainer.scrollTop += 100;
+    scrollContainer.dispatchEvent(SCROLL_EVENT);
 
     expect(root.querySelector("#item-7")).toBeNull();
     expect(root.querySelector("#item-8")).not.toBeNull();
@@ -159,10 +161,11 @@ describe("VirtualList", () => {
       ),
       root,
     );
-    const scroll_container = get_scroll_continer();
 
-    scroll_container.scrollTop += 100;
-    scroll_container.dispatchEvent(SCROLL_EVENT);
+    const scrollContainer = getScrollContainer();
+
+    scrollContainer.scrollTop += 100;
+    scrollContainer.dispatchEvent(SCROLL_EVENT);
 
     expect(root.querySelector("#item-8")).toBeNull();
     expect(root.querySelector("#item-9")).not.toBeNull();
@@ -189,10 +192,11 @@ describe("VirtualList", () => {
       ),
       root,
     );
-    const scroll_container = get_scroll_continer();
 
-    scroll_container.scrollTop += 100;
-    scroll_container.dispatchEvent(SCROLL_EVENT);
+    const scrollContainer = getScrollContainer();
+
+    scrollContainer.scrollTop += 100;
+    scrollContainer.dispatchEvent(SCROLL_EVENT);
 
     expect(root.querySelector("#item-8")).toBeNull();
     expect(root.querySelector("#item-9")).not.toBeNull();

--- a/packages/virtual/test/server.test.tsx
+++ b/packages/virtual/test/server.test.tsx
@@ -14,7 +14,7 @@ describe("VirtualList", () => {
         rowHeight={10}
         class="classString"
       >
-        {item => <div style={{ height: "100px" }}>{item}</div>}
+        {item => <div style={{ height: "10px" }}>{item}</div>}
       </VirtualList>
     ));
 
@@ -23,9 +23,9 @@ describe("VirtualList", () => {
         '<div style="overflow:auto;height:20px" class="classString">',
         '  <div style="position:relative;width:100%;height:10000px">',
         '    <div style="position:absolute;top:0px">',
-        '      <div style="height:100px">0</div>',
-        '      <div style="height:100px">1</div>',
-        '      <div style="height:100px">2</div>',
+        '      <div style="height:10px">0</div>',
+        '      <div style="height:10px">1</div>',
+        '      <div style="height:10px">2</div>',
         "    </div>",
         "  </div>",
         "</div>",

--- a/packages/virtual/test/server.test.tsx
+++ b/packages/virtual/test/server.test.tsx
@@ -7,20 +7,14 @@ const TEST_LIST = Array.from({ length: 1000 }, (_, i) => i);
 describe("VirtualList", () => {
   test("doesn't break in SSR", () => {
     const virtualListStr = renderToString(() => (
-      <VirtualList
-        each={TEST_LIST}
-        overscanCount={1}
-        rootHeight={20}
-        rowHeight={10}
-        class="classString"
-      >
+      <VirtualList each={TEST_LIST} overscanCount={1} rootHeight={20} rowHeight={10}>
         {item => <div style={{ height: "10px" }}>{item}</div>}
       </VirtualList>
     ));
 
     expect(virtualListStr).toEqual(
       [
-        '<div style="overflow:auto;height:20px" class="classString">',
+        '<div style="overflow:auto;height:20px">',
         '  <div style="position:relative;width:100%;height:10000px">',
         '    <div style="position:absolute;top:0px">',
         '      <div style="height:10px">0</div>',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -956,6 +956,9 @@ importers:
 
   packages/virtual:
     dependencies:
+      '@solid-primitives/utils':
+        specifier: workspace:^
+        version: link:../utils
       solid-js:
         specifier: ^1.6.12
         version: 1.8.20


### PR DESCRIPTION
As previously suggested, this is an attempt at rewriting the virtual list comp to be a headless utility function and adds tests and docs. It still exports the VirtualList comp for convenience, which uses the utility internally. The utility and comp are tested separately.

I think a lot of the TS in here is gross and people who know solid better than me might have better ideas for how to handle the ref. However, it does work and most of the ugliness is hidden from consumers. I don't really like the API, in terms of what you need to pass in and what comes back out and how you have to use it with the JSX, but I couldn't find anything to remove/add/simplify from/to/in it.