### PR TITLE
Fix broken stage badge

### DIFF
--- a/site/src/routes/package/[name]/(package).tsx
+++ b/site/src/routes/package/[name]/(package).tsx
@@ -40,7 +40,7 @@ const Page: Component = () => {
       return cachedData()?.primitives ?? dataResource()?.primitives;
     },
     get stage() {
-      return cachedData()?.stage ?? dataResource()?.stage;
+      return cachedData()?.primitive?.stage ?? dataResource()?.primitive?.stage;
     },
     get readme() {
       return dataResource()?.readme;
@@ -65,7 +65,7 @@ const Page: Component = () => {
         style={{ "padding-top": `${PRIMITIVE_PAGE_PADDING_TOP}px` }}
       >
         <div class="bg-page-main-bg rounded-3xl p-3 sm:p-8">
-          <div class="mb-[90px] flex items-center justify-between gap-[30px] text-[#232324] dark:text-white sm:gap-[100px]">
+          <div class="mb-[90px] flex items-center justify-between gap-[30px] text-[#232324] sm:gap-[100px] dark:text-white">
             <Heading name={data.name} formattedName={formattedName()} />
           </div>
 


### PR DESCRIPTION
Fix accessing correct stage path from `dataResource`/`cachedData` object in order to render stage badge correctly.

Before:
<img width="223" alt="Screenshot 2025-05-31 at 1 28 13 PM" src="https://github.com/user-attachments/assets/2be7d609-f2f5-40dc-bca4-8dae53b3008e" />

After:
<img width="217" alt="Screenshot 2025-05-31 at 1 28 32 PM" src="https://github.com/user-attachments/assets/7485dc93-5262-4648-9db2-3d9eefdf578c" />
