### PR TITLE
fix: static-store setValue with setterFn has correct arguments

### DIFF
--- a/.changeset/silent-paws-approve.md
+++ b/.changeset/silent-paws-approve.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/static-store": patch
+---
+
+fix: static-store setValue with setterFn has correct arguments

--- a/packages/static-store/src/index.ts
+++ b/packages/static-store/src/index.ts
@@ -68,7 +68,7 @@ export function createStaticStore<T extends object>(
   const setValue = (key: keyof T, value: SetterParam<any>): void => {
     const signal = cache[key];
     if (signal) return signal[1](value);
-    if (key in copy) copy[key] = accessWith(value, [copy[key]]);
+    if (key in copy) copy[key] = accessWith(value, copy[key]);
   };
 
   return [

--- a/packages/static-store/test/index.test.ts
+++ b/packages/static-store/test/index.test.ts
@@ -32,6 +32,9 @@ describe("createStaticStore", () => {
         d: [0, 1, 2],
       });
 
+      setState('a', prev => prev + 1);
+      expect(state.a).toBe(10);
+
       createEffect(() => {
         state.a;
         aUpdates++;


### PR DESCRIPTION
if a key is not listened to, setValue on that key incorrectly wraps the prev value in an array when passed as argument to a setterFn

```
const [state, setState] = createStaticStore({a: 1});
setState('a', prev => prev + 1); // prev is `[1]`, should be `1`
```