### PR TITLE
upgrade: presence package upgrade for Solid 2.0

### DIFF
--- a/.changeset/presence-solid2-migration.md
+++ b/.changeset/presence-solid2-migration.md
@@ -1,0 +1,15 @@
+---
+"@solid-primitives/presence": major
+---
+
+Migrate to Solid.js v2.0 (beta.10)
+
+## Breaking Changes
+
+**Peer dependency**: `solid-js@^2.0.0-beta.10` is now required.
+
+### `@solid-primitives/presence`
+
+- `createEffect` calls converted to the split compute/apply pattern required by Solid 2.0; cleanup is returned from the apply phase instead of calling `onCleanup`
+- Internal signals now use `{ ownedWrite: true }` to allow writes from the effect apply phases
+- No changes to the public `createPresence` API or `PresenceResult` type

--- a/packages/presence/package.json
+++ b/packages/presence/package.json
@@ -50,10 +50,10 @@
     "@solid-primitives/utils": "workspace:^"
   },
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "solid-js": "^2.0.0-beta.10"
   },
   "typesVersions": {},
   "devDependencies": {
-    "solid-js": "^1.9.7"
+    "solid-js": "^2.0.0-beta.10"
   }
 }

--- a/packages/presence/src/index.ts
+++ b/packages/presence/src/index.ts
@@ -6,15 +6,8 @@ See https://github.com/amannn/react-hooks/tree/main/packages/use-presence
 
 */
 
-import {
-  createSignal,
-  createEffect,
-  onCleanup,
-  type Accessor,
-  createMemo,
-  untrack,
-} from "solid-js";
-import { type MaybeAccessor, asAccessor } from "@solid-primitives/utils";
+import { createSignal, createEffect, type Accessor, createMemo, untrack } from "solid-js";
+import { type MaybeAccessor, asAccessor, INTERNAL_OPTIONS } from "@solid-primitives/utils";
 
 export type SharedTransitionConfig = {
   /** Duration in milliseconds used both for enter and exit transitions. */
@@ -56,53 +49,50 @@ function createPresenceBase(
 
   const initialSource = untrack(source);
   const initialState = options.initialEnter ? false : initialSource;
-  const [isVisible, setIsVisible] = createSignal(initialState);
-  const [isMounted, setIsMounted] = createSignal(initialSource);
-  const [hasEntered, setHasEntered] = createSignal(initialState);
+  const [isVisible, setIsVisible] = createSignal(initialState, INTERNAL_OPTIONS);
+  const [isMounted, setIsMounted] = createSignal(initialSource, INTERNAL_OPTIONS);
+  const [hasEntered, setHasEntered] = createSignal(initialState, INTERNAL_OPTIONS);
 
   const isExiting = createMemo(() => isMounted() && !source());
   const isEntering = createMemo(() => source() && !hasEntered());
   const isAnimating = createMemo(() => isEntering() || isExiting());
 
-  createEffect(() => {
-    if (source()) {
-      // `animateVisible` needs to be set to `true` in a second step, as
-      // when both flags would be flipped at the same time, there would
-      // be no transition. See the second effect below.
-      setIsMounted(true);
-    } else {
-      setHasEntered(false);
-      setIsVisible(false);
+  createEffect(
+    () => source(),
+    isActive => {
+      if (isActive) {
+        setIsMounted(true);
+      } else {
+        setHasEntered(false);
+        setIsVisible(false);
+        const timeoutId = setTimeout(() => setIsMounted(false), exitDuration());
+        return () => clearTimeout(timeoutId);
+      }
+    },
+  );
 
-      const timeoutId = setTimeout(() => {
-        setIsMounted(false);
-      }, exitDuration());
+  createEffect(
+    () => source() && isMounted() && !isVisible(),
+    shouldAnimate => {
+      if (shouldAnimate) {
+        // Force reflow so the initial invisible state is painted before
+        // isVisible becomes true, enabling CSS transitions to fire.
+        document.body.offsetHeight;
+        const animationFrameId = requestAnimationFrame(() => setIsVisible(true));
+        return () => cancelAnimationFrame(animationFrameId);
+      }
+    },
+  );
 
-      onCleanup(() => clearTimeout(timeoutId));
-    }
-  });
-
-  createEffect(() => {
-    if (source() && isMounted() && !isVisible()) {
-      document.body.offsetHeight; // force reflow
-
-      const animationFrameId = requestAnimationFrame(() => {
-        setIsVisible(true);
-      });
-
-      onCleanup(() => cancelAnimationFrame(animationFrameId));
-    }
-  });
-
-  createEffect(() => {
-    if (isVisible() && !hasEntered()) {
-      const timeoutId = setTimeout(() => {
-        setHasEntered(true);
-      }, enterDuration());
-
-      onCleanup(() => clearTimeout(timeoutId));
-    }
-  });
+  createEffect(
+    () => isVisible() && !hasEntered(),
+    shouldTrackEnter => {
+      if (shouldTrackEnter) {
+        const timeoutId = setTimeout(() => setHasEntered(true), enterDuration());
+        return () => clearTimeout(timeoutId);
+      }
+    },
+  );
 
   return {
     isMounted,
@@ -154,24 +144,33 @@ export function createPresence<TItem>(
   options: Options,
 ): PresenceResult<TItem> {
   const initial = untrack(item);
-  const [mountedItem, setMountedItem] = createSignal(initial);
-  const [shouldBeMounted, setShouldBeMounted] = createSignal(itemShouldBeMounted(initial));
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [mountedItem, setMountedItem] = createSignal<TItem | undefined>(initial as any, INTERNAL_OPTIONS);
+  const [shouldBeMounted, setShouldBeMounted] = createSignal(itemShouldBeMounted(initial), INTERNAL_OPTIONS);
   const { isMounted, ...rest } = createPresenceBase(shouldBeMounted, options);
 
-  createEffect(() => {
-    if (mountedItem() !== item()) {
-      if (isMounted()) {
+  createEffect(
+    () => ({
+      currentItem: item(),
+      mounted: mountedItem(),
+      isM: isMounted(),
+    }),
+    ({ currentItem, mounted, isM }) => {
+      if (mounted !== currentItem) {
+        if (isM) {
+          setShouldBeMounted(false);
+        } else if (itemShouldBeMounted(currentItem)) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          setMountedItem(currentItem as any);
+          setShouldBeMounted(true);
+        }
+      } else if (!itemShouldBeMounted(currentItem)) {
         setShouldBeMounted(false);
-      } else if (itemShouldBeMounted(item())) {
-        setMountedItem(() => item());
+      } else if (itemShouldBeMounted(currentItem)) {
         setShouldBeMounted(true);
       }
-    } else if (!itemShouldBeMounted(item())) {
-      setShouldBeMounted(false);
-    } else if (itemShouldBeMounted(item())) {
-      setShouldBeMounted(true);
-    }
-  });
+    },
+  );
 
   return {
     ...rest,

--- a/packages/presence/test/createPresence.test.ts
+++ b/packages/presence/test/createPresence.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterAll, beforeAll } from "vitest";
-import { createRoot, createSignal } from "solid-js";
+import { type Accessor, createRoot, createSignal, flush } from "solid-js";
 import { createPresence } from "../src/index.js";
 
 beforeAll(() => {
@@ -74,64 +74,71 @@ describe("createPresence", () => {
       dispose();
     }));
 
-  it("is in a mounted & animating state for the transitionDuration and then it is only in a mounted state", () =>
-    createRoot(async dispose => {
-      const [shouldRender, setShouldRender] = createSignal(false);
-      const transitionDuration = 50;
-      const { isMounted, isAnimating } = createPresence(shouldRender, {
-        transitionDuration,
-      });
-      expect(isMounted()).toBe(false);
-      expect(isAnimating()).toBe(false);
-      setShouldRender(true);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(isMounted()).toBe(true);
-      expect(isAnimating()).toBe(true);
-      await vi.advanceTimersByTimeAsync(transitionDuration + transitionTimeOffset);
-      expect(isMounted()).toBe(true);
-      expect(isAnimating()).toBe(false);
-      setShouldRender(false);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(isMounted()).toBe(true);
-      expect(isAnimating()).toBe(true);
-      await vi.advanceTimersByTimeAsync(transitionDuration + transitionTimeOffset);
-      expect(isMounted()).toBe(false);
-      expect(isAnimating()).toBe(false);
-      dispose();
-    }));
+  it("is in a mounted & animating state for the transitionDuration and then it is only in a mounted state", async () => {
+    const [shouldRender, setShouldRender] = createSignal(false);
+    const transitionDuration = 50;
 
-  it("swaps between a mounted & unmounted state based on unique enter & exit transition states", () =>
-    createRoot(async dispose => {
-      const [shouldRender, setShouldRender] = createSignal(false);
-      // using longer durations to ensure that the transitionTimeOffset
-      // is doesn't play into the test timings
-      const enterDuration = 300;
-      const exitDuration = 150;
-      const { isMounted, isAnimating } = createPresence(shouldRender, {
-        enterDuration,
-        exitDuration,
-      });
-      expect(isMounted()).toBe(false);
-      expect(isAnimating()).toBe(false);
-      setShouldRender(true);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(isMounted()).toBe(true);
-      expect(isAnimating()).toBe(true);
-      // ensure that we're not done animating after the shorter time
-      await vi.advanceTimersByTimeAsync(exitDuration + transitionTimeOffset);
-      expect(isAnimating()).toBe(true);
-      await vi.advanceTimersByTimeAsync(exitDuration + transitionTimeOffset);
-      expect(isMounted()).toBe(true);
-      expect(isAnimating()).toBe(false);
-      setShouldRender(false);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(isMounted()).toBe(true);
-      expect(isAnimating()).toBe(true);
-      await vi.advanceTimersByTimeAsync(exitDuration + transitionTimeOffset);
-      expect(isMounted()).toBe(false);
-      expect(isAnimating()).toBe(false);
-      dispose();
-    }));
+    let isMounted!: Accessor<boolean>;
+    let isAnimating!: Accessor<boolean>;
+    const dispose = createRoot(d => {
+      ({ isMounted, isAnimating } = createPresence(shouldRender, { transitionDuration }));
+      return d;
+    });
+
+    expect(isMounted()).toBe(false);
+    expect(isAnimating()).toBe(false);
+    setShouldRender(true);
+    flush();
+    expect(isMounted()).toBe(true);
+    expect(isAnimating()).toBe(true);
+    await vi.advanceTimersByTimeAsync(transitionDuration + transitionTimeOffset);
+    expect(isMounted()).toBe(true);
+    expect(isAnimating()).toBe(false);
+    setShouldRender(false);
+    flush();
+    expect(isMounted()).toBe(true);
+    expect(isAnimating()).toBe(true);
+    await vi.advanceTimersByTimeAsync(transitionDuration + transitionTimeOffset);
+    expect(isMounted()).toBe(false);
+    expect(isAnimating()).toBe(false);
+    dispose();
+  });
+
+  it("swaps between a mounted & unmounted state based on unique enter & exit transition states", async () => {
+    const [shouldRender, setShouldRender] = createSignal(false);
+    // using longer durations to ensure that the transitionTimeOffset
+    // doesn't play into the test timings
+    const enterDuration = 300;
+    const exitDuration = 150;
+
+    let isMounted!: Accessor<boolean>;
+    let isAnimating!: Accessor<boolean>;
+    const dispose = createRoot(d => {
+      ({ isMounted, isAnimating } = createPresence(shouldRender, { enterDuration, exitDuration }));
+      return d;
+    });
+
+    expect(isMounted()).toBe(false);
+    expect(isAnimating()).toBe(false);
+    setShouldRender(true);
+    flush();
+    expect(isMounted()).toBe(true);
+    expect(isAnimating()).toBe(true);
+    // ensure that we're not done animating after the shorter time
+    await vi.advanceTimersByTimeAsync(exitDuration + transitionTimeOffset);
+    expect(isAnimating()).toBe(true);
+    await vi.advanceTimersByTimeAsync(exitDuration + transitionTimeOffset);
+    expect(isMounted()).toBe(true);
+    expect(isAnimating()).toBe(false);
+    setShouldRender(false);
+    flush();
+    expect(isMounted()).toBe(true);
+    expect(isAnimating()).toBe(true);
+    await vi.advanceTimersByTimeAsync(exitDuration + transitionTimeOffset);
+    expect(isMounted()).toBe(false);
+    expect(isAnimating()).toBe(false);
+    dispose();
+  });
 
   // data switching tests
 
@@ -174,29 +181,37 @@ describe("createPresence", () => {
       dispose();
     }));
 
-  it("initially exchanges the data over the transition time", () =>
-    createRoot(async dispose => {
-      const [data, setData] = createSignal<Data>("foo");
-      const transitionDuration = 150;
-      const { mountedItem, isAnimating, isEntering, isExiting } = createPresence(data, {
+  it("initially exchanges the data over the transition time", async () => {
+    const [data, setData] = createSignal<Data>("foo");
+    const transitionDuration = 150;
+
+    let mountedItem!: Accessor<Data | undefined>;
+    let isAnimating!: Accessor<boolean>;
+    let isEntering!: Accessor<boolean>;
+    let isExiting!: Accessor<boolean>;
+    const dispose = createRoot(d => {
+      ({ mountedItem, isAnimating, isEntering, isExiting } = createPresence(data, {
         transitionDuration,
-      });
-      expect(isAnimating()).toBe(false);
-      setData("bar");
-      await vi.advanceTimersByTimeAsync(0);
-      expect(isAnimating()).toBe(true);
-      expect(mountedItem()).toBe("foo");
-      expect(isExiting()).toBe(true);
-      expect(isEntering()).toBe(false);
-      await vi.advanceTimersByTimeAsync(transitionDuration + transitionTimeOffset);
-      expect(isAnimating()).toBe(true);
-      expect(mountedItem()).toBe("bar");
-      expect(isEntering()).toBe(true);
-      expect(isExiting()).toBe(false);
-      await vi.advanceTimersByTimeAsync(transitionDuration + transitionTimeOffset);
-      expect(isAnimating()).toBe(false);
-      expect(isEntering()).toBe(false);
-      expect(isExiting()).toBe(false);
-      dispose();
-    }));
+      }));
+      return d;
+    });
+
+    expect(isAnimating()).toBe(false);
+    setData("bar");
+    flush();
+    expect(isAnimating()).toBe(true);
+    expect(mountedItem()).toBe("foo");
+    expect(isExiting()).toBe(true);
+    expect(isEntering()).toBe(false);
+    await vi.advanceTimersByTimeAsync(transitionDuration + transitionTimeOffset);
+    expect(isAnimating()).toBe(true);
+    expect(mountedItem()).toBe("bar");
+    expect(isEntering()).toBe(true);
+    expect(isExiting()).toBe(false);
+    await vi.advanceTimersByTimeAsync(transitionDuration + transitionTimeOffset);
+    expect(isAnimating()).toBe(false);
+    expect(isEntering()).toBe(false);
+    expect(isExiting()).toBe(false);
+    dispose();
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,8 +702,8 @@ importers:
         version: link:../utils
     devDependencies:
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
+        specifier: ^2.0.0-beta.10
+        version: 2.0.0-beta.10
 
   packages/promise:
     dependencies:
@@ -2366,36 +2366,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.3.0':
     resolution: {integrity: sha512-ejBAX8H0ZGsD8lSICDNyMbSEtPMWgDL0WFCt/0z7hyf5v8Imz4rAM8xY379mBsECkq/Wdqa5WEDLqtjZ+6NxfA==}
@@ -2506,36 +2512,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -2672,56 +2684,67 @@ packages:
     resolution: {integrity: sha512-gTJ/JnnjCMc15uwB10TTATBEhK9meBIY+gXP4s0sHD1zHOaIh4Dmy1X9wup18IiY9tTNk5gJc4yx9ctj/fjrIw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.43.0':
     resolution: {integrity: sha512-ZJ3gZynL1LDSIvRfz0qXtTNs56n5DI2Mq+WACWZ7yGHFUEirHBRt7fyIk0NsCKhmRhn7WAcjgSkSVVxKlPNFFw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.43.0':
     resolution: {integrity: sha512-8FnkipasmOOSSlfucGYEu58U8cxEdhziKjPD2FIa0ONVMxvl/hmONtX/7y4vGjdUhjcTHlKlDhw3H9t98fPvyA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.43.0':
     resolution: {integrity: sha512-KPPyAdlcIZ6S9C3S2cndXDkV0Bb1OSMsX0Eelr2Bay4EsF9yi9u9uzc9RniK3mcUGCLhWY9oLr6er80P5DE6XA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.43.0':
     resolution: {integrity: sha512-HPGDIH0/ZzAZjvtlXj6g+KDQ9ZMHfSP553za7o2Odegb/BEfwJcR0Sw0RLNpQ9nC6Gy8s+3mSS9xjZ0n3rhcYg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.43.0':
     resolution: {integrity: sha512-gEmwbOws4U4GLAJDhhtSPWPXUzDfMRedT3hFMyRAvM9Mrnj+dJIFIeL7otsv2WF3D7GrV0GIewW0y28dOYWkmw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.43.0':
     resolution: {integrity: sha512-XXKvo2e+wFtXZF/9xoWohHg+MuRnvO29TI5Hqe9xwN5uN8NKUYy7tXUG3EZAlfchufNCTHNGjEx7uN78KsBo0g==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.43.0':
     resolution: {integrity: sha512-ruf3hPWhjw6uDFsOAzmbNIvlXFXlBQ4nk57Sec8E8rUxs/AI4HD6xmiiasOOx/3QxS2f5eQMKTAwk7KHwpzr/Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.43.0':
     resolution: {integrity: sha512-QmNIAqDiEMEvFV15rsSnjoSmO0+eJLoKRD9EAa9rrYNwO/XRCtOGM3A5A0X+wmG+XRrw9Fxdsw+LnyYiZWWcVw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.43.0':
     resolution: {integrity: sha512-jAHr/S0iiBtFyzjhOkAics/2SrXE092qyqEg96e90L3t9Op8OTzS6+IX0Fy5wCt2+KqeHAkti+eitV0wvblEoQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.43.0':
     resolution: {integrity: sha512-3yATWgdeXyuHtBhrLt98w+5fKurdqvs8B53LaoKD7P7H7FKOONLsBVMNl9ghPQZQuYcceV5CDyPfyfGpMWD9mQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.43.0':
     resolution: {integrity: sha512-wVzXp2qDSCOpcBCT5WRWLmpJRIzv23valvcTwMHEobkjippNf+C3ys/+wf07poPkeNix0paTNemB2XrHr2TnGw==}
@@ -5208,24 +5231,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
Breaking change**: peer dependency now requires `solid-js@^2.0.0-beta.10`.

**Implementation changes** (internals only — public API is unchanged):
- `createEffect` converted to the required split compute/apply form; cleanup returned from apply instead of `onCleanup`
- Internal signals use `{ ownedWrite: true }` to permit writes from effect apply phases
- Tests restructured so signal writes happen outside `createRoot` (Solid 2.0 treats `createRoot` as an owned scope)