### PR TITLE
Fix for `<List>` "unused" signal

### DIFF
--- a/packages/list/README.md
+++ b/packages/list/README.md
@@ -36,8 +36,7 @@ function Component() {
       {(value, index) => {
         return (
           <div>
-            {" "}
-            {index()}: {value()}{" "}
+            {index()}: {value()}
           </div>
         );
       }}
@@ -54,7 +53,7 @@ Every element is keyed by item reference and index, but item reference is priori
 
 Underlying helper for `<List>` unkeyed control flow. Returns array with elements mapped using provided mapping function.
 
-Mapping function may use provided reactive value and reactive index, but signals for each of them are created only if they are used. Mapping function is ran only when original array has more elements than before. Elements are disposed only if original array has less elements than before.
+Mapping function may use provided reactive value and reactive index. Mapping function is ran only when original array has more elements than before. Elements are disposed only if original array has less elements than before.
 
 ## Demo
 

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/list",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A List component, an alternative to For and Index.",
   "author": "Maciek50322 <34212298+maciek50322@users.noreply.github.com>",
   "contributors": [],

--- a/packages/list/src/index.ts
+++ b/packages/list/src/index.ts
@@ -168,32 +168,20 @@ export function listArray<T, U>(
     item.valueSetter?.(newValueGetter);
   }
   function mapper(disposer: () => void) {
-    const t: ListItem<T> = {
-        value: newValue,
-        index: i,
-        disposer,
-      },
-      scopedV = newValue,
-      scopedI = i;
-    items.push(t);
-    // signal created when used
-    let sV: Accessor<T> = () => {
-        [sV, t.valueSetter] = isDev
-          ? createSignal(scopedV, { name: "value" })
-          : createSignal(scopedV);
-        return sV();
-      },
-      sI: Accessor<number> = () => {
-        [sI, t.indexSetter] = isDev
-          ? createSignal(scopedI, { name: "index" })
-          : createSignal(scopedI);
-        return sI();
-      };
+    const [sV, valueSetter] = isDev
+        ? createSignal(newValue, { name: "value" })
+        : createSignal(newValue),
+      [sI, indexSetter] = isDev ? createSignal(i, { name: "index" }) : createSignal(i);
 
-    return mapFn(
-      () => sV(),
-      () => sI(),
-    );
+    items.push({
+      value: newValue,
+      index: i,
+      disposer,
+      valueSetter,
+      indexSetter,
+    });
+
+    return mapFn(sV, sI);
   }
 }
 


### PR DESCRIPTION
I found that the "signal created when used" is giving wrong values when it's read only later after changes (eg. only in event callback function and none in jsx or other signals or component creation - work correctly if it's used there).