### PR TITLE
upgrade: input-mask package upgrade for Solid 2.0

### DIFF
--- a/.changeset/input-mask-solid2-migration.md
+++ b/.changeset/input-mask-solid2-migration.md
@@ -1,0 +1,16 @@
+---
+"@solid-primitives/input-mask": major
+---
+
+Migrate to Solid.js v2.0 (beta.10)
+
+## Breaking Changes
+
+**Peer dependency**: `solid-js@^2.0.0-beta.10` is now required.
+
+- The `solid-js/web` sub-path no longer exists in Solid 2.0; consumers using `render` must import it from `@solidjs/web`
+
+## Fixes
+
+- Corrected `maskArrayToFn` export name in README examples (was incorrectly documented as `arrayMaskToFn`)
+- Fixed optional-letter mask character documentation: `o` (was incorrectly documented as `z`)

--- a/packages/input-mask/README.md
+++ b/packages/input-mask/README.md
@@ -26,7 +26,7 @@ For convenience reasons, the handler returns the current value, which allows you
 import {
   stringMaskToArray,
   regexMaskToFn,
-  arrayMaskToFn,
+  maskArrayToFn,
   anyMaskToFn,
   createInputMask,
   stringMaskRegExp,
@@ -35,7 +35,7 @@ import {
 // 9 = any number,
 // 0 = any number (optional),
 // a = any letter,
-// z = any letter (optional),
+// o = any letter (optional),
 // * = any alphanumeric character,
 // ? = any alphanumeric character (optional)
 // any other letter becomes a fixed placeholder
@@ -45,7 +45,7 @@ import {
 stringMaskRegExp.u = /[A-Z]/;
 const isodate = "9999-99-99";
 // array mask: RegExp to match variable parts, strings for fixed placeholders
-const meetingId = [/\d/, /\d/, /\d/, "-", /\d/, /\d/, /\d/, "-", /\d/, /\d/, /\d/]);
+const meetingId = [/\d/, /\d/, /\d/, "-", /\d/, /\d/, /\d/, "-", /\d/, /\d/, /\d/];
 // regex replacer mask: a RegExp to match parts and a function to replace them
 // with the output of a function:
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_function_as_the_replacement
@@ -63,7 +63,7 @@ const meetingIdOrName = (value, selection) =>
 // converting string mask to array:
 const maskArrayFromString = stringMaskToArray(maskString);
 // converting other formats to function:
-const maskFuncFromArray = arrayMaskToFn(maskArray);
+const maskFuncFromArray = maskArrayToFn(maskArray);
 const maskFuncFromRegexReplacer = regexMaskToFn(regexMask, replacerFn);
 const maskFuncFromAny = anyMaskToFn(mask);
 

--- a/packages/input-mask/package.json
+++ b/packages/input-mask/package.json
@@ -48,16 +48,11 @@
     "solid",
     "primitives"
   ],
-  "peerDependenciesMeta": {
-    "solid-js": {
-      "optional": true
-    }
-  },
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "solid-js": "^2.0.0-beta.10"
   },
   "typesVersions": {},
   "devDependencies": {
-    "solid-js": "^1.9.7"
+    "solid-js": "2.0.0-beta.10"
   }
 }

--- a/packages/input-mask/test/index.test.tsx
+++ b/packages/input-mask/test/index.test.tsx
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import { render } from "solid-js/web";
 import { createInputMask, createMaskPattern } from "../src/index.js";
 
 const dispatchInputEvent = (node: HTMLElement) => {
@@ -8,11 +7,11 @@ const dispatchInputEvent = (node: HTMLElement) => {
 
 describe("createInputMask", () => {
   it("adds placeholder (e.g. to an iso date)", () => {
-    let input!: HTMLInputElement;
-    let dispose = render(
-      () => <input ref={input} onInput={createInputMask("9999-99-99")} />,
-      document.body,
-    );
+    const input = document.createElement("input");
+    const mask = createInputMask("9999-99-99");
+    input.addEventListener("input", mask as EventListener);
+    document.body.appendChild(input);
+
     input.value = "11111";
     dispatchInputEvent(input);
     expect(input.value).toBe("1111-1");
@@ -28,62 +27,55 @@ describe("createInputMask", () => {
     input.value = "1111-11-111";
     dispatchInputEvent(input);
     expect(input.value).toBe("1111-11-11");
-    dispose();
+
+    input.remove();
   });
 
   it("removes wrongful input (e.g. from iso-date)", () => {
-    let input!: HTMLInputElement;
-    let dispose = render(
-      () => <input ref={input} onInput={createInputMask("9999-99-99")} />,
-      document.body,
-    );
+    const input = document.createElement("input");
+    const mask = createInputMask("9999-99-99");
+    input.addEventListener("input", mask as EventListener);
+    document.body.appendChild(input);
+
     input.value = "a";
     dispatchInputEvent(input);
     expect(input.value).toBe("");
     input.value = "-";
     dispatchInputEvent(input);
     expect(input.value).toBe("");
-    dispose();
+
+    input.remove();
   });
 
   it("works with regex mask", () => {
-    let input!: HTMLInputElement;
-    let dispose = render(
-      () => (
-        <input
-          ref={input}
-          onInput={createInputMask([
-            /[^0-9a-zäöüß\-_/]|^(https?:\/\/|)(meet\.goto\.com|gotomeet\.me|)\/?/gi,
-            () => "",
-          ])}
-        />
-      ),
-      document.body,
-    );
+    const input = document.createElement("input");
+    const mask = createInputMask([
+      /[^0-9a-zäöüß\-_/]|^(https?:\/\/|)(meet\.goto\.com|gotomeet\.me|)\/?/gi,
+      () => "",
+    ]);
+    input.addEventListener("input", mask as EventListener);
+    document.body.appendChild(input);
+
     input.value = "https://meet.goto.com/test";
     dispatchInputEvent(input);
     expect(input.value).toBe("test");
-    dispose();
+
+    input.remove();
   });
 });
 
 describe("createMaskPattern", () => {
   it("adds data-mask-value and data-mask-pattern to the previous element", () => {
-    let input!: HTMLInputElement;
-    let label!: HTMLLabelElement;
-    let dispose = render(
-      () => (
-        <div>
-          <label ref={label}></label>
-          <input
-            ref={input}
-            placeholder="YYYY-MM-DD"
-            onInput={createMaskPattern(createInputMask("9999-99-99"), () => "YYYY-MM-DD")}
-          />
-        </div>
-      ),
-      document.body,
-    );
+    const div = document.createElement("div");
+    const label = document.createElement("label");
+    const input = document.createElement("input");
+    input.placeholder = "YYYY-MM-DD";
+    const mask = createMaskPattern(createInputMask("9999-99-99"), () => "YYYY-MM-DD");
+    input.addEventListener("input", mask as EventListener);
+    div.appendChild(label);
+    div.appendChild(input);
+    document.body.appendChild(div);
+
     expect(label.hasAttribute("data-mask-value")).toBe(false);
     expect(label.hasAttribute("data-mask-pattern")).toBe(false);
     input.value = "1";
@@ -94,6 +86,7 @@ describe("createMaskPattern", () => {
     dispatchInputEvent(input);
     expect(label.getAttribute("data-mask-value")).toBe("2077-1");
     expect(label.getAttribute("data-mask-pattern")).toBe("M-DD");
-    dispose();
+
+    div.remove();
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,9 +137,6 @@ importers:
       '@solid-primitives/event-listener':
         specifier: workspace:^
         version: link:../event-listener
-      '@solid-primitives/static-store':
-        specifier: workspace:^
-        version: link:../static-store
       '@solid-primitives/utils':
         specifier: workspace:^
         version: link:../utils
@@ -461,8 +458,8 @@ importers:
   packages/input-mask:
     devDependencies:
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
+        specifier: 2.0.0-beta.10
+        version: 2.0.0-beta.10
 
   packages/intersection-observer:
     dependencies:


### PR DESCRIPTION
Migrates `@solid-primitives/input-mask` to Solid.js v2.0 (beta.10).

### Changes

- **`package.json`**: Updated peer dependency `solid-js: ^1.6.12` → `^2.0.0-beta.10`; removed the `peerDependenciesMeta` optional marker; pinned dev dependency to `2.0.0-beta.10`
- **`test/index.test.tsx`**: Rewrote from JSX + `render()` to plain DOM (`document.createElement`). In Solid 2.0, `solid-js/web` no longer exists as a sub-path; `render` moved to `@solidjs/web`. Since `createInputMask` is a pure event-handler factory with no Solid reactive API usage, the tests need no Solid renderer at all.
- **`README.md`**: Fixed three pre-existing documentation bugs:
  - Import example listed `arrayMaskToFn` (wrong); correct export is `maskArrayToFn`
  - Usage example also used `arrayMaskToFn`
  - Optional-letter mask character documented as `z`; correct character is `o`
  - Extra stray `)` in the `meetingId` array mask example

### Breaking changes for downstream consumers

- Requires `solid-js@^2.0.0-beta.10`
- If consuming code imported `render` (or any other symbol) from `solid-js/web` alongside this package, those imports must be updated to `@solidjs/web`

### Notes

No reactive API changes were needed. `createInputMask` and `createMaskPattern` are pure event-handler factories with no Solid lifecycle hooks, signals, or effects — the primitives themselves are unaffected by Solid 2.0's async reactivity model, directive removal, or other API changes.

---Now let me save a memory for the key discovery about JSX tests and the solid-js/web → @solidjs/web migration pattern.