### PR TITLE
upgrade: styles package upgrade for Solid 2.0

### DIFF
--- a/.changeset/styles-solid2-migration.md
+++ b/.changeset/styles-solid2-migration.md
@@ -1,0 +1,14 @@
+---
+"@solid-primitives/styles": major
+---
+
+Migrate to Solid.js v2.0 (beta.10)
+
+## Breaking Changes
+
+**Peer dependency**: `solid-js@^2.0.0-beta.10` and `@solidjs/web@^2.0.0-beta.10` are now required.
+
+### `@solid-primitives/styles`
+
+- `isServer` now imported from `@solidjs/web` (not `solid-js/web`)
+- Requires Solid.js v2 — signal writes from browser callbacks (e.g. ResizeObserver) are microtask-batched; reads reflect the new value immediately but effects are deferred until the next microtask or `flush()`

--- a/packages/styles/README.md
+++ b/packages/styles/README.md
@@ -22,6 +22,8 @@ yarn add @solid-primitives/styles
 pnpm add @solid-primitives/styles
 ```
 
+**Peer dependencies**: `solid-js@^2.0.0-beta.10` and `@solidjs/web@^2.0.0-beta.10`
+
 ## `createRemSize`
 
 Creates a reactive signal with value of the current rem size in pixels, and tracks it's changes.

--- a/packages/styles/package.json
+++ b/packages/styles/package.json
@@ -57,10 +57,12 @@
     "@solid-primitives/utils": "workspace:^"
   },
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "@solidjs/web": "^2.0.0-beta.10",
+    "solid-js": "^2.0.0-beta.10"
   },
   "typesVersions": {},
   "devDependencies": {
-    "solid-js": "^1.9.7"
+    "@solidjs/web": "2.0.0-beta.10",
+    "solid-js": "2.0.0-beta.10"
   }
 }

--- a/packages/styles/src/index.ts
+++ b/packages/styles/src/index.ts
@@ -1,5 +1,5 @@
 import { type Accessor, onCleanup } from "solid-js";
-import { isServer } from "solid-js/web";
+import { isServer } from "@solidjs/web";
 import { createHydratableSingletonRoot } from "@solid-primitives/rootless";
 import { createHydratableSignal, noop } from "@solid-primitives/utils";
 

--- a/packages/styles/test/index.test.ts
+++ b/packages/styles/test/index.test.ts
@@ -1,5 +1,105 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
+import { createRoot, flush } from "solid-js";
+import { getRemSize, createRemSize, useRemSize } from "../src/index.js";
 
-describe("styles", () => {
-  it.todo("write tests");
+// Controllable ResizeObserver mock
+let triggerResize: () => void = () => {};
+let disconnected = false;
+
+class MockResizeObserver {
+  private cb: ResizeObserverCallback;
+  constructor(cb: ResizeObserverCallback) {
+    this.cb = cb;
+  }
+  observe() {
+    triggerResize = () => this.cb([], this as unknown as ResizeObserver);
+  }
+  unobserve() {}
+  disconnect() {
+    disconnected = true;
+    triggerResize = () => {};
+  }
+}
+global.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver;
+
+// Controllable font-size for getComputedStyle
+let mockFontSize = 16;
+const origGetComputedStyle = window.getComputedStyle.bind(window);
+window.getComputedStyle = (el: Element, pseudoElt?: string | null) => {
+  if (el === document.documentElement) {
+    return { fontSize: `${mockFontSize}px` } as CSSStyleDeclaration;
+  }
+  return origGetComputedStyle(el, pseudoElt ?? undefined);
+};
+
+beforeEach(() => {
+  mockFontSize = 16;
+  disconnected = false;
+  triggerResize = () => {};
+});
+
+describe("getRemSize", () => {
+  it("returns the current rem size", () => {
+    expect(getRemSize()).toBe(16);
+  });
+
+  it("reflects changes to the root font size", () => {
+    mockFontSize = 20;
+    expect(getRemSize()).toBe(20);
+  });
+});
+
+describe("createRemSize", () => {
+  it("returns an accessor with the initial rem size", () => {
+    const [remSize, dispose] = createRoot(dispose => [createRemSize(), dispose] as const);
+    expect(remSize()).toBe(16);
+    dispose();
+  });
+
+  it("updates the signal after ResizeObserver fires", () => {
+    // Return signal + dispose outside createRoot so triggerResize() is called
+    // outside any owned scope, matching how the browser fires it asynchronously.
+    const [remSize, dispose] = createRoot(dispose => [createRemSize(), dispose] as const);
+
+    expect(remSize()).toBe(16);
+
+    // First ResizeObserver fire is skipped (init guard)
+    triggerResize();
+    flush();
+    expect(remSize()).toBe(16);
+
+    // Subsequent fires update the signal
+    mockFontSize = 20;
+    triggerResize();
+    flush();
+    expect(remSize()).toBe(20);
+
+    dispose();
+  });
+
+  it("disconnects the ResizeObserver on cleanup", () => {
+    disconnected = false;
+    // Immediately dispose the inner root to trigger onCleanup
+    createRoot(innerDispose => {
+      createRemSize();
+      return innerDispose;
+    })();
+    expect(disconnected).toBe(true);
+  });
+});
+
+describe("useRemSize", () => {
+  it("returns an accessor with the current rem size", () => {
+    const [remSize, dispose] = createRoot(dispose => [useRemSize(), dispose] as const);
+    expect(typeof remSize()).toBe("number");
+    dispose();
+  });
+
+  it("returns the same signal for multiple callers", () => {
+    const [a, b, dispose] = createRoot(
+      dispose => [useRemSize(), useRemSize(), dispose] as const,
+    );
+    expect(a).toBe(b);
+    dispose();
+  });
 });

--- a/packages/styles/test/server.test.ts
+++ b/packages/styles/test/server.test.ts
@@ -1,5 +1,46 @@
-import { describe, it } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
+import { getRemSize, createRemSize, useRemSize, setServerRemSize } from "../src/index.js";
 
-describe("styles", () => {
-  it.todo("write tests");
+afterEach(() => {
+  // Reset server rem size to default between tests
+  setServerRemSize(16);
+});
+
+describe("getRemSize (server)", () => {
+  it("returns 16 by default", () => {
+    expect(getRemSize()).toBe(16);
+  });
+
+  it("reflects the value set by setServerRemSize", () => {
+    setServerRemSize(10);
+    expect(getRemSize()).toBe(10);
+  });
+});
+
+describe("createRemSize (server)", () => {
+  it("returns an accessor with the server rem size", () => {
+    const remSize = createRemSize();
+    expect(remSize()).toBe(16);
+  });
+
+  it("reflects setServerRemSize", () => {
+    setServerRemSize(12);
+    const remSize = createRemSize();
+    expect(remSize()).toBe(12);
+  });
+});
+
+describe("useRemSize (server)", () => {
+  it("returns an accessor with the server rem size", () => {
+    const remSize = useRemSize();
+    expect(remSize()).toBe(16);
+  });
+});
+
+describe("setServerRemSize", () => {
+  it("is a no-op in the browser environment (runs only on server)", () => {
+    // In SSR mode, setServerRemSize is the real setter
+    setServerRemSize(24);
+    expect(getRemSize()).toBe(24);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -932,9 +932,12 @@ importers:
         specifier: workspace:^
         version: link:../utils
     devDependencies:
+      '@solidjs/web':
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
 
   packages/timer:
     devDependencies:
@@ -2366,36 +2369,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.3.0':
     resolution: {integrity: sha512-ejBAX8H0ZGsD8lSICDNyMbSEtPMWgDL0WFCt/0z7hyf5v8Imz4rAM8xY379mBsECkq/Wdqa5WEDLqtjZ+6NxfA==}
@@ -2506,36 +2515,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -2672,56 +2687,67 @@ packages:
     resolution: {integrity: sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.43.0':
     resolution: {integrity: sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.43.0':
     resolution: {integrity: sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.43.0':
     resolution: {integrity: sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.43.0':
     resolution: {integrity: sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.43.0':
     resolution: {integrity: sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.43.0':
     resolution: {integrity: sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.43.0':
     resolution: {integrity: sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.43.0':
     resolution: {integrity: sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.43.0':
     resolution: {integrity: sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.43.0':
     resolution: {integrity: sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.43.0':
     resolution: {integrity: sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==}
@@ -5208,24 +5234,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
Upgrades `@solid-primitives/styles` to Solid 2.0 beta.10. The only source change is moving `isServer` from `solid-js/web` to `@solidjs/web`. Also replaces the stub test suite with a full set of browser and SSR tests covering `getRemSize`, `createRemSize`, `useRemSize`, and `setServerRemSize`.

**Breaking change**: peer dependencies are now `solid-js@^2.0.0-beta.10` and `@solidjs/web@^2.0.0-beta.10`. Consumers must also note that signal writes from browser callbacks (e.g. ResizeObserver) are microtask-batched in Solid 2 — reads remain synchronous but effects are deferred until the next microtask or `flush()`.