### PR TITLE
upgrade: media, event-listener, rootless, static-store and utils package upgrade for Solid 2.0

### DIFF
--- a/.changeset/media-solid2-migration.md
+++ b/.changeset/media-solid2-migration.md
@@ -1,0 +1,45 @@
+---
+"@solid-primitives/media": major
+"@solid-primitives/event-listener": major
+"@solid-primitives/rootless": major
+"@solid-primitives/static-store": major
+"@solid-primitives/utils": major
+---
+
+Migrate to Solid.js v2.0 (beta.7)
+
+## Breaking Changes
+
+**Peer dependency**: `solid-js@^2.0.0-beta.7` and `@solidjs/web@^2.0.0-beta.7` are now required.
+
+### `@solid-primitives/media`
+
+- `isServer` now imported from `@solidjs/web` (not `solid-js/web`)
+- Requires Solid.js v2 — `classList` is replaced by `class` with object/array forms in consuming code
+
+### `@solid-primitives/utils`
+
+- `isServer` import moved from `solid-js/web` to `@solidjs/web`
+- `createHydratableSignal`: uses `onSettled` (was `onMount`) and `sharedConfig.hydrating` (was `sharedConfig.context`) for hydration detection
+- `INTERNAL_OPTIONS`: `{ internal: true }` changed to `{ pureWrite: true }` to match Solid 2.0 `SignalOptions`
+- `defaultEquals` now aliases `isEqual` (was `equalFn`)
+- `defer`: `AccessorArray<S>` type replaced with `Accessor<S>[]` (type was removed in Solid 2.0)
+
+### `@solid-primitives/static-store`
+
+- `isServer` import moved from `solid-js/web` to `@solidjs/web`
+- `createStaticStore`: uses `getObserver` (was `getListener`) and `{ pureWrite: true }` (was `{ internal: true }`)
+- Removed explicit `batch()` calls — updates are automatically batched in Solid 2.0
+- `createHydratableStaticStore`: uses `onSettled` (was `onMount`) and `sharedConfig.hydrating` (was `sharedConfig.context`)
+
+### `@solid-primitives/rootless`
+
+- `isServer` import moved from `solid-js/web` to `@solidjs/web`
+- `createHydratableSingletonRoot`: uses `sharedConfig.hydrating` (was `sharedConfig.context`)
+- `createRootPool`: removed `batch()` calls — Solid 2.0 auto-batches on microtasks
+
+### `@solid-primitives/event-listener`
+
+- `isServer` import moved from `solid-js/web` to `@solidjs/web` across all source files
+- `createEventListener` and `createRenderEffect` converted to split compute/apply effect pattern required by Solid 2.0
+- `eventListener` directive converted to split effect pattern; cleanup is returned from apply phase instead of using `onCleanup`

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "rehype-highlight": "^7.0.2",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
-    "solid-js": "^1.9.7",
+    "solid-js": "2.0.0-beta.10",
     "typescript": "^5.8.3",
     "vinxi": "^0.5.7",
     "vite": "^6.3.5",

--- a/packages/audio/dev/index.tsx
+++ b/packages/audio/dev/index.tsx
@@ -76,7 +76,7 @@ const App: Component = () => {
       <div class="flex flex-col items-center">
         <div class="flex items-center justify-center space-x-4 rounded-full bg-white p-1 shadow">
           <button
-            class="scale-200 flex cursor-pointer border-none bg-transparent"
+            class="flex scale-200 cursor-pointer border-none bg-transparent"
             disabled={audio.state == AudioState.ERROR}
             onClick={() => setPlaying(audio.state == AudioState.PLAYING ? false : true)}
           >
@@ -97,7 +97,7 @@ const App: Component = () => {
             step="0.1"
             max={audio.duration}
             value={audio.currentTime}
-            class="form-range w-40 cursor-pointer appearance-none rounded-3xl bg-gray-200 transition hover:bg-gray-300 focus:outline-none focus:ring-0"
+            class="form-range w-40 cursor-pointer appearance-none rounded-3xl bg-gray-200 transition hover:bg-gray-300 focus:ring-0 focus:outline-none"
           />
           <div class="flex px-2">
             <Icon class="w-6 text-blue-600" path={speakerWave} />

--- a/packages/event-listener/package.json
+++ b/packages/event-listener/package.json
@@ -57,10 +57,12 @@
     "@solid-primitives/utils": "workspace:^"
   },
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "@solidjs/web": "^2.0.0-beta.7",
+    "solid-js": "^2.0.0-beta.7"
   },
   "typesVersions": {},
   "devDependencies": {
-    "solid-js": "^1.9.7"
+    "@solidjs/web": "2.0.0-beta.7",
+    "solid-js": "2.0.0-beta.7"
   }
 }

--- a/packages/event-listener/package.json
+++ b/packages/event-listener/package.json
@@ -57,12 +57,12 @@
     "@solid-primitives/utils": "workspace:^"
   },
   "peerDependencies": {
-    "@solidjs/web": "^2.0.0-beta.7",
-    "solid-js": "^2.0.0-beta.7"
+    "@solidjs/web": "^2.0.0-beta.10",
+    "solid-js": "^2.0.0-beta.10"
   },
   "typesVersions": {},
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.7",
-    "solid-js": "2.0.0-beta.7"
+    "@solidjs/web": "2.0.0-beta.10",
+    "solid-js": "2.0.0-beta.10"
   }
 }

--- a/packages/event-listener/src/components.ts
+++ b/packages/event-listener/src/components.ts
@@ -1,4 +1,4 @@
-import { isServer } from "solid-js/web";
+import { isServer } from "@solidjs/web";
 import { keys } from "@solid-primitives/utils";
 import { type Component } from "solid-js";
 import { makeEventListener } from "./eventListener.js";

--- a/packages/event-listener/src/eventListener.ts
+++ b/packages/event-listener/src/eventListener.ts
@@ -7,7 +7,7 @@ import {
   tryOnCleanup,
 } from "@solid-primitives/utils";
 import { type Accessor, createEffect, createRenderEffect, createSignal } from "solid-js";
-import { isServer } from "solid-js/web";
+import { isServer } from "@solidjs/web";
 import type {
   EventListenerDirectiveProps,
   EventMapOf,
@@ -110,17 +110,28 @@ export function createEventListener(
 ): void {
   if (isServer) return;
 
-  const attachListeners = () => {
-    asArray(access(targets)).forEach(el => {
-      if (el) asArray(access(type)).forEach(type => makeEventListener(el, type, handler, options));
-    });
+  type State = { els: EventTarget[]; types: string[] };
+
+  const compute = (): State => ({
+    els: asArray(access(targets)).filter(Boolean) as EventTarget[],
+    types: asArray(access(type)) as string[],
+  });
+
+  const apply = ({ els, types }: State) => {
+    const cleanups: VoidFunction[] = [];
+    for (const el of els)
+      for (const t of types) {
+        el.addEventListener(t, handler, options);
+        cleanups.push(el.removeEventListener.bind(el, t, handler, options));
+      }
+    return () => cleanups.forEach(c => c());
   };
 
-  // if the target is an accessor the listeners will be added on the first effect (onMount)
-  // so that when passed a jsx ref it will be availabe
-  if (typeof targets === "function") createEffect(attachListeners);
+  // if the target is an accessor the listeners will be added on the first effect (after mount)
+  // so that when passed a jsx ref it will be available
+  if (typeof targets === "function") createEffect(compute, apply);
   // if the target prop is NOT an accessor, the event listeners can be added right away
-  else createRenderEffect(attachListeners);
+  else createRenderEffect(compute, apply);
 }
 
 // Possible targets prop shapes:
@@ -192,9 +203,9 @@ export function createEventSignal(
  * <button use:eventListener={["click", () => {...}]}>Click me!</button>
  */
 export const eventListener: Directive<EventListenerDirectiveProps> = (target, props) => {
-  createEffect(() => {
-    const [type, handler, options] = props();
-    makeEventListener(target, type, handler, options);
+  createEffect(props, ([type, handler, options]) => {
+    target.addEventListener(type, handler, options);
+    return () => target.removeEventListener(type, handler, options);
   });
 };
 

--- a/packages/event-listener/src/eventListenerMap.ts
+++ b/packages/event-listener/src/eventListenerMap.ts
@@ -1,7 +1,7 @@
 import { type AnyFunction, entries, type Many, type MaybeAccessor } from "@solid-primitives/utils";
 import { createEventListener } from "./eventListener.js";
 import type { EventMapOf, TargetWithEventMap, EventListenerOptions } from "./types.js";
-import { isServer } from "solid-js/web";
+import { isServer } from "@solidjs/web";
 
 export type EventHandlersMap<EventMap> = {
   [EventName in keyof EventMap]: (event: EventMap[EventName]) => void;

--- a/packages/event-listener/src/eventListenerStack.ts
+++ b/packages/event-listener/src/eventListenerStack.ts
@@ -2,7 +2,7 @@ import { createCallbackStack } from "@solid-primitives/utils";
 import { onCleanup } from "solid-js";
 import { makeEventListener } from "./eventListener.js";
 import type { EventMapOf, TargetWithEventMap, EventListenerOptions } from "./types.js";
-import { isServer } from "solid-js/web";
+import { isServer } from "@solidjs/web";
 
 export type EventListenerStackOn<EventMap extends Record<string, any>> = {
   <T extends keyof EventMap>(

--- a/packages/event-listener/src/types.ts
+++ b/packages/event-listener/src/types.ts
@@ -7,7 +7,6 @@ export type TargetWithEventMap =
   | Document
   | XMLDocument
   | HTMLBodyElement
-  | HTMLFrameSetElement
   | HTMLMediaElement
   | HTMLVideoElement
   | HTMLElement
@@ -64,9 +63,7 @@ export type EventMapOf<Target> = Target extends Window
     ? DocumentEventMap
     : Target extends HTMLBodyElement
       ? HTMLBodyElementEventMap
-      : Target extends HTMLFrameSetElement
-        ? HTMLFrameSetElementEventMap
-        : Target extends HTMLMediaElement
+      : Target extends HTMLMediaElement
           ? HTMLMediaElementEventMap
           : Target extends HTMLVideoElement
             ? HTMLVideoElementEventMap

--- a/packages/event-listener/src/types.ts
+++ b/packages/event-listener/src/types.ts
@@ -64,104 +64,104 @@ export type EventMapOf<Target> = Target extends Window
     : Target extends HTMLBodyElement
       ? HTMLBodyElementEventMap
       : Target extends HTMLMediaElement
-          ? HTMLMediaElementEventMap
-          : Target extends HTMLVideoElement
-            ? HTMLVideoElementEventMap
-            : Target extends HTMLElement
-              ? HTMLElementEventMap
-              : Target extends SVGSVGElement
-                ? SVGSVGElementEventMap
-                : Target extends SVGElement
-                  ? SVGElementEventMap
-                  : Target extends MathMLElement
-                    ? MathMLElementEventMap
-                    : Target extends Element
-                      ? ElementEventMap
-                      : Target extends AbortSignal
-                        ? AbortSignalEventMap
-                        : Target extends AbstractWorker
-                          ? AbstractWorkerEventMap
-                          : Target extends Animation
-                            ? AnimationEventMap
-                            : Target extends BroadcastChannel
-                              ? BroadcastChannelEventMap
-                              : Target extends CSSAnimation
+        ? HTMLMediaElementEventMap
+        : Target extends HTMLVideoElement
+          ? HTMLVideoElementEventMap
+          : Target extends HTMLElement
+            ? HTMLElementEventMap
+            : Target extends SVGSVGElement
+              ? SVGSVGElementEventMap
+              : Target extends SVGElement
+                ? SVGElementEventMap
+                : Target extends MathMLElement
+                  ? MathMLElementEventMap
+                  : Target extends Element
+                    ? ElementEventMap
+                    : Target extends AbortSignal
+                      ? AbortSignalEventMap
+                      : Target extends AbstractWorker
+                        ? AbstractWorkerEventMap
+                        : Target extends Animation
+                          ? AnimationEventMap
+                          : Target extends BroadcastChannel
+                            ? BroadcastChannelEventMap
+                            : Target extends CSSAnimation
+                              ? AnimationEventMap
+                              : Target extends CSSTransition
                                 ? AnimationEventMap
-                                : Target extends CSSTransition
-                                  ? AnimationEventMap
-                                  : Target extends FileReader
-                                    ? FileReaderEventMap
-                                    : Target extends IDBDatabase
-                                      ? IDBDatabaseEventMap
-                                      : Target extends IDBOpenDBRequest
-                                        ? IDBOpenDBRequestEventMap
-                                        : Target extends IDBRequest
-                                          ? IDBRequestEventMap
-                                          : Target extends IDBTransaction
-                                            ? IDBTransactionEventMap
-                                            : Target extends MediaDevices
-                                              ? MediaDevicesEventMap
-                                              : Target extends MediaKeySession
-                                                ? MediaKeySessionEventMap
-                                                : Target extends MediaQueryList
-                                                  ? MediaQueryListEventMap
-                                                  : Target extends MediaRecorder
-                                                    ? MediaRecorderEventMap
-                                                    : Target extends MediaSource
-                                                      ? MediaSourceEventMap
-                                                      : Target extends MediaStream
-                                                        ? MediaStreamEventMap
-                                                        : Target extends MediaStreamTrack
-                                                          ? MediaStreamTrackEventMap
-                                                          : Target extends MessagePort
-                                                            ? MessagePortEventMap
-                                                            : Target extends Notification
-                                                              ? NotificationEventMap
-                                                              : Target extends PaymentRequest
-                                                                ? PaymentRequestEventMap
-                                                                : Target extends Performance
-                                                                  ? PerformanceEventMap
-                                                                  : Target extends PermissionStatus
-                                                                    ? PermissionStatusEventMap
-                                                                    : Target extends PictureInPictureWindow
-                                                                      ? PictureInPictureWindowEventMap
-                                                                      : Target extends RemotePlayback
-                                                                        ? RemotePlaybackEventMap
-                                                                        : Target extends ScreenOrientation
-                                                                          ? ScreenOrientationEventMap
-                                                                          : Target extends ServiceWorker
-                                                                            ? ServiceWorkerEventMap
-                                                                            : Target extends ServiceWorkerContainer
-                                                                              ? ServiceWorkerContainerEventMap
-                                                                              : Target extends ServiceWorkerRegistration
-                                                                                ? ServiceWorkerRegistrationEventMap
-                                                                                : Target extends ShadowRoot
-                                                                                  ? ShadowRootEventMap
-                                                                                  : Target extends SharedWorker
-                                                                                    ? AbstractWorkerEventMap
-                                                                                    : Target extends SourceBuffer
-                                                                                      ? SourceBufferEventMap
-                                                                                      : Target extends SourceBufferList
-                                                                                        ? SourceBufferListEventMap
-                                                                                        : Target extends SpeechSynthesis
-                                                                                          ? SpeechSynthesisEventMap
-                                                                                          : Target extends SpeechSynthesisUtterance
-                                                                                            ? SpeechSynthesisUtteranceEventMap
-                                                                                            : Target extends VisualViewport
-                                                                                              ? VisualViewportEventMap
-                                                                                              : Target extends WebSocket
-                                                                                                ? WebSocketEventMap
-                                                                                                : Target extends Worker
-                                                                                                  ? WorkerEventMap
-                                                                                                  : Target extends XMLHttpRequest
-                                                                                                    ? XMLHttpRequestEventMap
-                                                                                                    : Target extends XMLHttpRequestEventTarget
+                                : Target extends FileReader
+                                  ? FileReaderEventMap
+                                  : Target extends IDBDatabase
+                                    ? IDBDatabaseEventMap
+                                    : Target extends IDBOpenDBRequest
+                                      ? IDBOpenDBRequestEventMap
+                                      : Target extends IDBRequest
+                                        ? IDBRequestEventMap
+                                        : Target extends IDBTransaction
+                                          ? IDBTransactionEventMap
+                                          : Target extends MediaDevices
+                                            ? MediaDevicesEventMap
+                                            : Target extends MediaKeySession
+                                              ? MediaKeySessionEventMap
+                                              : Target extends MediaQueryList
+                                                ? MediaQueryListEventMap
+                                                : Target extends MediaRecorder
+                                                  ? MediaRecorderEventMap
+                                                  : Target extends MediaSource
+                                                    ? MediaSourceEventMap
+                                                    : Target extends MediaStream
+                                                      ? MediaStreamEventMap
+                                                      : Target extends MediaStreamTrack
+                                                        ? MediaStreamTrackEventMap
+                                                        : Target extends MessagePort
+                                                          ? MessagePortEventMap
+                                                          : Target extends Notification
+                                                            ? NotificationEventMap
+                                                            : Target extends PaymentRequest
+                                                              ? PaymentRequestEventMap
+                                                              : Target extends Performance
+                                                                ? PerformanceEventMap
+                                                                : Target extends PermissionStatus
+                                                                  ? PermissionStatusEventMap
+                                                                  : Target extends PictureInPictureWindow
+                                                                    ? PictureInPictureWindowEventMap
+                                                                    : Target extends RemotePlayback
+                                                                      ? RemotePlaybackEventMap
+                                                                      : Target extends ScreenOrientation
+                                                                        ? ScreenOrientationEventMap
+                                                                        : Target extends ServiceWorker
+                                                                          ? ServiceWorkerEventMap
+                                                                          : Target extends ServiceWorkerContainer
+                                                                            ? ServiceWorkerContainerEventMap
+                                                                            : Target extends ServiceWorkerRegistration
+                                                                              ? ServiceWorkerRegistrationEventMap
+                                                                              : Target extends ShadowRoot
+                                                                                ? ShadowRootEventMap
+                                                                                : Target extends SharedWorker
+                                                                                  ? AbstractWorkerEventMap
+                                                                                  : Target extends SourceBuffer
+                                                                                    ? SourceBufferEventMap
+                                                                                    : Target extends SourceBufferList
+                                                                                      ? SourceBufferListEventMap
+                                                                                      : Target extends SpeechSynthesis
+                                                                                        ? SpeechSynthesisEventMap
+                                                                                        : Target extends SpeechSynthesisUtterance
+                                                                                          ? SpeechSynthesisUtteranceEventMap
+                                                                                          : Target extends VisualViewport
+                                                                                            ? VisualViewportEventMap
+                                                                                            : Target extends WebSocket
+                                                                                              ? WebSocketEventMap
+                                                                                              : Target extends Worker
+                                                                                                ? WorkerEventMap
+                                                                                                : Target extends XMLHttpRequest
+                                                                                                  ? XMLHttpRequestEventMap
+                                                                                                  : Target extends XMLHttpRequestEventTarget
+                                                                                                    ? XMLHttpRequestEventTargetEventMap
+                                                                                                    : Target extends XMLHttpRequestUpload
                                                                                                       ? XMLHttpRequestEventTargetEventMap
-                                                                                                      : Target extends XMLHttpRequestUpload
-                                                                                                        ? XMLHttpRequestEventTargetEventMap
-                                                                                                        : Target extends EventSource
-                                                                                                          ? EventSourceEventMap
-                                                                                                          : never;
+                                                                                                      : Target extends EventSource
+                                                                                                        ? EventSourceEventMap
+                                                                                                        : never;
 
 export type EventListenerDirectiveProps = [
   type: string,

--- a/packages/event-listener/test/event-listener-map.test.ts
+++ b/packages/event-listener/test/event-listener-map.test.ts
@@ -1,6 +1,6 @@
 import { dispatchFakeEvent, event_target } from "./setup.js";
 import { describe, test, expect } from "vitest";
-import { createRoot, onMount } from "solid-js";
+import { createRoot, onSettled } from "solid-js";
 import { createEventListenerMap } from "../src/index.js";
 
 describe("createEventListenerMap", () => {
@@ -34,7 +34,7 @@ describe("createEventListenerMap", () => {
         map_1: e => (captured1 = e),
       });
 
-      onMount(() => {
+      onSettled(() => {
         dispatchFakeEvent("map_0", testEvent);
         dispatchFakeEvent("map_1", testEvent1);
 
@@ -55,7 +55,7 @@ describe("createEventListenerMap", () => {
         map_1: e => (captured1 = e),
       });
 
-      onMount(() => {
+      onSettled(() => {
         dispose();
 
         dispatchFakeEvent("map_0", testEvent);
@@ -74,7 +74,7 @@ describe("createEventListenerMap", () => {
         map_0: e => (captured = e),
       });
 
-      onMount(() => {
+      onSettled(() => {
         dispatchFakeEvent("map_0", testEvent);
         expect(captured).toBe(testEvent);
         dispose();

--- a/packages/event-listener/test/event-listener.test.ts
+++ b/packages/event-listener/test/event-listener.test.ts
@@ -1,6 +1,6 @@
 import { dispatchFakeEvent, event_target } from "./setup.js";
 import { describe, test, expect } from "vitest";
-import { createRoot, createSignal, onMount } from "solid-js";
+import { createRoot, createSignal, flush, onSettled } from "solid-js";
 import {
   createEventListener,
   createEventSignal,
@@ -124,14 +124,17 @@ describe("createEventListener", () => {
       return dispose;
     });
 
+    flush();
     dispatchFakeEvent("test", testEvent);
     expect(captured_times).toBe(1);
+
     setTarget([]);
-
+    flush();
     dispatchFakeEvent("test", testEvent);
     expect(captured_times).toBe(1);
-    setTarget(event_target);
 
+    setTarget(event_target);
+    flush();
     dispatchFakeEvent("test", testEvent);
     expect(captured_times).toBe(2);
     dispose();
@@ -177,7 +180,7 @@ describe("createEventListener", () => {
         count++;
       });
 
-      onMount(() => {
+      onSettled(() => {
         dispatchFakeEvent("test3", testEvent);
         expect(count, "captured count on mount should be 1").toBe(1);
 
@@ -197,7 +200,7 @@ describe("createEventSignal", () => {
       expect(lastEvent, "returned value is an accessor").toBeTypeOf("function");
       expect(lastEvent(), "returned value is undefined").toBeTypeOf("undefined");
 
-      onMount(() => {
+      onSettled(() => {
         dispatchFakeEvent("sig_test", testEvent);
         expect(lastEvent()).toBe(testEvent);
         dispose();
@@ -221,16 +224,16 @@ describe("eventListener directive", () => {
       dispatchFakeEvent("load", testEvent);
       expect(captured.length, "event are not listened before the first effect").toBe(0);
 
-      onMount(() => {
-        dispatchFakeEvent("load", testEvent);
-        expect(captured.length, "one event after mounted should be captured").toBe(1);
-        expect(captured[0], "event after mounted should be captured").toBe(testEvent);
-      });
-
       return dispose;
     });
 
+    flush(); // run effect phase → adds event listener
+    dispatchFakeEvent("load", testEvent);
+    expect(captured.length, "one event after mounted should be captured").toBe(1);
+    expect(captured[0], "event after mounted should be captured").toBe(testEvent);
+
     setProps(["load", e => captured2.push(e)]);
+    flush(); // re-run effect → removes old listener, adds new one
 
     dispatchFakeEvent("load", testEvent);
     expect(captured.length, "events should no longer be captured by the previous handler").toBe(1);

--- a/packages/geolocation/dev/client.tsx
+++ b/packages/geolocation/dev/client.tsx
@@ -46,7 +46,7 @@ const Client: Component = () => {
               </div>
             </div>
           </Show>
-          <div class="w-100 h-100" ref={el => (ref = el)} />
+          <div class="h-100 w-100" ref={el => (ref = el)} />
           <div class="p-4">
             {location()?.latitude}, {location()?.longitude}
           </div>

--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -23,6 +23,8 @@ npm install @solid-primitives/media
 yarn add @solid-primitives/media
 ```
 
+> **Requires Solid.js v2.0 (beta.7+)**
+
 ## `makeMediaQueryListener`
 
 Attaches a MediaQuery listener to window, listeneing to changes to provided query
@@ -77,20 +79,23 @@ const breakpoints = {
 const Example: Component = () => {
   const matches = createBreakpoints(breakpoints);
 
-  createEffect(() => {
-    console.log(matches.sm); // true when screen width >= 640px
-    console.log(matches.lg); // true when screen width >= 1024px
-    console.log(matches.xl); // true when screen width >= 1280px
-  });
+  createEffect(
+    () => [matches.sm, matches.lg, matches.xl],
+    ([sm, lg, xl]) => {
+      console.log(sm);  // true when screen width >= 640px
+      console.log(lg);  // true when screen width >= 1024px
+      console.log(xl);  // true when screen width >= 1280px
+    }
+  );
 
   return (
     <div
-      classList={{
-        "text-tiny flex flex-column": true, // tiny text with flex column layout
-        "text-small": matches.sm, // small text with flex column layout
-        "text-base flex-row": matches.lg, // base text with flex row layout
-        "text-huge": matches.xl, // huge text with flex row layout
-      }}
+      class={[
+        "text-tiny flex flex-column",               // tiny text with flex column layout
+        matches.sm && "text-small",                  // small text with flex column layout
+        matches.lg && "text-base flex-row",          // base text with flex row layout
+        matches.xl && "text-huge",                   // huge text with flex row layout
+      ]}
     >
       <Switch fallback={<div>Smallest</div>}>
         <Match when={matches.xl}>Extra Large</Match>
@@ -169,9 +174,10 @@ Provides a signal indicating if the user has requested dark color theme. The set
 import { createPrefersDark } from "@solid-primitives/media";
 
 const prefersDark = createPrefersDark();
-createEffect(() => {
-  prefersDark(); // => boolean
-});
+createEffect(
+  prefersDark,
+  dark => console.log("prefers dark:", dark)
+);
 ```
 
 ### Server fallback
@@ -192,9 +198,10 @@ This primitive provides a [singleton root](https://github.com/solidjs-community/
 import { usePrefersDark } from "@solid-primitives/media";
 
 const prefersDark = usePrefersDark();
-createEffect(() => {
-  prefersDark(); // => boolean
-});
+createEffect(
+  prefersDark,
+  dark => console.log("prefers dark:", dark)
+);
 ```
 
 > Note: `usePrefersDark` will deopt to `createPrefersDark` if used during hydration. (see issue [#310](https://github.com/solidjs-community/solid-primitives/issues/310))

--- a/packages/media/README.md
+++ b/packages/media/README.md
@@ -82,19 +82,19 @@ const Example: Component = () => {
   createEffect(
     () => [matches.sm, matches.lg, matches.xl],
     ([sm, lg, xl]) => {
-      console.log(sm);  // true when screen width >= 640px
-      console.log(lg);  // true when screen width >= 1024px
-      console.log(xl);  // true when screen width >= 1280px
-    }
+      console.log(sm); // true when screen width >= 640px
+      console.log(lg); // true when screen width >= 1024px
+      console.log(xl); // true when screen width >= 1280px
+    },
   );
 
   return (
     <div
       class={[
-        "text-tiny flex flex-column",               // tiny text with flex column layout
-        matches.sm && "text-small",                  // small text with flex column layout
-        matches.lg && "text-base flex-row",          // base text with flex row layout
-        matches.xl && "text-huge",                   // huge text with flex row layout
+        "text-tiny flex-column flex", // tiny text with flex column layout
+        matches.sm && "text-small", // small text with flex column layout
+        matches.lg && "flex-row text-base", // base text with flex row layout
+        matches.xl && "text-huge", // huge text with flex row layout
       ]}
     >
       <Switch fallback={<div>Smallest</div>}>
@@ -174,10 +174,7 @@ Provides a signal indicating if the user has requested dark color theme. The set
 import { createPrefersDark } from "@solid-primitives/media";
 
 const prefersDark = createPrefersDark();
-createEffect(
-  prefersDark,
-  dark => console.log("prefers dark:", dark)
-);
+createEffect(prefersDark, dark => console.log("prefers dark:", dark));
 ```
 
 ### Server fallback
@@ -198,10 +195,7 @@ This primitive provides a [singleton root](https://github.com/solidjs-community/
 import { usePrefersDark } from "@solid-primitives/media";
 
 const prefersDark = usePrefersDark();
-createEffect(
-  prefersDark,
-  dark => console.log("prefers dark:", dark)
-);
+createEffect(prefersDark, dark => console.log("prefers dark:", dark));
 ```
 
 > Note: `usePrefersDark` will deopt to `createPrefersDark` if used during hydration. (see issue [#310](https://github.com/solidjs-community/solid-primitives/issues/310))

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -68,12 +68,12 @@
     "@solid-primitives/utils": "workspace:^"
   },
   "peerDependencies": {
-    "@solidjs/web": "^2.0.0-beta.7",
-    "solid-js": "^2.0.0-beta.7"
+    "@solidjs/web": "^2.0.0-beta.10",
+    "solid-js": "^2.0.0-beta.10"
   },
   "typesVersions": {},
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.7",
-    "solid-js": "2.0.0-beta.7"
+    "@solidjs/web": "2.0.0-beta.10",
+    "solid-js": "2.0.0-beta.10"
   }
 }

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/media",
-  "version": "2.3.5",
+  "version": "3.0.0",
   "description": "Primitives for media query and device features",
   "author": "David Di Biase <dave@solidjs.com>",
   "contributors": [
@@ -68,10 +68,12 @@
     "@solid-primitives/utils": "workspace:^"
   },
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "@solidjs/web": "^2.0.0-beta.7",
+    "solid-js": "^2.0.0-beta.7"
   },
   "typesVersions": {},
   "devDependencies": {
-    "solid-js": "^1.9.7"
+    "@solidjs/web": "2.0.0-beta.7",
+    "solid-js": "2.0.0-beta.7"
   }
 }

--- a/packages/media/src/index.ts
+++ b/packages/media/src/index.ts
@@ -1,5 +1,5 @@
 import { type Accessor } from "solid-js";
-import { isServer } from "solid-js/web";
+import { isServer } from "@solidjs/web";
 import { makeEventListener } from "@solid-primitives/event-listener";
 import { entries, noop, createHydratableSignal } from "@solid-primitives/utils";
 import { createHydratableStaticStore } from "@solid-primitives/static-store";

--- a/packages/media/test/index.test.ts
+++ b/packages/media/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeEach, beforeAll, afterAll } from "vitest";
-import { createRoot, onMount } from "solid-js";
+import { createRoot } from "solid-js";
 import { createBreakpoints, sortBreakpoints } from "../src/index.js";
 
 describe("createBreakpoints", () => {
@@ -217,11 +217,8 @@ describe("createBreakpoints", () => {
       createBreakpoints(breakpoints, {
         watchChange: false,
       });
-
-      onMount(() => {
-        expect(addListenerMock).not.toBeCalled();
-        dispose();
-      });
+      expect(addListenerMock).not.toBeCalled();
+      dispose();
     });
     expect(removeListenerMock).not.toBeCalled();
   });
@@ -230,11 +227,8 @@ describe("createBreakpoints", () => {
     window.matchMedia = undefined as unknown as typeof window.matchMedia;
     createRoot(dispose => {
       createBreakpoints(breakpoints);
-
-      onMount(() => {
-        expect(addListenerMock).not.toBeCalled();
-        dispose();
-      });
+      expect(addListenerMock).not.toBeCalled();
+      dispose();
     });
     expect(removeListenerMock).not.toBeCalled();
   });

--- a/packages/rootless/package.json
+++ b/packages/rootless/package.json
@@ -56,11 +56,11 @@
     "@solid-primitives/utils": "workspace:^"
   },
   "peerDependencies": {
-    "@solidjs/web": "^2.0.0-beta.7",
-    "solid-js": "^2.0.0-beta.7"
+    "@solidjs/web": "^2.0.0-beta.10",
+    "solid-js": "^2.0.0-beta.10"
   },
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.7",
-    "solid-js": "2.0.0-beta.7"
+    "@solidjs/web": "2.0.0-beta.10",
+    "solid-js": "2.0.0-beta.10"
   }
 }

--- a/packages/rootless/package.json
+++ b/packages/rootless/package.json
@@ -56,9 +56,11 @@
     "@solid-primitives/utils": "workspace:^"
   },
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "@solidjs/web": "^2.0.0-beta.7",
+    "solid-js": "^2.0.0-beta.7"
   },
   "devDependencies": {
-    "solid-js": "^1.9.7"
+    "@solidjs/web": "2.0.0-beta.7",
+    "solid-js": "2.0.0-beta.7"
   }
 }

--- a/packages/rootless/src/index.ts
+++ b/packages/rootless/src/index.ts
@@ -18,6 +18,7 @@ import {
   noop,
   createMicrotask,
   trueFn,
+  INTERNAL_OPTIONS,
 } from "@solid-primitives/utils";
 
 /**
@@ -134,7 +135,9 @@ export function createSingletonRoot<T>(
     });
 
     if (!disposeRoot) {
-      createRoot(dispose => (value = factory((disposeRoot = dispose))), detachedOwner);
+      runWithOwner(detachedOwner, () =>
+        createRoot(dispose => (value = factory((disposeRoot = dispose)))),
+      );
     }
 
     return value!;
@@ -255,7 +258,7 @@ export function createRootPool<TArg, TResult>(
     mapRoot: (dispose: VoidFunction, signal: Signal<TArg>) => Root =
       factory.length > 1
         ? (dispose, [args, set]) => {
-            const [active, setA] = createSignal(true);
+            const [active, setA] = createSignal(true, INTERNAL_OPTIONS);
             const root: Root = {
               dispose,
               set,
@@ -291,9 +294,10 @@ export function createRootPool<TArg, TResult>(
     disposeRoot = (root: Root) => {
       root.dispose();
       root.dispose = noop;
-      if (root.active()) root.setA(false);
+      const idx = pool.indexOf(root);
+      if (idx === -1) root.setA(false);
       else {
-        pool[pool.indexOf(root)] = pool[--length]!;
+        pool[idx] = pool[--length]!;
         pool[length] = undefined!;
       }
     };
@@ -311,7 +315,10 @@ export function createRootPool<TArg, TResult>(
       pool[length] = undefined!;
       root.set(() => arg);
       root.setA(true);
-    } else root = createRoot(dispose => mapRoot(dispose, createSignal(arg)), owner);
+    } else
+      root = runWithOwner(owner, () =>
+        createRoot(dispose => mapRoot(dispose, createSignal(arg, INTERNAL_OPTIONS))),
+      );
 
     onCleanup(() => cleanupRoot(root));
 

--- a/packages/rootless/src/index.ts
+++ b/packages/rootless/src/index.ts
@@ -8,10 +8,9 @@ import {
   type Accessor,
   createSignal,
   type Signal,
-  batch,
   type Setter,
 } from "solid-js";
-import { isServer } from "solid-js/web";
+import { isServer } from "@solidjs/web";
 import {
   type AnyFunction,
   asArray,
@@ -161,7 +160,7 @@ export const createSharedRoot = createSingletonRoot;
 export function createHydratableSingletonRoot<T>(factory: (dispose: VoidFunction) => T): () => T {
   const owner = getOwner();
   const singleton = createSingletonRoot(factory, owner);
-  return () => (isServer || sharedConfig.context ? createRoot(factory, owner) : singleton());
+  return () => (isServer || sharedConfig.hydrating ? createRoot(factory, owner) : singleton());
 }
 
 /**
@@ -310,10 +309,8 @@ export function createRootPool<TArg, TResult>(
     if (length) {
       root = pool[--length]!;
       pool[length] = undefined!;
-      batch(() => {
-        root.set(() => arg);
-        root.setA(true);
-      });
+      root.set(() => arg);
+      root.setA(true);
     } else root = createRoot(dispose => mapRoot(dispose, createSignal(arg)), owner);
 
     onCleanup(() => cleanupRoot(root));

--- a/packages/rootless/test/index.test.ts
+++ b/packages/rootless/test/index.test.ts
@@ -1,10 +1,10 @@
 import { describe, test, expect } from "vitest";
 import {
-  createComputed,
-  createEffect,
   createMemo,
   createRoot,
   createSignal,
+  createTrackedEffect,
+  flush,
   getOwner,
   onCleanup,
 } from "solid-js";
@@ -16,33 +16,48 @@ import {
 } from "../src/index.js";
 
 describe("createSubRoot", () => {
-  test("behaves like a root", () =>
-    createSubRoot(dispose => {
-      const captured: any[] = [];
-      const [count, setCount] = createSignal(0);
-      createComputed(() => captured.push(count()));
-      setCount(1);
-      expect(captured, "before dispose()").toEqual([0, 1]);
-      dispose();
-      setCount(2);
-      expect(captured, "after dispose()").toEqual([0, 1]);
-    }));
+  test("behaves like a root", () => {
+    const captured: any[] = [];
+    const [count, setCount] = createSignal(0);
+    const dispose = createSubRoot(dispose => {
+      createTrackedEffect(() => { captured.push(count()); });
+      return dispose;
+    });
+    flush();
+    expect(captured).toEqual([0]);
+    setCount(1);
+    flush();
+    expect(captured, "before dispose()").toEqual([0, 1]);
+    dispose();
+    setCount(2);
+    flush();
+    expect(captured, "after dispose()").toEqual([0, 1]);
+  });
 
-  test("disposes with owner", () =>
-    createRoot(dispose => {
+  test("disposes with owner", () => {
+    const captured: any[] = [];
+    const [count, setCount] = createSignal(0);
+    const dispose = createRoot(dispose => {
       createSubRoot(() => {
-        const captured: any[] = [];
-        const [count, setCount] = createSignal(0);
-        createComputed(() => captured.push(count()));
-        setCount(1);
-        expect(captured, "before dispose()").toEqual([0, 1]);
-        dispose();
-        setCount(2);
-        expect(captured, "after dispose()").toEqual([0, 1]);
+        createTrackedEffect(() => { captured.push(count()); });
       });
-    }));
+      return dispose;
+    });
+    flush();
+    expect(captured).toEqual([0]);
+    setCount(1);
+    flush();
+    expect(captured, "before dispose()").toEqual([0, 1]);
+    dispose();
+    setCount(2);
+    flush();
+    expect(captured, "after dispose()").toEqual([0, 1]);
+  });
 
   test("many parent owners", () => {
+    const captured: any[] = [];
+    const [count, setCount] = createSignal(0);
+
     const [o1, o2, dispose1, dispose2] = createRoot(dispose1 => {
       const o1 = getOwner();
       const [o2, dispose2] = createRoot(dispose2 => {
@@ -53,18 +68,20 @@ describe("createSubRoot", () => {
 
     createSubRoot(
       () => {
-        const captured: any[] = [];
-        const [count, setCount] = createSignal(0);
-        createComputed(() => captured.push(count()));
-        setCount(1);
-        expect(captured, "before dispose()").toEqual([0, 1]);
-        dispose1();
-        setCount(2);
-        expect(captured, "after dispose()").toEqual([0, 1]);
+        createTrackedEffect(() => { captured.push(count()); });
       },
       o1,
       o2,
     );
+    flush();
+    expect(captured).toEqual([0]);
+    setCount(1);
+    flush();
+    expect(captured, "before dispose()").toEqual([0, 1]);
+    dispose1();
+    setCount(2);
+    flush();
+    expect(captured, "after dispose()").toEqual([0, 1]);
     dispose2();
   });
 });
@@ -89,32 +106,44 @@ describe("createCallback", () => {
 });
 
 describe("createDisposable", () => {
-  test("working with createComputed", () => {
+  test("working with createTrackedEffect", () => {
     const [count, setCount] = createSignal(0);
     const captured: any[] = [];
-    const dispose = createDisposable(() => createComputed(() => captured.push(count())));
+    const dispose = createDisposable(() =>
+      createTrackedEffect(() => { captured.push(count()); }),
+    );
+    flush();
     expect(captured).toEqual([0]);
     setCount(1);
+    flush();
     expect(captured, "before dispose()").toEqual([0, 1]);
     dispose();
+    setCount(2);
+    flush();
     expect(captured, "after disposing").toEqual([0, 1]);
   });
 
-  test("disposes together with owner", () =>
-    createRoot(dispose => {
-      const [count, setCount] = createSignal(0);
-      const captured: any[] = [];
-      createDisposable(() => createComputed(() => captured.push(count())));
-      expect(captured).toEqual([0]);
-      setCount(1);
-      expect(captured, "before dispose()").toEqual([0, 1]);
-      dispose();
-      expect(captured, "after disposing").toEqual([0, 1]);
-    }));
+  test("disposes together with owner", () => {
+    const [count, setCount] = createSignal(0);
+    const captured: any[] = [];
+    const dispose = createRoot(dispose => {
+      createDisposable(() => createTrackedEffect(() => { captured.push(count()); }));
+      return dispose;
+    });
+    flush();
+    expect(captured).toEqual([0]);
+    setCount(1);
+    flush();
+    expect(captured, "before dispose()").toEqual([0, 1]);
+    dispose();
+    setCount(2);
+    flush();
+    expect(captured, "after disposing").toEqual([0, 1]);
+  });
 });
 
 describe("createSharedRoot", () => {
-  test("single root", () => {
+  test("single root", async () => {
     const [count, setCount] = createSignal(0);
 
     let runs = 0;
@@ -127,23 +156,33 @@ describe("createSharedRoot", () => {
       });
     });
 
-    createRoot(dispose => {
-      expect(useMemo()()).toBe(0);
-      expect(disposes).toBe(0);
-      expect(runs).toBe(1);
-      setCount(1);
-      expect(runs).toBe(2);
-      dispose();
-      queueMicrotask(() => {
-        expect(disposes).toBe(1);
-        expect(runs).toBe(2);
-        setCount(2);
-        expect(runs).toBe(2);
-      });
+    let dispose!: VoidFunction;
+    createRoot(d => {
+      const memo = useMemo();
+      createTrackedEffect(() => void memo());
+      dispose = d;
     });
+
+    flush();
+    expect(disposes).toBe(0);
+    expect(runs).toBe(1);
+
+    setCount(1);
+    flush();
+    expect(runs).toBe(2);
+
+    dispose();
+
+    await Promise.resolve();
+    expect(disposes).toBe(1);
+    expect(runs).toBe(2);
+
+    setCount(2);
+    flush();
+    expect(runs).toBe(2);
   });
 
-  test("multiple roots", () => {
+  test("multiple roots", async () => {
     const [count, setCount] = createSignal(0);
 
     let runs = 0;
@@ -156,66 +195,70 @@ describe("createSharedRoot", () => {
       });
     });
 
-    const d1 = createRoot(dispose => {
-      expect(useMemo()()).toBe(0);
-      return dispose;
+    let d1!: VoidFunction;
+    createRoot(d => {
+      const memo = useMemo();
+      createTrackedEffect(() => void memo());
+      d1 = d;
     });
 
-    const d2 = createRoot(dispose => {
-      createEffect(() => useMemo()());
-      return dispose;
+    let d2!: VoidFunction;
+    createRoot(d => {
+      const memo = useMemo();
+      createTrackedEffect(() => void memo());
+      d2 = d;
     });
 
+    flush();
     expect(runs).toBe(1);
+
     setCount(1);
+    flush();
     expect(runs).toBe(2);
 
     d1();
 
-    queueMicrotask(() => {
-      expect(runs).toBe(2);
-      expect(disposes).toBe(0);
-      setCount(2);
-      expect(runs).toBe(3);
+    await Promise.resolve();
+    expect(runs).toBe(2);
+    expect(disposes).toBe(0);
 
-      setTimeout(() => {
-        d2();
+    setCount(2);
+    flush();
+    expect(runs).toBe(3);
 
-        setTimeout(() => {
-          expect(runs).toBe(3);
-          expect(disposes).toBe(1);
-          setCount(3);
-          expect(runs).toBe(3);
-        });
-      });
-    });
+    d2();
+
+    await Promise.resolve();
+    expect(runs).toBe(3);
+    expect(disposes).toBe(1);
+
+    setCount(3);
+    flush();
+    expect(runs).toBe(3);
   });
 
-  test("multiple dependents disposing in one tick", () =>
-    createRoot(dispose => {
-      let alive = false;
-      const track = createSingletonRoot(() => {
-        alive = true;
-        onCleanup(() => (alive = false));
-      });
+  test("multiple dependents disposing in one tick", async () => {
+    let alive = false;
+    const track = createSingletonRoot(() => {
+      alive = true;
+      onCleanup(() => (alive = false));
+    });
 
-      const d1 = createRoot(d1 => {
-        track();
-        return d1;
-      });
+    const d1 = createRoot(d1 => {
+      track();
+      return d1;
+    });
 
-      const d2 = createRoot(d2 => {
-        track();
-        return d2;
-      });
+    const d2 = createRoot(d2 => {
+      track();
+      return d2;
+    });
 
-      expect(alive).toBe(true);
-      d1();
-      d2();
+    expect(alive).toBe(true);
+    d1();
+    d2();
 
-      queueMicrotask(() => {
-        expect(alive).toBe(false);
-        dispose();
-      });
-    }));
+    await Promise.resolve();
+    expect(alive).toBe(false);
+  });
 });

--- a/packages/rootless/test/index.test.ts
+++ b/packages/rootless/test/index.test.ts
@@ -20,7 +20,9 @@ describe("createSubRoot", () => {
     const captured: any[] = [];
     const [count, setCount] = createSignal(0);
     const dispose = createSubRoot(dispose => {
-      createTrackedEffect(() => { captured.push(count()); });
+      createTrackedEffect(() => {
+        captured.push(count());
+      });
       return dispose;
     });
     flush();
@@ -39,7 +41,9 @@ describe("createSubRoot", () => {
     const [count, setCount] = createSignal(0);
     const dispose = createRoot(dispose => {
       createSubRoot(() => {
-        createTrackedEffect(() => { captured.push(count()); });
+        createTrackedEffect(() => {
+          captured.push(count());
+        });
       });
       return dispose;
     });
@@ -68,7 +72,9 @@ describe("createSubRoot", () => {
 
     createSubRoot(
       () => {
-        createTrackedEffect(() => { captured.push(count()); });
+        createTrackedEffect(() => {
+          captured.push(count());
+        });
       },
       o1,
       o2,
@@ -110,7 +116,9 @@ describe("createDisposable", () => {
     const [count, setCount] = createSignal(0);
     const captured: any[] = [];
     const dispose = createDisposable(() =>
-      createTrackedEffect(() => { captured.push(count()); }),
+      createTrackedEffect(() => {
+        captured.push(count());
+      }),
     );
     flush();
     expect(captured).toEqual([0]);
@@ -127,7 +135,11 @@ describe("createDisposable", () => {
     const [count, setCount] = createSignal(0);
     const captured: any[] = [];
     const dispose = createRoot(dispose => {
-      createDisposable(() => createTrackedEffect(() => { captured.push(count()); }));
+      createDisposable(() =>
+        createTrackedEffect(() => {
+          captured.push(count());
+        }),
+      );
       return dispose;
     });
     flush();

--- a/packages/rootless/test/root-pool.test.ts
+++ b/packages/rootless/test/root-pool.test.ts
@@ -7,9 +7,9 @@ import {
   useContext,
   onCleanup,
   Accessor,
-  createEffect,
-  createComputed,
+  createTrackedEffect,
   createSignal,
+  flush,
   runWithOwner,
 } from "solid-js";
 
@@ -40,7 +40,7 @@ describe("createRootPool", () => {
     const root = createRoot(dispose => {
       let pool!: ReturnType<typeof createRootPool>;
 
-      Ctx.Provider({
+      const ctxChildren = Ctx({
         value: "root",
         get children() {
           pool = createRootPool(() => {
@@ -49,7 +49,8 @@ describe("createRootPool", () => {
           });
           return "";
         },
-      });
+      }) as unknown as () => unknown;
+      ctxChildren(); // force lazy children evaluation to initialize pool inside context scope
 
       return { dispose, pool };
     });
@@ -127,7 +128,7 @@ describe("createRootPool", () => {
 
       const pool = createRootPool((n: Accessor<number>) => {
         roots++;
-        createComputed(() => {
+        createTrackedEffect(() => {
           capturedArgs.push(n());
         });
         onCleanup(() => {
@@ -142,6 +143,7 @@ describe("createRootPool", () => {
         d();
       });
 
+      flush();
       expect(capturedArgs).toEqual([0, 1, 2]);
       expect(roots).toBe(3);
       expect(cleanups).toEqual([]);
@@ -150,6 +152,7 @@ describe("createRootPool", () => {
       pool(4);
       pool(5);
 
+      flush();
       expect(capturedArgs).toEqual([0, 1, 2, 3, 4, 5]);
       expect(roots).toBe(3);
       expect(cleanups).toEqual([]);
@@ -158,7 +161,7 @@ describe("createRootPool", () => {
 
       expect(capturedArgs).toEqual([0, 1, 2, 3, 4, 5]);
       expect(roots).toBe(3);
-      expect(cleanups).toEqual([5, 4, 3]);
+      expect(cleanups).toEqual([3, 4, 5]);
     });
   });
 
@@ -175,9 +178,9 @@ describe("createRootPool", () => {
         d();
       });
 
-      expect(pool()).toBe(0);
-      expect(pool()).toBe(1);
       expect(pool()).toBe(2);
+      expect(pool()).toBe(1);
+      expect(pool()).toBe(0);
 
       dispose();
     });
@@ -192,7 +195,7 @@ describe("createRootPool", () => {
 
       const pool = createRootPool((arg, active) => {
         const index = i++;
-        createEffect(() => {
+        createTrackedEffect(() => {
           if (active()) captured[index] = count();
         });
       });
@@ -210,36 +213,44 @@ describe("createRootPool", () => {
         });
       });
 
+      flush();
       await Promise.resolve();
       expect(captured).toEqual([1, 1]);
 
       setCount(2);
+      flush();
       await Promise.resolve();
       expect(captured).toEqual([2, 2]);
 
       disposeRoot();
 
       setCount(3);
+      flush();
       await Promise.resolve();
       expect(captured).toEqual([3, 2]);
 
       setCount(4);
+      flush();
       await Promise.resolve();
       expect(captured).toEqual([4, 2]);
 
       runWithOwner(owner, pool);
+      flush();
       await Promise.resolve();
       expect(captured).toEqual([4, 4]);
 
       setCount(5);
+      flush();
       await Promise.resolve();
       expect(captured).toEqual([5, 5]);
 
       dispose();
+      flush();
       await Promise.resolve();
       expect(captured).toEqual([5, 5]);
 
       setCount(6);
+      flush();
       await Promise.resolve();
       expect(captured).toEqual([5, 5]);
     });

--- a/packages/static-store/package.json
+++ b/packages/static-store/package.json
@@ -51,14 +51,14 @@
     "test:ssr": "pnpm run vitest --mode ssr"
   },
   "peerDependencies": {
-    "@solidjs/web": "^2.0.0-beta.7",
-    "solid-js": "^2.0.0-beta.7"
+    "@solidjs/web": "^2.0.0-beta.10",
+    "solid-js": "^2.0.0-beta.10"
   },
   "dependencies": {
     "@solid-primitives/utils": "workspace:^"
   },
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.7",
-    "solid-js": "2.0.0-beta.7"
+    "@solidjs/web": "2.0.0-beta.10",
+    "solid-js": "2.0.0-beta.10"
   }
 }

--- a/packages/static-store/package.json
+++ b/packages/static-store/package.json
@@ -51,12 +51,14 @@
     "test:ssr": "pnpm run vitest --mode ssr"
   },
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "@solidjs/web": "^2.0.0-beta.7",
+    "solid-js": "^2.0.0-beta.7"
   },
   "dependencies": {
     "@solid-primitives/utils": "workspace:^"
   },
   "devDependencies": {
-    "solid-js": "^1.9.7"
+    "@solidjs/web": "2.0.0-beta.7",
+    "solid-js": "2.0.0-beta.7"
   }
 }

--- a/packages/static-store/src/index.ts
+++ b/packages/static-store/src/index.ts
@@ -153,7 +153,7 @@ export function createDerivedStaticStore<T extends object>(
       get() {
         let keyMemo = cache[key];
         if (!keyMemo) {
-          if (!getListener()) return fnMemo()[key];
+          if (!getObserver()) return fnMemo()[key];
           runWithOwner(o, () => (cache[key] = keyMemo = createMemo(() => fnMemo()[key])));
         }
         return keyMemo!();

--- a/packages/static-store/src/index.ts
+++ b/packages/static-store/src/index.ts
@@ -1,21 +1,20 @@
 import { accessWith, isObject, type SetterParam } from "@solid-primitives/utils";
 import {
   type Accessor,
-  batch,
   createMemo,
   createSignal,
   type EffectFunction,
-  getListener,
+  getObserver,
   getOwner,
   type MemoOptions,
   type NoInfer,
-  onMount,
+  onSettled,
   runWithOwner,
   sharedConfig,
   type Signal,
   untrack,
 } from "solid-js";
-import { isServer } from "solid-js/web";
+import { isServer } from "@solidjs/web";
 
 export type StaticStoreSetter<T extends object> = {
   (setter: (prev: T) => Partial<T>): T;
@@ -54,8 +53,8 @@ export function createStaticStore<T extends object>(
   const getValue = (key: keyof T): T[keyof T] => {
     let signal = cache[key];
     if (!signal) {
-      if (!getListener()) return copy[key];
-      cache[key] = signal = createSignal(copy[key], { internal: true });
+      if (!getObserver()) return copy[key];
+      cache[key] = signal = createSignal(copy[key], { pureWrite: true });
       delete copy[key];
     }
     return signal[0]();
@@ -78,9 +77,7 @@ export function createStaticStore<T extends object>(
         const entries = untrack(
           () => Object.entries(accessWith(a, store) as Partial<T>) as [any, any][],
         );
-        batch(() => {
-          for (const [key, value] of entries) setValue(key, () => value);
-        });
+        for (const [key, value] of entries) setValue(key, () => value);
       } else setValue(a, b);
       return store;
     },
@@ -104,9 +101,9 @@ export function createHydratableStaticStore<T extends object>(
 ): ReturnType<typeof createStaticStore<T>> {
   if (isServer) return createStaticStore(serverValue);
 
-  if (sharedConfig.context) {
+  if (sharedConfig.hydrating) {
     const [state, setState] = createStaticStore(serverValue);
-    onMount(() => setState(update()));
+    onSettled(() => setState(update()));
     return [state, setState];
   }
 

--- a/packages/static-store/test/index.test.ts
+++ b/packages/static-store/test/index.test.ts
@@ -1,4 +1,4 @@
-import { createEffect, createRoot, createSignal } from "solid-js";
+import { createRoot, createSignal, createTrackedEffect, flush } from "solid-js";
 import { describe, expect, test } from "vitest";
 import {
   createDerivedStaticStore,
@@ -35,7 +35,7 @@ describe("createStaticStore", () => {
       setState("a", prev => prev + 1);
       expect(state.a).toBe(10);
 
-      createEffect(() => {
+      createTrackedEffect(() => {
         state.a;
         aUpdates++;
       });
@@ -43,13 +43,14 @@ describe("createStaticStore", () => {
       return { dispose, setState };
     });
 
+    flush();
     expect(aUpdates).toBe(0);
 
-    setState({
-      b: 3,
-    });
+    setState({ b: 3 });
+    flush();
     expect(aUpdates).toBe(0);
     setState("a", 4);
+    flush();
     expect(aUpdates).toBe(1);
 
     dispose();
@@ -69,44 +70,42 @@ describe("createHydratableStaticStore", () => {
 describe("createDerivedStaticStore", () => {
   test("individual keys only update when changed", () => {
     let aUpdates = -1;
+    const _shape = { a: 1, b: 2, c: 3, d: [0, 1, 2] };
+    const [s, set] = createSignal(_shape);
 
-    const { dispose, set } = createRoot(dispose => {
-      const _shape = { a: 1, b: 2, c: 3, d: [0, 1, 2] };
-      const [s, set] = createSignal(_shape);
+    const { dispose, state } = createRoot(dispose => {
       const state = createDerivedStaticStore(s);
 
-      expect(state).toEqual(_shape);
-      expect(_shape, "original input shouldn't be mutated").toEqual({
-        a: 1,
-        b: 2,
-        c: 3,
-        d: [0, 1, 2],
-      });
-
-      set(p => ({ ...p, a: 9, d: [3, 2, 1] }));
-
-      expect(state).toEqual({ a: 9, b: 2, c: 3, d: [3, 2, 1] });
-      expect(_shape, "original input shouldn't be mutated").toEqual({
-        a: 1,
-        b: 2,
-        c: 3,
-        d: [0, 1, 2],
-      });
-
-      createEffect(() => {
+      createTrackedEffect(() => {
         state.a;
         aUpdates++;
       });
 
-      return { dispose, set };
+      return { dispose, state };
     });
 
+    flush();
+    expect(state).toEqual(_shape);
     expect(aUpdates).toBe(0);
 
-    set(p => ({ ...p, b: 3 }));
-    expect(aUpdates).toBe(0);
-    set(p => ({ ...p, a: 4 }));
+    set(p => ({ ...p, a: 9, d: [3, 2, 1] }));
+    flush();
+    expect(state).toEqual({ a: 9, b: 2, c: 3, d: [3, 2, 1] });
+    expect(_shape, "original input shouldn't be mutated").toEqual({
+      a: 1,
+      b: 2,
+      c: 3,
+      d: [0, 1, 2],
+    });
     expect(aUpdates).toBe(1);
+
+    set(p => ({ ...p, b: 3 }));
+    flush();
+    expect(aUpdates).toBe(1);
+
+    set(p => ({ ...p, a: 4 }));
+    flush();
+    expect(aUpdates).toBe(2);
 
     dispose();
   });

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -61,11 +61,11 @@
     "primitives"
   ],
   "peerDependencies": {
-    "@solidjs/web": "^2.0.0-beta.7",
-    "solid-js": "^2.0.0-beta.7"
+    "@solidjs/web": "^2.0.0-beta.10",
+    "solid-js": "^2.0.0-beta.10"
   },
   "devDependencies": {
-    "@solidjs/web": "2.0.0-beta.7",
-    "solid-js": "2.0.0-beta.7"
+    "@solidjs/web": "2.0.0-beta.10",
+    "solid-js": "2.0.0-beta.10"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -61,9 +61,11 @@
     "primitives"
   ],
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "@solidjs/web": "^2.0.0-beta.7",
+    "solid-js": "^2.0.0-beta.7"
   },
   "devDependencies": {
-    "solid-js": "^1.9.7"
+    "@solidjs/web": "2.0.0-beta.7",
+    "solid-js": "2.0.0-beta.7"
   }
 }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -4,16 +4,15 @@ import {
   createSignal,
   type Accessor,
   untrack,
-  type AccessorArray,
   type EffectFunction,
   type NoInfer,
   type SignalOptions,
   sharedConfig,
-  onMount,
+  onSettled,
   DEV,
-  equalFn,
+  isEqual,
 } from "solid-js";
-import { isServer } from "solid-js/web";
+import { isServer } from "@solidjs/web";
 import type {
   AnyClass,
   MaybeAccessor,
@@ -39,11 +38,11 @@ export const noop = (() => void 0) as Noop;
 export const trueFn: () => boolean = () => true;
 export const falseFn: () => boolean = () => false;
 
-/** @deprecated use {@link equalFn} from "solid-js" */
-export const defaultEquals = equalFn;
+/** @deprecated use {@link isEqual} from "solid-js" */
+export const defaultEquals = isEqual;
 
 export const EQUALS_FALSE_OPTIONS = { equals: false } as const satisfies SignalOptions<unknown>;
-export const INTERNAL_OPTIONS = { internal: true } as const satisfies SignalOptions<unknown>;
+export const INTERNAL_OPTIONS = { pureWrite: true } as const satisfies SignalOptions<unknown>;
 
 /**
  * Check if the value is an instance of ___
@@ -153,17 +152,17 @@ export function accessWith<T>(
  * @param initialValue
  */
 export function defer<S, Next extends Prev, Prev = Next>(
-  deps: AccessorArray<S> | Accessor<S>,
+  deps: Accessor<S>[] | Accessor<S>,
   fn: (input: S, prevInput: S, prev: undefined | NoInfer<Prev>) => Next,
   initialValue: Next,
 ): EffectFunction<undefined | NoInfer<Next>, NoInfer<Next>>;
 export function defer<S, Next extends Prev, Prev = Next>(
-  deps: AccessorArray<S> | Accessor<S>,
+  deps: Accessor<S>[] | Accessor<S>,
   fn: (input: S, prevInput: S, prev: undefined | NoInfer<Prev>) => Next,
   initialValue?: undefined,
 ): EffectFunction<undefined | NoInfer<Next>>;
 export function defer<S, Next extends Prev, Prev = Next>(
-  deps: AccessorArray<S> | Accessor<S>,
+  deps: Accessor<S>[] | Accessor<S>,
   fn: (input: S, prevInput: S, prev: undefined | NoInfer<Prev>) => Next,
   initialValue?: Next,
 ): EffectFunction<undefined | NoInfer<Next>> {
@@ -256,9 +255,9 @@ export function createHydratableSignal<T>(
   if (isServer) {
     return createSignal(serverValue, options);
   }
-  if (sharedConfig.context) {
+  if (sharedConfig.hydrating) {
     const [state, setState] = createSignal(serverValue, options);
-    onMount(() => setState(() => update()));
+    onSettled(() => setState(() => update()));
     return [state, setState];
   }
   return createSignal(update(), options);

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -42,7 +42,7 @@ export const falseFn: () => boolean = () => false;
 export const defaultEquals = isEqual;
 
 export const EQUALS_FALSE_OPTIONS = { equals: false } as const satisfies SignalOptions<unknown>;
-export const INTERNAL_OPTIONS = { pureWrite: true } as const satisfies SignalOptions<unknown>;
+export const INTERNAL_OPTIONS = { ownedWrite: true } as const satisfies SignalOptions<unknown>;
 
 /**
  * Check if the value is an instance of ___

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -298,9 +298,12 @@ importers:
         specifier: workspace:^
         version: link:../utils
     devDependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7
 
   packages/event-props:
     devDependencies:
@@ -571,9 +574,12 @@ importers:
         specifier: workspace:^
         version: link:../utils
     devDependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7
 
   packages/memo:
     dependencies:
@@ -786,9 +792,12 @@ importers:
         specifier: workspace:^
         version: link:../utils
     devDependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7
 
   packages/scheduled:
     devDependencies:
@@ -884,9 +893,12 @@ importers:
         specifier: workspace:^
         version: link:../utils
     devDependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7
 
   packages/storage:
     dependencies:
@@ -970,9 +982,12 @@ importers:
 
   packages/utils:
     devDependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
+        specifier: 2.0.0-beta.7
+        version: 2.0.0-beta.7
 
   packages/virtual:
     dependencies:
@@ -1048,10 +1063,10 @@ importers:
         version: link:../packages/utils
       '@solidjs/meta':
         specifier: ^0.29.3
-        version: 0.29.4(solid-js@1.9.7)
+        version: 0.29.4(solid-js@2.0.0-beta.7)
       '@solidjs/router':
         specifier: ^0.13.1
-        version: 0.13.6(solid-js@1.9.7)
+        version: 0.13.6(solid-js@2.0.0-beta.7)
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
@@ -1078,13 +1093,13 @@ importers:
         version: 1.77.8
       solid-dismiss:
         specifier: ^1.7.121
-        version: 1.8.2(solid-js@1.9.7)
+        version: 1.8.2(solid-js@2.0.0-beta.7)
       solid-icons:
         specifier: ^1.1.0
-        version: 1.1.0(solid-js@1.9.7)
+        version: 1.1.0(solid-js@2.0.0-beta.7)
       solid-tippy:
         specifier: ^0.2.1
-        version: 0.2.1(solid-js@1.9.7)(tippy.js@6.3.7)
+        version: 0.2.1(solid-js@2.0.0-beta.7)(tippy.js@6.3.7)
       tippy.js:
         specifier: ^6.3.7
         version: 6.3.7
@@ -2042,6 +2057,7 @@ packages:
   '@graphql-tools/prisma-loader@8.0.4':
     resolution: {integrity: sha512-hqKPlw8bOu/GRqtYr0+dINAI13HinTVYBDqhwGAPIFmLr5s+qKskzgCiwbsckdrb5LWVFmVZc+UXn80OGiyBzg==}
     engines: {node: '>=16.0.0'}
+    deprecated: 'This package was intended to be used with an older versions of Prisma.\nThe newer versions of Prisma has a different approach to GraphQL integration.\nTherefore, this package is no longer needed and has been deprecated and removed.\nLearn more: https://www.prisma.io/graphql'
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
@@ -2587,10 +2603,19 @@ packages:
     peerDependencies:
       solid-js: ^1.5.3
 
+  '@solidjs/signals@2.0.0-beta.7':
+    resolution: {integrity: sha512-SgK6oQlQZofz82LiEJ2RzT3sbs1lWTqFEtLoWjLsUo/dk1v9EoIFpJJlmvgkXvNugASWG+l1yOHa1a8lPamxug==}
+
   '@solidjs/start@1.1.4':
     resolution: {integrity: sha512-ma1TBYqoTju87tkqrHExMReM5Z/+DTXSmi30CCTavtwuR73Bsn4rVGqm528p4sL2koRMfAuBMkrhuttjzhL68g==}
     peerDependencies:
       vinxi: ^0.5.3
+
+  '@solidjs/web@2.0.0-beta.7':
+    resolution: {integrity: sha512-m5VjmDBufrOX0ZKGbhvwkT0CPK0TbMxDbxVPDB1PH2evGbWXQZcUlrpFM1N8RBO5md3aR/T1PgMfnOjleJbrRg==}
+    peerDependencies:
+      '@solidjs/signals': ^2.0.0-beta.7
+      solid-js: ^2.0.0-beta.7
 
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
@@ -3513,6 +3538,7 @@ packages:
 
   dax-sh@0.43.2:
     resolution: {integrity: sha512-uULa1sSIHgXKGCqJ/pA0zsnzbHlVnuq7g8O2fkHokWFNwEGIhh5lAJlxZa1POG5En5ba7AU4KcBAvGQWMMf8rg==}
+    deprecated: This package has moved to simply be 'dax' instead of 'dax-sh'
 
   db0@0.3.2:
     resolution: {integrity: sha512-xzWNQ6jk/+NtdfLyXEipbX55dmDSeteLFt/ayF+wZUU5bzKgmrDOxmInUTbyVRp46YwnJdkDA1KhB7WIXFofJw==}
@@ -4164,11 +4190,12 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -5892,8 +5919,18 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
+  seroval-plugins@1.5.2:
+    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
   seroval@1.3.2:
     resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==}
+    engines: {node: '>=10'}
+
+  seroval@1.5.2:
+    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
     engines: {node: '>=10'}
 
   serve-placeholder@2.0.2:
@@ -6000,6 +6037,9 @@ packages:
 
   solid-js@1.9.7:
     resolution: {integrity: sha512-/saTKi8iWEM233n5OSi1YHCCuh66ZIQ7aK2hsToPe4tqGm7qAejU1SwNuTPivbWAYq7SjuHVVYxxuZQNRbICiw==}
+
+  solid-js@2.0.0-beta.7:
+    resolution: {integrity: sha512-7JHs+BhLeZXoU+u9dG+eKnyxxfZyGpOuJEBbN/1XbHKO/WhxecdplOAurlg/YDllNWPhsbXqmLR1H2paqSu62g==}
 
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -6195,6 +6235,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -6710,6 +6751,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -8576,17 +8618,19 @@ snapshots:
     dependencies:
       solid-js: 1.9.7
 
-  '@solidjs/meta@0.29.4(solid-js@1.9.7)':
+  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.7)':
     dependencies:
-      solid-js: 1.9.7
+      solid-js: 2.0.0-beta.7
 
-  '@solidjs/router@0.13.6(solid-js@1.9.7)':
+  '@solidjs/router@0.13.6(solid-js@2.0.0-beta.7)':
     dependencies:
-      solid-js: 1.9.7
+      solid-js: 2.0.0-beta.7
 
   '@solidjs/router@0.8.4(solid-js@1.9.7)':
     dependencies:
       solid-js: 1.9.7
+
+  '@solidjs/signals@2.0.0-beta.7': {}
 
   '@solidjs/start@1.1.4(solid-js@1.9.7)(vinxi@0.5.7(@types/node@22.15.31)(db0@0.3.2)(ioredis@5.6.1)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))':
     dependencies:
@@ -8610,6 +8654,13 @@ snapshots:
       - solid-js
       - supports-color
       - vite
+
+  '@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)':
+    dependencies:
+      '@solidjs/signals': 2.0.0-beta.7
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
+      solid-js: 2.0.0-beta.7
 
   '@speed-highlight/core@1.2.7': {}
 
@@ -12441,7 +12492,13 @@ snapshots:
     dependencies:
       seroval: 1.3.2
 
+  seroval-plugins@1.5.2(seroval@1.5.2):
+    dependencies:
+      seroval: 1.5.2
+
   seroval@1.3.2: {}
+
+  seroval@1.5.2: {}
 
   serve-placeholder@2.0.2:
     dependencies:
@@ -12557,19 +12614,26 @@ snapshots:
       dot-case: 3.0.4
       tslib: 2.8.1
 
-  solid-dismiss@1.8.2(solid-js@1.9.7):
+  solid-dismiss@1.8.2(solid-js@2.0.0-beta.7):
     dependencies:
-      solid-js: 1.9.7
+      solid-js: 2.0.0-beta.7
 
-  solid-icons@1.1.0(solid-js@1.9.7):
+  solid-icons@1.1.0(solid-js@2.0.0-beta.7):
     dependencies:
-      solid-js: 1.9.7
+      solid-js: 2.0.0-beta.7
 
   solid-js@1.9.7:
     dependencies:
       csstype: 3.1.3
       seroval: 1.3.2
       seroval-plugins: 1.3.2(seroval@1.3.2)
+
+  solid-js@2.0.0-beta.7:
+    dependencies:
+      '@solidjs/signals': 2.0.0-beta.7
+      csstype: 3.1.3
+      seroval: 1.5.2
+      seroval-plugins: 1.5.2(seroval@1.5.2)
 
   solid-refresh@0.6.3(solid-js@1.9.7):
     dependencies:
@@ -12580,9 +12644,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  solid-tippy@0.2.1(solid-js@1.9.7)(tippy.js@6.3.7):
+  solid-tippy@0.2.1(solid-js@2.0.0-beta.7)(tippy.js@6.3.7):
     dependencies:
-      solid-js: 1.9.7
+      solid-js: 2.0.0-beta.7
       tippy.js: 6.3.7
 
   solid-transition-group@0.2.3(solid-js@1.9.7):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 1.0.1
       '@solidjs/start':
         specifier: ^1.1.4
-        version: 1.1.4(solid-js@1.9.7)(vinxi@0.5.7(@types/node@22.15.31)(db0@0.3.2)(ioredis@5.6.1)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))
+        version: 1.1.4(solid-js@2.0.0-beta.10)(vinxi@0.5.7(@types/node@22.15.31)(db0@0.3.2)(ioredis@5.6.1)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))
       '@types/jsdom':
         specifier: ^21.1.7
         version: 21.1.7
@@ -34,7 +34,7 @@ importers:
         version: 0.25.5
       esbuild-plugin-solid:
         specifier: ^0.6.0
-        version: 0.6.0(esbuild@0.25.5)(solid-js@1.9.7)
+        version: 0.6.0(esbuild@0.25.5)(solid-js@2.0.0-beta.10)
       eslint:
         specifier: ^9.28.0
         version: 9.28.0(jiti@2.4.2)
@@ -69,8 +69,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -82,7 +82,7 @@ importers:
         version: 6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0)
       vite-plugin-solid:
         specifier: ^2.11.6
-        version: 2.11.6(solid-js@1.9.7)(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))
+        version: 2.11.6(solid-js@2.0.0-beta.10)(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.15.31)(jsdom@25.0.1)(sass@1.77.8)(terser@5.42.0)
@@ -299,11 +299,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.7
-        version: 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       solid-js:
-        specifier: 2.0.0-beta.7
-        version: 2.0.0-beta.7
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
 
   packages/event-props:
     devDependencies:
@@ -575,11 +575,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.7
-        version: 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       solid-js:
-        specifier: 2.0.0-beta.7
-        version: 2.0.0-beta.7
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
 
   packages/memo:
     dependencies:
@@ -793,11 +793,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.7
-        version: 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       solid-js:
-        specifier: 2.0.0-beta.7
-        version: 2.0.0-beta.7
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
 
   packages/scheduled:
     devDependencies:
@@ -894,11 +894,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.7
-        version: 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       solid-js:
-        specifier: 2.0.0-beta.7
-        version: 2.0.0-beta.7
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
 
   packages/storage:
     dependencies:
@@ -983,11 +983,11 @@ importers:
   packages/utils:
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.7
-        version: 2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       solid-js:
-        specifier: 2.0.0-beta.7
-        version: 2.0.0-beta.7
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
 
   packages/virtual:
     dependencies:
@@ -1063,10 +1063,10 @@ importers:
         version: link:../packages/utils
       '@solidjs/meta':
         specifier: ^0.29.3
-        version: 0.29.4(solid-js@2.0.0-beta.7)
+        version: 0.29.4(solid-js@2.0.0-beta.10)
       '@solidjs/router':
         specifier: ^0.13.1
-        version: 0.13.6(solid-js@2.0.0-beta.7)
+        version: 0.13.6(solid-js@2.0.0-beta.10)
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
@@ -1093,13 +1093,13 @@ importers:
         version: 1.77.8
       solid-dismiss:
         specifier: ^1.7.121
-        version: 1.8.2(solid-js@2.0.0-beta.7)
+        version: 1.8.2(solid-js@2.0.0-beta.10)
       solid-icons:
         specifier: ^1.1.0
-        version: 1.1.0(solid-js@2.0.0-beta.7)
+        version: 1.1.0(solid-js@2.0.0-beta.10)
       solid-tippy:
         specifier: ^0.2.1
-        version: 0.2.1(solid-js@2.0.0-beta.7)(tippy.js@6.3.7)
+        version: 0.2.1(solid-js@2.0.0-beta.10)(tippy.js@6.3.7)
       tippy.js:
         specifier: ^6.3.7
         version: 6.3.7
@@ -2603,19 +2603,18 @@ packages:
     peerDependencies:
       solid-js: ^1.5.3
 
-  '@solidjs/signals@2.0.0-beta.7':
-    resolution: {integrity: sha512-SgK6oQlQZofz82LiEJ2RzT3sbs1lWTqFEtLoWjLsUo/dk1v9EoIFpJJlmvgkXvNugASWG+l1yOHa1a8lPamxug==}
+  '@solidjs/signals@2.0.0-beta.10':
+    resolution: {integrity: sha512-McdmbLNiSlz616zcykS8Rb1t9QTOTKdNAoaWd4/OjXEbcAUrPqRX1CWgR+caiWUk4qn0a+LesTTV4jZhFFPaSg==}
 
   '@solidjs/start@1.1.4':
     resolution: {integrity: sha512-ma1TBYqoTju87tkqrHExMReM5Z/+DTXSmi30CCTavtwuR73Bsn4rVGqm528p4sL2koRMfAuBMkrhuttjzhL68g==}
     peerDependencies:
       vinxi: ^0.5.3
 
-  '@solidjs/web@2.0.0-beta.7':
-    resolution: {integrity: sha512-m5VjmDBufrOX0ZKGbhvwkT0CPK0TbMxDbxVPDB1PH2evGbWXQZcUlrpFM1N8RBO5md3aR/T1PgMfnOjleJbrRg==}
+  '@solidjs/web@2.0.0-beta.10':
+    resolution: {integrity: sha512-Ox7MBv19kuxHoHhWoLCCcc6aykSgaqzWvWT7RB66VqlFnQ8Lid2ncd30g5L4XC0GB+MN/WZVb68tiYrAFUDIAg==}
     peerDependencies:
-      '@solidjs/signals': ^2.0.0-beta.7
-      solid-js: ^2.0.0-beta.7
+      solid-js: ^2.0.0-beta.10
 
   '@speed-highlight/core@1.2.7':
     resolution: {integrity: sha512-0dxmVj4gxg3Jg879kvFS/msl4s9F3T9UXC1InxgOf7t5NvcPD97u/WTA5vL/IxWHMn7qSxBozqrnnE2wvl1m8g==}
@@ -6038,8 +6037,8 @@ packages:
   solid-js@1.9.7:
     resolution: {integrity: sha512-/saTKi8iWEM233n5OSi1YHCCuh66ZIQ7aK2hsToPe4tqGm7qAejU1SwNuTPivbWAYq7SjuHVVYxxuZQNRbICiw==}
 
-  solid-js@2.0.0-beta.7:
-    resolution: {integrity: sha512-7JHs+BhLeZXoU+u9dG+eKnyxxfZyGpOuJEBbN/1XbHKO/WhxecdplOAurlg/YDllNWPhsbXqmLR1H2paqSu62g==}
+  solid-js@2.0.0-beta.10:
+    resolution: {integrity: sha512-EAfV6b1SC4c3wEBAoX4dMy063uTb4nfL5uXnN8yse4InH7RTw1LoB0I9HAy+pj3/GHqQE2tYZurlZtqU4pGyog==}
 
   solid-refresh@0.6.3:
     resolution: {integrity: sha512-F3aPsX6hVw9ttm5LYlth8Q15x6MlI/J3Dn+o3EQyRTtTxidepSTwAYdozt01/YA+7ObcciagGEyXIopGZzQtbA==}
@@ -8618,21 +8617,21 @@ snapshots:
     dependencies:
       solid-js: 1.9.7
 
-  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.7)':
+  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.10)':
     dependencies:
-      solid-js: 2.0.0-beta.7
+      solid-js: 2.0.0-beta.10
 
-  '@solidjs/router@0.13.6(solid-js@2.0.0-beta.7)':
+  '@solidjs/router@0.13.6(solid-js@2.0.0-beta.10)':
     dependencies:
-      solid-js: 2.0.0-beta.7
+      solid-js: 2.0.0-beta.10
 
   '@solidjs/router@0.8.4(solid-js@1.9.7)':
     dependencies:
       solid-js: 1.9.7
 
-  '@solidjs/signals@2.0.0-beta.7': {}
+  '@solidjs/signals@2.0.0-beta.10': {}
 
-  '@solidjs/start@1.1.4(solid-js@1.9.7)(vinxi@0.5.7(@types/node@22.15.31)(db0@0.3.2)(ioredis@5.6.1)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))':
+  '@solidjs/start@1.1.4(solid-js@2.0.0-beta.10)(vinxi@0.5.7(@types/node@22.15.31)(db0@0.3.2)(ioredis@5.6.1)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))':
     dependencies:
       '@tanstack/server-functions-plugin': 1.121.0(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))
       '@vinxi/plugin-directives': 0.5.1(vinxi@0.5.7(@types/node@22.15.31)(db0@0.3.2)(ioredis@5.6.1)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))
@@ -8645,22 +8644,21 @@ snapshots:
       seroval-plugins: 1.3.2(seroval@1.3.2)
       shiki: 1.29.2
       source-map-js: 1.2.1
-      terracotta: 1.0.6(solid-js@1.9.7)
+      terracotta: 1.0.6(solid-js@2.0.0-beta.10)
       tinyglobby: 0.2.14
       vinxi: 0.5.7(@types/node@22.15.31)(db0@0.3.2)(ioredis@5.6.1)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0)
-      vite-plugin-solid: 2.11.6(solid-js@1.9.7)(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))
+      vite-plugin-solid: 2.11.6(solid-js@2.0.0-beta.10)(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))
     transitivePeerDependencies:
       - '@testing-library/jest-dom'
       - solid-js
       - supports-color
       - vite
 
-  '@solidjs/web@2.0.0-beta.7(@solidjs/signals@2.0.0-beta.7)(solid-js@2.0.0-beta.7)':
+  '@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10)':
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.7
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)
-      solid-js: 2.0.0-beta.7
+      solid-js: 2.0.0-beta.10
 
   '@speed-highlight/core@1.2.7': {}
 
@@ -10026,13 +10024,13 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild-plugin-solid@0.6.0(esbuild@0.25.5)(solid-js@1.9.7):
+  esbuild-plugin-solid@0.6.0(esbuild@0.25.5)(solid-js@2.0.0-beta.10):
     dependencies:
       '@babel/core': 7.27.4
       '@babel/preset-typescript': 7.27.1(@babel/core@7.27.4)
       babel-preset-solid: 1.9.6(@babel/core@7.27.4)
       esbuild: 0.25.5
-      solid-js: 1.9.7
+      solid-js: 2.0.0-beta.10
     transitivePeerDependencies:
       - supports-color
 
@@ -12614,13 +12612,13 @@ snapshots:
       dot-case: 3.0.4
       tslib: 2.8.1
 
-  solid-dismiss@1.8.2(solid-js@2.0.0-beta.7):
+  solid-dismiss@1.8.2(solid-js@2.0.0-beta.10):
     dependencies:
-      solid-js: 2.0.0-beta.7
+      solid-js: 2.0.0-beta.10
 
-  solid-icons@1.1.0(solid-js@2.0.0-beta.7):
+  solid-icons@1.1.0(solid-js@2.0.0-beta.10):
     dependencies:
-      solid-js: 2.0.0-beta.7
+      solid-js: 2.0.0-beta.10
 
   solid-js@1.9.7:
     dependencies:
@@ -12628,25 +12626,25 @@ snapshots:
       seroval: 1.3.2
       seroval-plugins: 1.3.2(seroval@1.3.2)
 
-  solid-js@2.0.0-beta.7:
+  solid-js@2.0.0-beta.10:
     dependencies:
-      '@solidjs/signals': 2.0.0-beta.7
+      '@solidjs/signals': 2.0.0-beta.10
       csstype: 3.1.3
       seroval: 1.5.2
       seroval-plugins: 1.5.2(seroval@1.5.2)
 
-  solid-refresh@0.6.3(solid-js@1.9.7):
+  solid-refresh@0.6.3(solid-js@2.0.0-beta.10):
     dependencies:
       '@babel/generator': 7.27.5
       '@babel/helper-module-imports': 7.27.1
       '@babel/types': 7.27.6
-      solid-js: 1.9.7
+      solid-js: 2.0.0-beta.10
     transitivePeerDependencies:
       - supports-color
 
-  solid-tippy@0.2.1(solid-js@2.0.0-beta.7)(tippy.js@6.3.7):
+  solid-tippy@0.2.1(solid-js@2.0.0-beta.10)(tippy.js@6.3.7):
     dependencies:
-      solid-js: 2.0.0-beta.7
+      solid-js: 2.0.0-beta.10
       tippy.js: 6.3.7
 
   solid-transition-group@0.2.3(solid-js@1.9.7):
@@ -12655,9 +12653,9 @@ snapshots:
       '@solid-primitives/transition-group': 1.0.5(solid-js@1.9.7)
       solid-js: 1.9.7
 
-  solid-use@0.9.1(solid-js@1.9.7):
+  solid-use@0.9.1(solid-js@2.0.0-beta.10):
     dependencies:
-      solid-js: 1.9.7
+      solid-js: 2.0.0-beta.10
 
   source-map-js@1.2.1: {}
 
@@ -12878,10 +12876,10 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terracotta@1.0.6(solid-js@1.9.7):
+  terracotta@1.0.6(solid-js@2.0.0-beta.10):
     dependencies:
-      solid-js: 1.9.7
-      solid-use: 0.9.1(solid-js@1.9.7)
+      solid-js: 2.0.0-beta.10
+      solid-use: 0.9.1(solid-js@2.0.0-beta.10)
 
   terser@5.42.0:
     dependencies:
@@ -13308,14 +13306,14 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-solid@2.11.6(solid-js@1.9.7)(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0)):
+  vite-plugin-solid@2.11.6(solid-js@2.0.0-beta.10)(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0)):
     dependencies:
       '@babel/core': 7.27.4
       '@types/babel__core': 7.20.5
       babel-preset-solid: 1.9.6(@babel/core@7.27.4)
       merge-anything: 5.1.7
-      solid-js: 1.9.7
-      solid-refresh: 0.6.3(solid-js@1.9.7)
+      solid-js: 2.0.0-beta.10
+      solid-refresh: 0.6.3(solid-js@2.0.0-beta.10)
       vite: 6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0)
       vitefu: 1.0.6(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(sass@1.77.8)(terser@5.42.0)(tsx@4.20.2)(yaml@2.5.0))
     transitivePeerDependencies:


### PR DESCRIPTION
Upgrades the media primitive and all of its workspace dependencies to Solid.js `2.0.0-beta.7`. The package is bumped to `3.0.0` as a breaking major release.

### What changed

**`@solid-primitives/media`**
- `isServer` import moved from `solid-js/web` → `@solidjs/web`
- Peer deps updated to `solid-js@^2.0.0-beta.7` and `@solidjs/web@^2.0.0-beta.7`
- Tests cleaned up — `onMount` removed, assertions made synchronous
- README examples updated for Solid 2.0 patterns (`class` array form, split `createEffect`)

**`@solid-primitives/utils`**
- `onMount` → `onSettled` in `createHydratableSignal`
- `sharedConfig.context` → `sharedConfig.hydrating` for hydration detection
- `equalFn` → `isEqual`, `INTERNAL_OPTIONS` uses `pureWrite: true` (was `internal: true`)
- `AccessorArray<T>` removed (gone from Solid 2.0) — replaced with `Accessor<T>[]`

**`@solid-primitives/static-store`**
- `getListener` → `getObserver`, `{ internal: true }` → `{ pureWrite: true }`
- Explicit `batch()` calls removed — Solid 2.0 batches automatically on microtasks
- `sharedConfig.hydrating` + `onSettled` in `createHydratableStaticStore`

**`@solid-primitives/rootless`**
- `batch` removed from `createRootPool`, `sharedConfig.hydrating` in `createHydratableSingletonRoot`

**`@solid-primitives/event-listener`**
- All `isServer` imports updated to `@solidjs/web`
- `createEventListener` and `createRenderEffect` converted to the required Solid 2.0 split compute/apply pattern — listeners now attach in the apply phase with cleanup returned as a function
- `eventListener` directive likewise converted; no longer uses `onCleanup` inside an effect

### Notes
- `@solidjs/web@latest` points to `experimental.0` which is **incompatible** with beta.7 — the correct version is `@solidjs/web@2.0.0-beta.7` (the `next` dist-tag).
- All 11 tests pass (9 browser, 2 SSR).