### PR TITLE
fix: selection contenteditable node detection

### DIFF
--- a/.changeset/light-boxes-cough.md
+++ b/.changeset/light-boxes-cough.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/selection": patch
+---
+
+fix: selection contenteditable node detection

--- a/packages/selection/dev/index.tsx
+++ b/packages/selection/dev/index.tsx
@@ -34,6 +34,11 @@ const App: Component = () => {
         <div contentEditable>
           t<b>e</b>
           <i>s</i>t
+          <ul>
+            <li>first item</li>
+            <li>second item</li>
+            <li>third item</li>
+          </ul>
         </div>
       </div>
       <div>

--- a/packages/selection/src/index.ts
+++ b/packages/selection/src/index.ts
@@ -17,7 +17,7 @@ export const getTextNodes = (startNode: Node) => {
 const addNodeLength = (length: number, node: Node) => length + (node as Text).data.length;
 
 const getRangePos = (container: Node, offset: number, texts: Node[]) => {
-  const index = texts.indexOf(container);
+  const index = texts.findIndex((text) => text === container || text.parentElement === container);
   return index === -1 ? NaN : texts.slice(0, index).reduce(addNodeLength, 0) + offset;
 };
 


### PR DESCRIPTION
If you triple click on an li inside a list inside a contenteditable div (except for the last one), you get a selectionEnd of NaN. This is because for reasons unknown, in this case we receive the parent of the text node instead of the text node in the range.