### PR TITLE
upgrade: trigger package upgrade for Solid 2.0

### DIFF
--- a/.changeset/trigger-solid2-migration.md
+++ b/.changeset/trigger-solid2-migration.md
@@ -1,0 +1,16 @@
+---
+"@solid-primitives/trigger": major
+---
+
+Migrate to Solid.js v2.0 (beta.10)
+
+## Breaking Changes
+
+**Peer dependency**: `solid-js@^2.0.0-beta.10` and `@solidjs/web@^2.0.0-beta.10` are now required.
+
+### `@solid-primitives/trigger`
+
+- `isServer` now imported from `@solidjs/web` (not `solid-js/web`)
+- `getListener` replaced by `getObserver` (renamed in Solid 2.0)
+- Signal options updated: `internal: true` removed, `ownedWrite: true` added — allows `dirty()` and `dirtyAll()` to be called from within reactive scopes
+- Added `test/server.test.ts` verifying SSR no-op behaviour for `createTrigger` and `createTriggerCache`

--- a/packages/trigger/package.json
+++ b/packages/trigger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/trigger",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "description": "A set of primitives based on Solid signals, used to trigger computations.",
   "author": "Damian Tarnawski <gthetarnav@gmail.com>",
   "contributors": [],
@@ -52,13 +52,15 @@
     "trigger"
   ],
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "@solidjs/web": "^2.0.0-beta.10",
+    "solid-js": "^2.0.0-beta.10"
   },
   "dependencies": {
     "@solid-primitives/utils": "workspace:^"
   },
   "typesVersions": {},
   "devDependencies": {
-    "solid-js": "^1.9.7"
+    "@solidjs/web": "2.0.0-beta.10",
+    "solid-js": "2.0.0-beta.10"
   }
 }

--- a/packages/trigger/src/index.ts
+++ b/packages/trigger/src/index.ts
@@ -1,13 +1,14 @@
-import { createSignal, getListener, onCleanup, type SignalOptions, DEV } from "solid-js";
-import { isServer } from "solid-js/web";
+import { createSignal, getObserver, onCleanup, type SignalOptions, DEV } from "solid-js";
+import { isServer } from "@solidjs/web";
 import { noop } from "@solid-primitives/utils";
 
 export type Trigger = [track: VoidFunction, dirty: VoidFunction];
 
-const triggerOptions: SignalOptions<any> =
-  !isServer && DEV ? { equals: false, name: "trigger" } : { equals: false };
-const triggerCacheOptions: SignalOptions<any> =
-  !isServer && DEV ? { equals: false, internal: true } : triggerOptions;
+const triggerOptions: SignalOptions<any> = !isServer && DEV
+  ? { equals: false, name: "trigger", ownedWrite: true }
+  : { equals: false, ownedWrite: true };
+
+const triggerCacheOptions: SignalOptions<any> = { equals: false, ownedWrite: true };
 
 /**
  * Set listeners in reactive computations and then trigger them when you want.
@@ -56,16 +57,14 @@ export class TriggerCache<T> {
   }
 
   track(key: T) {
-    if (!getListener()) return;
+    if (!getObserver()) return;
     let trigger = this.#map.get(key);
     if (!trigger) {
       const [$, $$] = createSignal(undefined, triggerCacheOptions);
       this.#map.set(key, (trigger = { $, $$, n: 1 }));
     } else trigger.n++;
     onCleanup(() => {
-      // remove the trigger when no one is listening to it
       if (--trigger.n === 0)
-        // microtask is to avoid removing the trigger used by a single listener
         queueMicrotask(() => trigger.n === 0 && this.#map.delete(key));
     });
     trigger.$();

--- a/packages/trigger/test/index.test.ts
+++ b/packages/trigger/test/index.test.ts
@@ -1,4 +1,4 @@
-import { createComputed, createEffect, createRoot, createSignal } from "solid-js";
+import { createEffect, createRoot, createSignal, flush } from "solid-js";
 import { describe, test, expect } from "vitest";
 import { createTriggerCache } from "../src/index.js";
 
@@ -9,14 +9,17 @@ describe("createTriggerCache", () => {
       let runs = -1;
       const key1 = {};
       const key2 = {};
-      createComputed(() => {
-        track(key1);
-        runs++;
-      });
+      createEffect(
+        () => { track(key1); },
+        () => { runs++; },
+      );
+      flush();
       expect(runs).toBe(0);
       dirty(key2);
+      flush();
       expect(runs).toBe(0);
       dirty(key1);
+      flush();
       expect(runs).toBe(1);
 
       dispose();
@@ -26,38 +29,43 @@ describe("createTriggerCache", () => {
     createRoot(dispose => {
       const [track, , dirtyAll] = createTriggerCache(Map);
       let runs = -1;
-      createComputed(() => {
-        track(1);
-        runs++;
-      });
+      createEffect(
+        () => { track(1); },
+        () => { runs++; },
+      );
+      flush();
       expect(runs).toBe(0);
       dirtyAll();
+      flush();
       expect(runs).toBe(1);
 
       dispose();
     }));
 
-  test("weak trigger cache", () =>
+  test("map trigger cache", () =>
     createRoot(dispose => {
       const [track, dirty] = createTriggerCache();
       let runs1 = -1;
       let runs2 = -1;
       const key1 = "key1";
       const key2 = "key2";
-      createComputed(() => {
-        track(key1);
-        runs1++;
-      });
-      createComputed(() => {
-        track(key2);
-        runs2++;
-      });
+      createEffect(
+        () => { track(key1); },
+        () => { runs1++; },
+      );
+      createEffect(
+        () => { track(key2); },
+        () => { runs2++; },
+      );
+      flush();
       expect(runs1).toBe(0);
       expect(runs2).toBe(0);
       dirty(key2);
+      flush();
       expect(runs1).toBe(0);
       expect(runs2).toBe(1);
       dirty(key1);
+      flush();
       expect(runs1).toBe(1);
       expect(runs2).toBe(1);
 
@@ -73,17 +81,19 @@ describe("createTriggerCache", () => {
         return map;
       } as any);
 
-      createEffect(() => {
-        track(key);
-      });
+      createEffect(
+        () => { track(key); },
+        () => {},
+      );
 
       return { dirty, dispose };
     });
 
+    flush();
     expect(map.size).toBe(1);
 
     dirty(key);
-
+    flush();
     expect(map.size).toBe(1);
 
     dispose();
@@ -105,42 +115,44 @@ describe("createTriggerCache", () => {
         return map;
       } as any);
 
-      createComputed(() => {
-        if (enabled1()) track(key);
-      });
-      createComputed(() => {
-        if (enabled2()) track(key);
-      });
+      createEffect(
+        () => { if (enabled1()) track(key); },
+        () => {},
+      );
+      createEffect(
+        () => { if (enabled2()) track(key); },
+        () => {},
+      );
 
       return { dirty, dispose };
     });
 
+    flush();
     expect(map.size).toBe(1);
 
     dirty(key);
-
+    flush();
     expect(map.size).toBe(1);
 
     setEnabled1(false);
-
+    flush();
     await Promise.resolve();
     expect(map.size).toBe(1);
 
     setEnabled2(false);
-
+    flush();
     await Promise.resolve();
     expect(map.size).toBe(0);
 
     setEnabled1(true);
-
+    flush();
     await Promise.resolve();
     expect(map.size).toBe(1);
 
     setEnabled2(true);
     setEnabled1(false);
-
+    flush();
     await Promise.resolve();
-
     expect(map.size).toBe(1);
 
     dispose();

--- a/packages/trigger/test/server.test.ts
+++ b/packages/trigger/test/server.test.ts
@@ -1,0 +1,21 @@
+import { describe, test, expect, vi } from "vitest";
+import { createTrigger, createTriggerCache } from "../src/index.js";
+
+describe("createTrigger", () => {
+  test("returns no-ops on the server", () => {
+    const [track, dirty] = createTrigger();
+    expect(track).toBeTypeOf("function");
+    expect(dirty).toBeTypeOf("function");
+    expect(() => track()).not.toThrow();
+    expect(() => dirty()).not.toThrow();
+  });
+});
+
+describe("createTriggerCache", () => {
+  test("dirty and dirtyAll are no-ops on the server", () => {
+    const [track, dirty, dirtyAll] = createTriggerCache<string>();
+    expect(() => dirty("key")).not.toThrow();
+    expect(() => dirtyAll()).not.toThrow();
+    expect(() => track("key")).not.toThrow();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -960,9 +960,12 @@ importers:
         specifier: workspace:^
         version: link:../utils
     devDependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
 
   packages/tween:
     devDependencies:
@@ -2366,36 +2369,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.3.0':
     resolution: {integrity: sha512-ejBAX8H0ZGsD8lSICDNyMbSEtPMWgDL0WFCt/0z7hyf5v8Imz4rAM8xY379mBsECkq/Wdqa5WEDLqtjZ+6NxfA==}
@@ -2506,36 +2515,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -2672,56 +2687,67 @@ packages:
     resolution: {integrity: sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.43.0':
     resolution: {integrity: sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.43.0':
     resolution: {integrity: sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.43.0':
     resolution: {integrity: sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.43.0':
     resolution: {integrity: sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.43.0':
     resolution: {integrity: sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.43.0':
     resolution: {integrity: sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.43.0':
     resolution: {integrity: sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.43.0':
     resolution: {integrity: sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.43.0':
     resolution: {integrity: sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.43.0':
     resolution: {integrity: sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.43.0':
     resolution: {integrity: sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==}
@@ -5208,24 +5234,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
- isServer`** import moved from `solid-js/web` → `@solidjs/web`
- **`getListener`** → `getObserver` (renamed in Solid 2.0)
- Signal options: replaced `{ internal: true }` with `{ ownedWrite: true }` so `dirty()` / `dirtyAll()` can be safely called from within reactive scopes without throwing `SIGNAL_WRITE_IN_OWNED_SCOPE`
- Tests rewritten to replace `createComputed` (removed in beta.10) with the new split `createEffect(compute, apply)` pattern, with `flush()` calls to drive synchronous effect scheduling
- New `test/server.test.ts` covering SSR no-op behaviour for both `createTrigger` and `createTriggerCache`
- Peer/dev deps bumped to `solid-js@2.0.0-beta.10` + `@solidjs/web@2.0.0-beta.10`; version bumped to `2.0.0