### PR TITLE
upgrade: broadcast-channel package upgrade for Solid 2.0

### DIFF
--- a/.changeset/broadcast-channel-solid2-migration.md
+++ b/.changeset/broadcast-channel-solid2-migration.md
@@ -1,0 +1,12 @@
+---
+"@solid-primitives/broadcast-channel": major
+---
+
+Migrate to Solid.js v2.0 (beta.10)
+
+## Breaking Changes
+
+**Peer dependencies**: `solid-js@^2.0.0-beta.10` and `@solidjs/web@^2.0.0-beta.10` are now required.
+
+- `isServer` is now imported from `@solidjs/web` (was `solid-js/web`)
+- `createEffect` usage follows the split compute/apply pattern required by Solid 2.0 — single-argument `createEffect` is no longer supported

--- a/packages/broadcast-channel/README.md
+++ b/packages/broadcast-channel/README.md
@@ -107,13 +107,12 @@ postMessage({ id: 2, message: "hi" });
 const { message } = createBroadcastChannel("test_channel");
 
 createEffect(
-  on(
-    message,
-    data => {
+  () => message(),
+  data => {
+    if (data !== null) {
       console.log(data); // { id: 2, message: "hi" }
-    },
-    { defer: true },
-  ),
+    }
+  },
 );
 ```
 
@@ -143,19 +142,18 @@ postMessage({ id: "wrong type", message: "hi" }); // ❌
 postMessage({ id: 5, message: "hi" }); // ✅
 
 createEffect(
-  on(
-    message,
-    data => {
-      consumeDataIncorrect(data!); // ❌
-      //                    ^^^
+  () => message(),
+  data => {
+    if (data !== null) {
+      consumeDataIncorrect(data); // ❌
+      //                   ^^^
       // Argument of type 'TData' is not assignable to parameter of type '{ id: string; message: string; }'.
       // Types of property 'id' are incompatible.
       // Type 'number' is not assignable to type 'string'.
 
-      consumeDataCorrect(data!); // ✅
-    },
-    { defer: true },
-  ),
+      consumeDataCorrect(data); // ✅
+    }
+  },
 );
 
 const consumeDataIncorrect = (data: { id: string; message: string }) => {

--- a/packages/broadcast-channel/dev/index.tsx
+++ b/packages/broadcast-channel/dev/index.tsx
@@ -101,7 +101,7 @@ const App: Component = () => {
 
   return (
     <div class="flex min-h-screen justify-between gap-4 bg-gray-800 p-5 pt-[80px] text-white">
-      <header class="fixed left-0 top-0 z-10 flex h-[60px] w-full items-center gap-8 bg-gray-800 px-5">
+      <header class="fixed top-0 left-0 z-10 flex h-[60px] w-full items-center gap-8 bg-gray-800 px-5">
         <h1>
           Page Id: <span class="font-mono">{page.id}</span>
         </h1>
@@ -115,7 +115,7 @@ const App: Component = () => {
             <For each={Object.keys(page.pages)}>
               {item => (
                 <li
-                  class="whitespace-nowrap font-mono"
+                  class="font-mono whitespace-nowrap"
                   classList={{ "color-blue-400": page.id === item }}
                 >
                   id: {item}
@@ -125,7 +125,7 @@ const App: Component = () => {
           </ul>
         </div>
       </div>
-      <div class="flex-grow-1 flex flex-col gap-4 [@media(min-width:825px)]:flex-row">
+      <div class="flex flex-grow-1 flex-col gap-4 [@media(min-width:825px)]:flex-row">
         <MessageContainer page={page} channelName="the_matrix" />
         {/* Example of using same channel name where it uses same instance instead of creating new one */}
         <MessageContainer page={page} channelName="sc2" />

--- a/packages/broadcast-channel/package.json
+++ b/packages/broadcast-channel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/broadcast-channel",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Primitives to manage Broadcast Channel API",
   "author": "Caleb Taylor <aquaductape@gmail.com>",
   "contributors": [],
@@ -51,10 +51,12 @@
     "test:ssr": "pnpm run vitest --mode ssr"
   },
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "@solidjs/web": "^2.0.0-beta.10",
+    "solid-js": "^2.0.0-beta.10"
   },
   "typesVersions": {},
   "devDependencies": {
-    "solid-js": "^1.9.7"
+    "@solidjs/web": "2.0.0-beta.10",
+    "solid-js": "2.0.0-beta.10"
   }
 }

--- a/packages/broadcast-channel/src/index.ts
+++ b/packages/broadcast-channel/src/index.ts
@@ -1,5 +1,5 @@
 import { createSignal, onCleanup } from "solid-js";
-import { isServer } from "solid-js/web";
+import { isServer } from "@solidjs/web";
 
 export type OnMessageCB = (e: MessageEvent) => void;
 

--- a/packages/broadcast-channel/test/index.test.ts
+++ b/packages/broadcast-channel/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeAll, afterAll } from "vitest";
-import { createEffect, createRoot } from "solid-js";
+import { createEffect, createRoot, flush } from "solid-js";
 import { createBroadcastChannel, makeBroadcastChannel } from "../src/index.js";
 
 /*
@@ -223,20 +223,25 @@ describe("createBroadcastChannel", () => {
     const dispose = createRoot(dispose => {
       const { message } = createBroadcastChannel<MsgType>(channelName);
 
-      createEffect(() => {
-        captured.push(message());
-      });
+      createEffect(
+        () => message(),
+        msg => {
+          captured.push(msg);
+        },
+      );
 
       return dispose;
     });
 
+    flush(); // run initial apply with null
     mockedBCInstance.postMessage("hi");
+    flush(); // run apply with updated value
     expect(captured).toEqual([null, "hi"]);
 
     dispose();
   });
 
-  test("posting messages with single instance channel name but called makeBroadcastChannel multiple times", () => {
+  test("posting messages with single instance channel name but called createBroadcastChannel multiple times", () => {
     const channelName = "channel-1";
     const mockedBCInstance = buildMockBroadcastChannel(channelName);
 
@@ -247,18 +252,26 @@ describe("createBroadcastChannel", () => {
       const bc1 = createBroadcastChannel<MsgType>(channelName);
       const bc2 = createBroadcastChannel<MsgType>(channelName);
 
-      createEffect(() => {
-        message1 += bc1.message() + ";";
-      });
+      createEffect(
+        () => bc1.message(),
+        msg => {
+          message1 += msg + ";";
+        },
+      );
 
-      createEffect(() => {
-        message2 += bc2.message() + ";";
-      });
+      createEffect(
+        () => bc2.message(),
+        msg => {
+          message2 += msg + ";";
+        },
+      );
 
       return dispose;
     });
 
+    flush(); // run initial apply with null
     mockedBCInstance.postMessage("hi");
+    flush(); // run apply with updated value
     expect(message1).toBe("null;hi;");
     expect(message2).toBe("null;hi;");
 

--- a/packages/broadcast-channel/test/index.test.ts
+++ b/packages/broadcast-channel/test/index.test.ts
@@ -223,12 +223,9 @@ describe("createBroadcastChannel", () => {
     const dispose = createRoot(dispose => {
       const { message } = createBroadcastChannel<MsgType>(channelName);
 
-      createEffect(
-        () => message(),
-        msg => {
-          captured.push(msg);
-        },
-      );
+      createEffect(message, (msg: MsgType | null) => {
+        captured.push(msg);
+      });
 
       return dispose;
     });
@@ -254,14 +251,14 @@ describe("createBroadcastChannel", () => {
 
       createEffect(
         () => bc1.message(),
-        msg => {
+        (msg: MsgType | null) => {
           message1 += msg + ";";
         },
       );
 
       createEffect(
         () => bc2.message(),
-        msg => {
+        (msg: MsgType | null) => {
           message2 += msg + ";";
         },
       );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,9 +153,12 @@ importers:
 
   packages/broadcast-channel:
     devDependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
 
   packages/clipboard:
     dependencies:
@@ -2366,36 +2369,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.3.0':
     resolution: {integrity: sha512-ejBAX8H0ZGsD8lSICDNyMbSEtPMWgDL0WFCt/0z7hyf5v8Imz4rAM8xY379mBsECkq/Wdqa5WEDLqtjZ+6NxfA==}
@@ -2506,36 +2515,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -2672,56 +2687,67 @@ packages:
     resolution: {integrity: sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.43.0':
     resolution: {integrity: sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.43.0':
     resolution: {integrity: sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.43.0':
     resolution: {integrity: sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.43.0':
     resolution: {integrity: sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.43.0':
     resolution: {integrity: sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.43.0':
     resolution: {integrity: sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.43.0':
     resolution: {integrity: sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.43.0':
     resolution: {integrity: sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.43.0':
     resolution: {integrity: sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.43.0':
     resolution: {integrity: sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.43.0':
     resolution: {integrity: sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==}
@@ -5208,24 +5234,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
Updates peer dependencies to `solid-js@^2.0.0-beta.10` and `@solidjs/web@^2.0.0-beta.10`. Moves `isServer` import to `@solidjs/web`, updates tests to the split `createEffect(compute, apply)` pattern, and removes use of the now-removed `on` helper from README examples.