### PR TITLE
fix kbd typo in keyboard readme

### DIFF
--- a/packages/keyboard/README.md
+++ b/packages/keyboard/README.md
@@ -74,7 +74,7 @@ createEffect(() => {
 });
 
 <For each={keys()}>
-  {key => <kbd>{key}</kdb>}
+  {key => <kbd>{key}</kbd>}
 </For>
 ```
 


### PR DESCRIPTION
the closing tag said `</kdb>` instead of `</kbd>`