### PR TITLE
Fix create deep signal

### DIFF
--- a/.changeset/small-coats-obey.md
+++ b/.changeset/small-coats-obey.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/resource": patch
+---
+
+Fix setter input value in `createDeepSignal`.

--- a/packages/resource/src/index.ts
+++ b/packages/resource/src/index.ts
@@ -298,7 +298,8 @@ export function createDeepSignal<T>(v?: T): Signal<T> {
   return [
     () => store[0],
     (update: T) => (
-      setStore(0, reconcile(typeof update === "function" ? update(unwrap(store[0])) : v)), store[0]
+      setStore(0, reconcile(typeof update === "function" ? update(unwrap(store[0])) : update)),
+      store[0]
     ),
   ] as Signal<T>;
 }

--- a/packages/resource/test/index.test.ts
+++ b/packages/resource/test/index.test.ts
@@ -419,4 +419,26 @@ describe("createDeepSignal", () => {
         return run + 1;
       });
     }));
+  test("mutates the resource with callback", () =>
+    testEffect(done => {
+      const [data, { mutate }] = createResource(() => ({ counter: 1 }), {
+        storage: createDeepSignal,
+      });
+      mutate(() => ({ counter: 2 }));
+      createEffect(() => {
+        expect(data()?.counter).toBe(2);
+        done();
+      });
+    }));
+  test("mutates the resource with plain object", () =>
+    testEffect(done => {
+      const [data, { mutate }] = createResource(() => ({ counter: 1 }), {
+        storage: createDeepSignal,
+      });
+      mutate({ counter: 2 });
+      createEffect(() => {
+        expect(data()?.counter).toBe(2);
+        done();
+      });
+    }));
 });


### PR DESCRIPTION
The setter of `createDeepSignal` is not working if you pass a non-function value.

```ts
const [data, { mutate }] = createResource(() => ({ counter: 1 }), {
  storage: createDeepSignal,
});
// mutate(() => ({ counter: 2 })); // works
mutate({ counter: 2 }); // not working
createEffect(() => {
  console.log(data()?.counter); // 1
});
```