### PR TITLE
Typo makes `getPositionToScreen` buggy

### DIFF
--- a/.changeset/nasty-otters-camp.md
+++ b/.changeset/nasty-otters-camp.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/mouse": patch
+---
+
+Use `scrollY` not `screenY` in `getPositionToScreen` 

--- a/packages/mouse/src/common.ts
+++ b/packages/mouse/src/common.ts
@@ -164,5 +164,5 @@ export const getPositionToScreen = isServer
   ? (): Position => DEFAULT_MOUSE_POSITION
   : (pageX: number, pageY: number): Position => ({
       x: pageX - window.scrollX,
-      y: pageY - window.screenY,
+      y: pageY - window.scrollY,
     });


### PR DESCRIPTION
AFAIK, we want to use scrollY not screenY.