### PR TITLE
Add `ConsumeContext`

### DIFF
--- a/.changeset/strong-moose-attend.md
+++ b/.changeset/strong-moose-attend.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/context": minor
+---
+
+Add `ConsumeContext`

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -135,11 +135,13 @@ import { MultiProvider } from "@solid-primitives/context";
 
 Inspired by React's `Context.Consumer` component, `ConsumeContext` allows using contexts directly within JSX without the needing to extract the content JSX into a separate function.
 
-This is particularly useful when you want to use the context in the same JSX block where you're providing it and directly bind the context value to HTML.
+This is particularly useful when you want to use the context in the same JSX block where you're providing it and directly bind the context value to the frontend.
+
+Note that this component solely serves as syntactic sugar and doesn't provide any additional functionality over inlining SolidJS's `useContext` hook within JSX.
 
 ### How to use it
 
-`ConsumeContext` takes a `useFn` prop with the context's `use...` function and a `children` prop that will receive the context value. The use function may directly come from `createContextProvider`.
+`ConsumeContext` takes a `useFn` prop with the context's `use...()` function and a `children` prop that will receive the context value. The use function may directly come from `createContextProvider()`.
 
 ```tsx
 import { createContextProvider, ConsumeContext } from "@solid-primitives/context";
@@ -164,7 +166,21 @@ const [CounterProvider, useCounter] = createContextProvider(() => {
 </CounterProvider>;
 ```
 
+Alternatively, you may also pass the raw SolidJS context over `context` in case you have created a context using `createContext()`.
+
 ```tsx
+import { ConsumeContext } from "@solid-primitives/context";
+
+// Create a context
+const CounterContext = createContext(/*...*/);
+
+// Consume it using the raw context
+<ConsumeContext context={CounterContext}>
+  {({ count, increment }) => {
+    // ...
+  }}
+</ConsumeContext>
+```
 
 ## Changelog
 

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -12,6 +12,7 @@ Primitives simplifying the creation and use of SolidJS Context API.
 
 - [`createContextProvider`](#createcontextprovider) - Create the Context Provider component and useContext function with types inferred from the factory function.
 - [`MultiProvider`](#multiprovider) - A component that allows you to provide multiple contexts at once.
+- [`ConsumeContext`](#consumecontext) - A component that allows you to consume contexts directly within JSX.
 
 ## Installation
 
@@ -129,6 +130,41 @@ import { MultiProvider } from "@solid-primitives/context";
 
 > **Warning**
 > Components and values passed to `MultiProvider` will be evaluated only once, so make sure that the structure is static. If is isn't, please use nested provider components instead.
+
+## `ConsumeContext`
+
+Inspired by React's `Context.Consumer` component, `ConsumeContext` allows using contexts directly within JSX without the needing to extract the content JSX into a separate function.
+
+This is particularly useful when you want to use the context in the same JSX block where you're providing it and directly bind the context value to HTML.
+
+### How to use it
+
+`ConsumeContext` takes a `useFn` prop with the context's `use...` function and a `children` prop that will receive the context value. The use function may directly come from `createContextProvider`.
+
+```tsx
+import { createContextProvider, ConsumeContext } from "@solid-primitives/context";
+
+// Create a context provider
+const [CounterProvider, useCounter] = createContextProvider(() => {
+  const [count, setCount] = createSignal(0);
+  const increment = () => setCount(count() + 1);
+  return { count, increment };
+});
+
+// Provide it, consume it and use it in the same JSX block
+<CounterProvider>
+  <ConsumeContext useFn={useCounter}>
+    {({ count, increment }) => (
+      <div>
+        <button onClick={increment}>Increment</button>
+        <span>{count()}</span>
+      </div>
+    )}
+  </ConsumeContext>
+</CounterProvider>;
+```
+
+```tsx
 
 ## Changelog
 

--- a/packages/context/README.md
+++ b/packages/context/README.md
@@ -141,7 +141,9 @@ Note that this component solely serves as syntactic sugar and doesn't provide an
 
 ### How to use it
 
-`ConsumeContext` takes a `useFn` prop with the context's `use...()` function and a `children` prop that will receive the context value. The use function may directly come from `createContextProvider()`.
+`ConsumeContext` takes a `use` prop that can be either one of the following:
+* A `use...()` function returned by `createContextProvider` or a inline function that returns the context value like `() => useContext(MyContext)`.
+* A `context` prop that takes a raw SolidJS context created by `createContext()`.
 
 ```tsx
 import { createContextProvider, ConsumeContext } from "@solid-primitives/context";
@@ -155,7 +157,7 @@ const [CounterProvider, useCounter] = createContextProvider(() => {
 
 // Provide it, consume it and use it in the same JSX block
 <CounterProvider>
-  <ConsumeContext useFn={useCounter}>
+  <ConsumeContext use={useCounter}>
     {({ count, increment }) => (
       <div>
         <button onClick={increment}>Increment</button>
@@ -163,19 +165,19 @@ const [CounterProvider, useCounter] = createContextProvider(() => {
       </div>
     )}
   </ConsumeContext>
-</CounterProvider>;
+</CounterProvider>
 ```
 
-Alternatively, you may also pass the raw SolidJS context over `context` in case you have created a context using `createContext()`.
+With the raw SolidJS context returned by `createContext()`:
 
 ```tsx
 import { ConsumeContext } from "@solid-primitives/context";
 
 // Create a context
-const CounterContext = createContext(/*...*/);
+const counterContext = createContext(/*...*/);
 
 // Consume it using the raw context
-<ConsumeContext context={CounterContext}>
+<ConsumeContext use={counterContext}>
   {({ count, increment }) => {
     // ...
   }}

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -124,7 +124,19 @@ export function MultiProvider<T extends readonly [unknown?, ...unknown[]]>(props
  * A component that allows you to consume a context without extracting the children into a separate function.
  * This is particularly useful when the context needs to be used within the same JSX where it is provided.
  *
- * @param useFn A function that returns the context value. Preferably the `use...` function returned from `createContextProvider`.
+ * The `ConsumeContext` component is equivalent to the following code and solely exists as syntactic sugar:
+ *
+ * ```tsx
+ * <CounterProvider>
+ *   {untrack(() => {
+ *     const context = useContext(counterContext); // or useCounter()
+ *     return children(context);
+ *   })}
+ * </CounterProvider>
+ * ```
+ *
+ * @param useFn A function that returns the context value. Preferably the `use...()` function returned from `createContextProvider()`.
+ * @param context The context object itself returned by `createContext()`. If `useFn` is provided, this will be ignored.
  *
  * @example
  * ```tsx
@@ -140,9 +152,14 @@ export function MultiProvider<T extends readonly [unknown?, ...unknown[]]>(props
  * ```
  */
 export function ConsumeContext<T>(props: {
-  useFn: () => T | undefined,
   children: (value: T | undefined) => JSX.Element
-}): JSX.Element {
-  const context = props.useFn();
+} & ({
+  useFn: () => T | undefined,
+  context?: never;
+} | {
+  useFn?: never;
+  context: Context<T>;
+})): JSX.Element {
+  const context = props.useFn ? props.useFn() : useContext(props.context);
   return props.children(context);
 }

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -119,3 +119,30 @@ export function MultiProvider<T extends readonly [unknown?, ...unknown[]]>(props
   };
   return fn(0);
 }
+
+/**
+ * A component that allows you to consume a context without extracting the children into a separate function.
+ * This is particularly useful when the context needs to be used within the same JSX where it is provided.
+ *
+ * @param useFn A function that returns the context value. Preferably the `use...` function returned from `createContextProvider`.
+ *
+ * @example
+ * ```tsx
+ * // create the context
+ * const [CounterProvider, useCounter] // = createContextProvider(...)
+ *
+ * // use the context
+ * <ConsumeContext useFn={useCounter}>
+ *   {({ count }) => (
+ *     <div>Count: {count()}</div>
+ *   )}
+ * </ConsumeContext>
+ * ```
+ */
+export function ConsumeContext<T>(props: {
+  useFn: () => T | undefined,
+  children: (value: T | undefined) => JSX.Element
+}): JSX.Element {
+  const context = props.useFn();
+  return props.children(context);
+}

--- a/packages/context/src/index.ts
+++ b/packages/context/src/index.ts
@@ -135,31 +135,49 @@ export function MultiProvider<T extends readonly [unknown?, ...unknown[]]>(props
  * </CounterProvider>
  * ```
  *
- * @param useFn A function that returns the context value. Preferably the `use...()` function returned from `createContextProvider()`.
- * @param context The context object itself returned by `createContext()`. If `useFn` is provided, this will be ignored.
+ * @param use Either one of the following:
+ *  - A function that returns the context value. Preferably the `use...()` function returned from `createContextProvider()`.
+ *  - The context itself returned from `createContext()`.
+ *  - A inline function that returns the context value.
  *
  * @example
  * ```tsx
  * // create the context
  * const [CounterProvider, useCounter] // = createContextProvider(...)
  *
- * // use the context
- * <ConsumeContext useFn={useCounter}>
- *   {({ count }) => (
- *     <div>Count: {count()}</div>
- *   )}
- * </ConsumeContext>
+ * // provide and use the context
+ * <CounterProvider count={1}>
+ *   <ConsumeContext use={useCounter}>
+ *     {({ count }) => (
+ *       <div>Count: {count()}</div>
+ *     )}
+ *   </ConsumeContext>
+ * </CounterProvider>
+ * ```
+ *
+ * ```tsx
+ * // create the context
+ * const counterContext = createContext({ count: 0 });
+ *
+ * // provide and use the context
+ * <counterContext.Provider value={{ count: 1 }}>
+ *   <ConsumeContext use={counterContext}>
+ *     {({ count }) => (
+ *       <div>Count: {count}</div>
+ *     )}
+ *   </ConsumeContext>
+ * </counterContext.Provider>
  * ```
  */
 export function ConsumeContext<T>(props: {
-  children: (value: T | undefined) => JSX.Element
-} & ({
-  useFn: () => T | undefined,
-  context?: never;
-} | {
-  useFn?: never;
-  context: Context<T>;
-})): JSX.Element {
-  const context = props.useFn ? props.useFn() : useContext(props.context);
+  children: (value: T | undefined) => JSX.Element,
+  use: (() => T | undefined) | Context<T>,
+}): JSX.Element {
+  let context: T | undefined;
+  if (typeof props.use === "function") {
+    context = props.use();
+  } else {
+    context = useContext(props.use);
+  }
   return props.children(context);
 }

--- a/packages/context/test/index.test.tsx
+++ b/packages/context/test/index.test.tsx
@@ -109,7 +109,7 @@ describe("MultiProvider", () => {
 });
 
 describe("ConsumeContext", () => {
-  test("consumes a context", () => {
+  test("consumes a context via use-function", () => {
     const Ctx = createContext<string>("Hello");
 
     function useCtx() {
@@ -120,6 +120,23 @@ describe("ConsumeContext", () => {
     createRoot(() => {
       <Ctx.Provider value="World">
         <ConsumeContext useFn={useCtx}>
+          {value => (
+            capture = value
+          )}
+        </ConsumeContext>
+      </Ctx.Provider>;
+    });
+
+    expect(capture).toBe("World");
+  });
+
+  test("consumes a context via context object", () => {
+    const Ctx = createContext<string>("Hello");
+
+    let capture;
+    createRoot(() => {
+      <Ctx.Provider value="World">
+        <ConsumeContext context={Ctx}>
           {value => (
             capture = value
           )}

--- a/packages/context/test/index.test.tsx
+++ b/packages/context/test/index.test.tsx
@@ -109,41 +109,35 @@ describe("MultiProvider", () => {
 });
 
 describe("ConsumeContext", () => {
-  test("consumes a context via use-function", () => {
+  test("consumes a context", () => {
     const Ctx = createContext<string>("Hello");
+    const useCtx = () => useContext(Ctx);
 
-    function useCtx() {
-      return useContext(Ctx);
-    }
-
-    let capture;
+    let capture1;
+    let capture2;
+    let capture3;
     createRoot(() => {
       <Ctx.Provider value="World">
-        <ConsumeContext useFn={useCtx}>
+        <ConsumeContext use={Ctx}>
           {value => (
-            capture = value
+            capture1 = value
+          )}
+        </ConsumeContext>
+        <ConsumeContext use={useCtx}>
+          {value => (
+            capture2 = value
+          )}
+        </ConsumeContext>
+        <ConsumeContext use={() => useContext(Ctx)}>
+          {value => (
+            capture3 = value
           )}
         </ConsumeContext>
       </Ctx.Provider>;
     });
 
-    expect(capture).toBe("World");
-  });
-
-  test("consumes a context via context object", () => {
-    const Ctx = createContext<string>("Hello");
-
-    let capture;
-    createRoot(() => {
-      <Ctx.Provider value="World">
-        <ConsumeContext context={Ctx}>
-          {value => (
-            capture = value
-          )}
-        </ConsumeContext>
-      </Ctx.Provider>;
-    });
-
-    expect(capture).toBe("World");
+    expect(capture1).toBe("World");
+    expect(capture2).toBe("World");
+    expect(capture3).toBe("World");
   });
 });

--- a/packages/context/test/index.test.tsx
+++ b/packages/context/test/index.test.tsx
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { createContext, createRoot, FlowComponent, JSX, untrack, useContext } from "solid-js";
 import { render } from "solid-js/web";
-import { createContextProvider, MultiProvider } from "../src/index.js";
+import { ConsumeContext, createContextProvider, MultiProvider } from "../src/index.js";
 
 type TestContextValue = {
   message: string;
@@ -105,5 +105,28 @@ describe("MultiProvider", () => {
     expect(capture1).toBe("Hello");
     expect(capture2).toBe("World");
     expect(capture3).toBe(TEST_MESSAGE);
+  });
+});
+
+describe("ConsumeContext", () => {
+  test("consumes a context", () => {
+    const Ctx = createContext<string>("Hello");
+
+    function useCtx() {
+      return useContext(Ctx);
+    }
+
+    let capture;
+    createRoot(() => {
+      <Ctx.Provider value="World">
+        <ConsumeContext useFn={useCtx}>
+          {value => (
+            capture = value
+          )}
+        </ConsumeContext>
+      </Ctx.Provider>;
+    });
+
+    expect(capture).toBe("World");
   });
 });

--- a/packages/context/test/server.test.tsx
+++ b/packages/context/test/server.test.tsx
@@ -63,39 +63,33 @@ describe("MultiProvider", () => {
 describe("ConsumeContext", () => {
   test("consumes a context via use-function", () => {
     const Ctx = createContext<string>("Hello");
+    const useCtx = () => useContext(Ctx);
 
-    function useCtx() {
-      return useContext(Ctx);
-    }
-
-    let capture;
+    let capture1;
+    let capture2;
+    let capture3;
     renderToString(() => {
       <Ctx.Provider value="World">
-        <ConsumeContext useFn={useCtx}>
+        <ConsumeContext use={Ctx}>
           {value => (
-            capture = value
+            capture1 = value
+          )}
+        </ConsumeContext>
+        <ConsumeContext use={useCtx}>
+          {value => (
+            capture2 = value
+          )}
+        </ConsumeContext>
+        <ConsumeContext use={() => useContext(Ctx)}>
+          {value => (
+            capture3 = value
           )}
         </ConsumeContext>
       </Ctx.Provider>;
     });
 
-    expect(capture).toBe("World");
-  });
-
-  test("consumes a context via context object", () => {
-    const Ctx = createContext<string>("Hello");
-
-    let capture;
-    renderToString(() => {
-      <Ctx.Provider value="World">
-        <ConsumeContext context={Ctx}>
-          {value => (
-            capture = value
-          )}
-        </ConsumeContext>
-      </Ctx.Provider>;
-    });
-
-    expect(capture).toBe("World");
+    expect(capture1).toBe("World");
+    expect(capture2).toBe("World");
+    expect(capture3).toBe("World");
   });
 });

--- a/packages/context/test/server.test.tsx
+++ b/packages/context/test/server.test.tsx
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "vitest";
 import { createContext, FlowComponent, JSX, untrack, useContext } from "solid-js";
 import { renderToString } from "solid-js/web";
-import { createContextProvider, MultiProvider } from "../src/index.js";
+import { ConsumeContext, createContextProvider, MultiProvider } from "../src/index.js";
 
 type TestContextValue = {
   message: string;
@@ -57,5 +57,28 @@ describe("MultiProvider", () => {
     expect(capture1).toBe("Hello");
     expect(capture2).toBe("World");
     expect(capture3).toBe(TEST_MESSAGE);
+  });
+});
+
+describe("ConsumeContext", () => {
+  test("consumes a context", () => {
+    const Ctx = createContext<string>("Hello");
+
+    function useCtx() {
+      return useContext(Ctx);
+    }
+
+    let capture;
+    renderToString(() => {
+      <Ctx.Provider value="World">
+        <ConsumeContext useFn={useCtx}>
+          {value => (
+            capture = value
+          )}
+        </ConsumeContext>
+      </Ctx.Provider>;
+    });
+
+    expect(capture).toBe("World");
   });
 });

--- a/packages/context/test/server.test.tsx
+++ b/packages/context/test/server.test.tsx
@@ -61,7 +61,7 @@ describe("MultiProvider", () => {
 });
 
 describe("ConsumeContext", () => {
-  test("consumes a context", () => {
+  test("consumes a context via use-function", () => {
     const Ctx = createContext<string>("Hello");
 
     function useCtx() {
@@ -72,6 +72,23 @@ describe("ConsumeContext", () => {
     renderToString(() => {
       <Ctx.Provider value="World">
         <ConsumeContext useFn={useCtx}>
+          {value => (
+            capture = value
+          )}
+        </ConsumeContext>
+      </Ctx.Provider>;
+    });
+
+    expect(capture).toBe("World");
+  });
+
+  test("consumes a context via context object", () => {
+    const Ctx = createContext<string>("Hello");
+
+    let capture;
+    renderToString(() => {
+      <Ctx.Provider value="World">
+        <ConsumeContext context={Ctx}>
           {value => (
             capture = value
           )}


### PR DESCRIPTION
Add a function to directly consume contexts within JSX. Inspired by React's `Context.Consumer` component, but nicely integrated with this primitive's `createContextProvider`.

Tests have been added and source code + README.md is documented