### PR TITLE
fix: stage badge for specific primitive

### DIFF
--- a/site/src/routes/package/[name]/(package).tsx
+++ b/site/src/routes/package/[name]/(package).tsx
@@ -40,7 +40,7 @@ const Page: Component = () => {
       return cachedData()?.primitives ?? dataResource()?.primitives;
     },
     get stage() {
-      return cachedData()?.stage ?? dataResource()?.stage;
+      return cachedData()?.primitive?.stage ?? dataResource()?.primitive?.stage;
     },
     get readme() {
       return dataResource()?.readme;


### PR DESCRIPTION
The stage badge is not displaying correctly.

Relevant issue: #757

This was already fixed for the badges shown on the front page (#759), however it's not fixed for a specific primitive's page.

To reproduce error:

* Open any primitive specific page (e.g. https://primitives.solidjs.community/package/active-element)
* See that the Stage is not correct.