### PR TITLE
don't check mapFn length

### DIFF
--- a/packages/keyed/dev/entries.tsx
+++ b/packages/keyed/dev/entries.tsx
@@ -1,6 +1,6 @@
 // changes to this file might be applicable to similar files - grep 95DB7339-BB2A-4F06-A34A-25DDF8BF7AF7
 
-import { createStore, produce } from "solid-js/store";
+import { createStore } from "solid-js/store";
 import { createEffect } from "solid-js";
 import { Entries } from "../src/index.js";
 import { TransitionGroup } from "solid-transition-group";

--- a/packages/keyed/src/index.ts
+++ b/packages/keyed/src/index.ts
@@ -189,14 +189,8 @@ export function Entries<K extends string | number, V>(props: {
   const mapFn = props.children;
   return createMemo(
     mapArray(
-      () => props.of && Object.keys(props.of),
-      mapFn.length < 3
-        ? key =>
-            (mapFn as (key: string, v: Accessor<V>) => JSX.Element)(
-              key,
-              () => props.of![key as never],
-            )
-        : (key, i) => mapFn(key as never, () => props.of![key as never], i),
+      () => props.of && (Object.keys(props.of) as never[]),
+      (key, i) => mapFn(key, () => props.of![key], i),
       "fallback" in props ? { fallback: () => props.fallback } : undefined,
     ),
   ) as unknown as JSX.Element;
@@ -227,13 +221,7 @@ export function MapEntries<K, V>(props: {
   return createMemo(
     mapArray(
       () => props.of && Array.from(props.of.keys()),
-      mapFn.length < 3
-        ? key =>
-            (mapFn as (key: K, v: Accessor<V>) => JSX.Element)(
-              key,
-              () => (props.of as Map<K, V>).get(key)!,
-            )
-        : (key, i) => mapFn(key, () => (props.of as Map<K, V>).get(key)!, i),
+      (key, i) => mapFn(key, () => (props.of as Map<K, V>).get(key)!, i),
       "fallback" in props ? { fallback: () => props.fallback } : undefined,
     ),
   ) as unknown as JSX.Element;


### PR DESCRIPTION
In the course of writing `<SetEntries>`, I did a bit of digging on something I found confusing, resulting in this PR.

I'm not sure why we need to check the parameter count of the `mapFn`:

https://github.com/solidjs-community/solid-primitives/blob/71f6c5e2621b6ab2c3811b1ccc5acfbf2319ab3d/packages/keyed/src/index.ts#L230-L237

Without types for easier reading:

```js
mapFn.length < 3
    ? (key   ) => mapFn(key, () => props.of.get(key))
    : (key, i) => mapFn(key, () => props.of.get(key), i),
```

The `mapFn` is user-defined and may take 2 or 3 parameters. However, I believe that this is irrelevant and can be simplified to 

```js
(key, i) => mapFn(key, () => props.of.get(key), i),
```

You can see that in the following code, if you pass 3 arguments to a function that has 2 parameters, the 3rd argument is ignored:

```ts
let xs = ["a", "b", "c"]

const userFn2 = (key: string, val: string) => {
    return [key, val]
}

const userFn3 = (key: string, val: string, i: number) => {
    return [key, val, i]
}

console.log("userFn2       ", xs.map(x      => userFn2(x, x)))
console.log("userFn3       ", xs.map((x, i) => userFn3(x, x, i)))
console.log("userFn2 with 3", xs.map((x, i) => userFn2(x, x, i)))
//[LOG]: "userFn2       ",  [["a", "a"], ["b", "b"], ["c", "c"]] 
//[LOG]: "userFn3       ",  [["a", "a", 0], ["b", "b", 1], ["c", "c", 2]] 
//[LOG]: "userFn2 with 3",  [["a", "a"], ["b", "b"], ["c", "c"]]
```

[Playground.](https://www.typescriptlang.org/play/?ssl=13&ssc=66&pln=1&pc=1#code/DYUwLgBAHgzhC8EDaAiAhigNBFAjLOAxigLoBQZhA9gHYyQCuMIATgGI0BMCEAFANYgAngC4I9FgEsaAc2wA3NMDETpMgJQIAfBADeZCIYgtwDFjWSChCpeQC+FanUbN2NAMw8BwlWCmybZXE-NWxJMRoGAFtcVk14HX0jY1NzS2FAsPtHWhgqUAA6YCoZXhQmVg5uZMMCWAKotAAHXiga7QgKt05W7Ch1Acpc-JAikrKujk92upgG5t5eiEl4nUmPJagwgfUhuhGx0vLXKogAd0kwAAsId1n5lqWVjvWerehtwaA)

This demos what happens when the user gives us a fn with 2 parameters, but `solid-primitives` gives it 3 arguments.

[Relevant StackOverflow.](https://stackoverflow.com/questions/12694031/)

Perhaps I'm missing something obvious - I'm not super experienced with JS 😅