### PR TITLE
Entries takes key's type as a generic

### DIFF
--- a/.changeset/lemon-planets-try.md
+++ b/.changeset/lemon-planets-try.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/keyed": patch
+---
+
+Makes Entries take key's type as a generic

--- a/packages/keyed/src/index.ts
+++ b/packages/keyed/src/index.ts
@@ -176,10 +176,14 @@ export function Key<T>(props: {
  *
  * @see https://github.com/solidjs-community/solid-primitives/tree/main/packages/keyed#Entries
  */
-export function Entries<V>(props: {
-  of: Record<string, V> | ArrayLike<V> | undefined | null | false;
+export function Entries<K extends string | number, V>(props: {
+  of: Record<K, V> | ArrayLike<V> | undefined | null | false;
   fallback?: JSX.Element;
-  children: (key: string, v: Accessor<V>, i: Accessor<number>) => JSX.Element;
+  children: (
+    key: K extends number ? string : K,
+    v: Accessor<V>,
+    i: Accessor<number>,
+  ) => JSX.Element;
 }): JSX.Element {
   const mapFn = props.children;
   return createMemo(
@@ -191,7 +195,7 @@ export function Entries<V>(props: {
               key,
               () => props.of![key as never],
             )
-        : (key, i) => mapFn(key, () => props.of![key as never], i),
+        : (key, i) => mapFn(key as never, () => props.of![key as never], i),
       "fallback" in props ? { fallback: () => props.fallback } : undefined,
     ),
   ) as unknown as JSX.Element;


### PR DESCRIPTION
I have an object whose keys are "[branded](https://www.learningtypescript.com/articles/branded-types)" strings, which are basically more strictly typed strings. This PR fixes the type of the key passed through to the callback.

I demo the new behavior in the screenshot below, where you can see the types in the inline hints:

![image](https://github.com/user-attachments/assets/b65cef97-ed78-4169-b782-d84cce07c243)
