### PR TITLE
new: controlled-signal package for Solid 2.0

### DIFF
--- a/packages/controlled-signal/CHANGELOG.md
+++ b/packages/controlled-signal/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @solid-primitives/controlled-signal
+
+## 0.0.100
+
+Initial release.

--- a/packages/controlled-signal/LICENSE
+++ b/packages/controlled-signal/LICENSE
@@ -1,0 +1,29 @@
+MIT License
+
+Copyright (c) 2022 David Di Biase and the SolidJS Community
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+Portions of this package are adapted from @kobaltedev/kobalte:
+https://github.com/kobaltedev/kobalte/tree/main/packages/core/src/primitives/create-controllable-signal
+
+Copyright (c) 2022 Kobalte Contributors
+MIT License

--- a/packages/controlled-signal/README.md
+++ b/packages/controlled-signal/README.md
@@ -1,0 +1,137 @@
+# @solid-primitives/controlled-signal
+
+[![size](https://img.shields.io/bundlephobia/minzip/@solid-primitives/controlled-signal?style=for-the-badge&label=size)](https://bundlephobia.com/package/@solid-primitives/controlled-signal)
+[![version](https://img.shields.io/npm/v/@solid-primitives/controlled-signal?style=for-the-badge)](https://www.npmjs.com/package/@solid-primitives/controlled-signal)
+[![stage](https://img.shields.io/endpoint?style=for-the-badge&url=https%3A%2F%2Fraw.githubusercontent.com%2Fsolidjs-community%2Fsolid-primitives%2Fmain%2Fassets%2Fbadges%2Fstage-0.json)](https://github.com/solidjs-community/solid-primitives#contribution-process)
+
+Reactive signals that support both **controlled** (externally managed) and **uncontrolled** (internally managed) state — a pattern commonly used in headless UI components such as dialogs, dropdowns, and toggles.
+
+## Installation
+
+```bash
+npm install @solid-primitives/controlled-signal
+# or
+pnpm add @solid-primitives/controlled-signal
+```
+
+## How it works
+
+A **controllable signal** has two modes:
+
+- **Uncontrolled** — when no `value` prop is provided (or it is `undefined`). The signal manages its own internal state, initialized from `defaultValue`.
+- **Controlled** — when a `value` prop is provided. The signal defers entirely to the external value; `setValue` calls `onChange` but does not update internal state.
+
+This mirrors the [controlled/uncontrolled pattern](https://react.dev/learn/sharing-state-between-components#controlled-and-uncontrolled-components) from React, adapted for SolidJS reactivity.
+
+## Primitives
+
+### `createControllableSignal`
+
+```ts
+import { createControllableSignal } from "@solid-primitives/controlled-signal";
+
+const [value, setValue] = createControllableSignal<T>(props);
+```
+
+**Props:**
+
+| Prop           | Type                       | Description                                      |
+| -------------- | -------------------------- | ------------------------------------------------ |
+| `value`        | `Accessor<T \| undefined>` | Controlled value. When defined, enables controlled mode. |
+| `defaultValue` | `Accessor<T \| undefined>` | Initial value for uncontrolled mode.             |
+| `onChange`     | `(value: T) => void`       | Called whenever the value would change.          |
+
+**Returns:** `[value: Accessor<T | undefined>, setValue: (next) => void]`
+
+#### Uncontrolled usage
+
+```ts
+const [open, setOpen] = createControllableSignal({ defaultValue: () => false });
+
+setOpen(true);         // updates internal state and calls onChange if provided
+setOpen(prev => !prev); // functional form
+```
+
+#### Controlled usage
+
+```ts
+// The consumer drives the state; your component just calls onChange.
+const [value, setValue] = createControllableSignal({
+  value: () => props.open,
+  onChange: props.onOpenChange,
+});
+
+// setValue does NOT update internal state in controlled mode.
+// It calls onChange so the consumer can update their signal.
+setValue(true);
+```
+
+---
+
+### `createControllableBooleanSignal`
+
+Variant of `createControllableSignal` for `boolean` values. Returns `false` instead of `undefined` when unset.
+
+```ts
+const [open, setOpen] = createControllableBooleanSignal({
+  defaultValue: () => false,
+});
+```
+
+---
+
+### `createControllableArraySignal`
+
+Variant for `Array<T>` values. Returns `[]` instead of `undefined` when unset.
+
+```ts
+const [items, setItems] = createControllableArraySignal<string>({
+  defaultValue: () => ["a", "b"],
+});
+
+setItems(prev => [...prev, "c"]);
+```
+
+---
+
+### `createControllableSetSignal`
+
+Variant for `Set<T>` values. Returns `new Set()` instead of `undefined` when unset.
+
+```ts
+const [selected, setSelected] = createControllableSetSignal<number>({
+  defaultValue: () => new Set([1, 2]),
+});
+
+setSelected(prev => new Set([...prev, 3]));
+```
+
+---
+
+## Building a headless component
+
+```tsx
+import { createControllableBooleanSignal } from "@solid-primitives/controlled-signal";
+
+function createToggle(props: {
+  pressed?: Accessor<boolean | undefined>;
+  defaultPressed?: Accessor<boolean | undefined>;
+  onChange?: (pressed: boolean) => void;
+}) {
+  const [pressed, setPressed] = createControllableBooleanSignal({
+    value: props.pressed,
+    defaultValue: props.defaultPressed,
+    onChange: props.onChange,
+  });
+
+  return { pressed, toggle: () => setPressed(p => !p) };
+}
+```
+
+## Credits
+
+This primitive is adapted from the [`create-controllable-signal`](https://github.com/kobaltedev/kobalte/tree/main/packages/core/src/primitives/create-controllable-signal) implementation in [Kobalte](https://github.com/kobaltedev/kobalte) by the Kobalte Contributors, used under the [MIT License](https://github.com/kobaltedev/kobalte/blob/main/LICENSE).
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md)

--- a/packages/controlled-signal/package.json
+++ b/packages/controlled-signal/package.json
@@ -1,0 +1,72 @@
+{
+  "name": "@solid-primitives/controlled-signal",
+  "version": "0.0.100",
+  "description": "Reactive signals that support both controlled (externally managed) and uncontrolled (internally managed) state — a pattern commonly used in headless UI components.",
+  "author": "David Di Biase <dave@solidjs.com>",
+  "contributors": [
+    "Kobalte Contributors <https://github.com/kobaltedev/kobalte>"
+  ],
+  "license": "MIT",
+  "homepage": "https://primitives.solidjs.community/package/controlled-signal",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solidjs-community/solid-primitives.git"
+  },
+  "bugs": {
+    "url": "https://github.com/solidjs-community/solid-primitives/issues"
+  },
+  "primitive": {
+    "name": "controlled-signal",
+    "stage": 0,
+    "list": [
+      "createControllableSignal",
+      "createControllableBooleanSignal",
+      "createControllableArraySignal",
+      "createControllableSetSignal"
+    ],
+    "category": "Reactivity"
+  },
+  "keywords": [
+    "solid",
+    "primitives",
+    "signal",
+    "controlled",
+    "controllable",
+    "uncontrolled",
+    "headless",
+    "ui"
+  ],
+  "private": false,
+  "sideEffects": false,
+  "files": [
+    "dist"
+  ],
+  "type": "module",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "browser": {},
+  "exports": {
+    "import": {
+      "@solid-primitives/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "typesVersions": {},
+  "scripts": {
+    "dev": "node --import=@nothing-but/node-resolve-ts --experimental-transform-types ../../scripts/dev.ts",
+    "build": "node --import=@nothing-but/node-resolve-ts --experimental-transform-types ../../scripts/build.ts",
+    "vitest": "vitest -c ../../configs/vitest.config.ts",
+    "test": "pnpm run vitest",
+    "test:ssr": "pnpm run vitest --mode ssr"
+  },
+  "dependencies": {
+    "@solid-primitives/utils": "workspace:^"
+  },
+  "peerDependencies": {
+    "solid-js": "^2.0.0-beta.12"
+  },
+  "devDependencies": {
+    "solid-js": "2.0.0-beta.12"
+  }
+}

--- a/packages/controlled-signal/src/index.ts
+++ b/packages/controlled-signal/src/index.ts
@@ -1,0 +1,91 @@
+/*
+ * Adapted from @kobaltedev/kobalte
+ * https://github.com/kobaltedev/kobalte/tree/main/packages/core/src/primitives/create-controllable-signal
+ * Copyright (c) 2022 Kobalte Contributors — MIT License
+ */
+
+import { type Accessor, createMemo, createSignal, untrack } from "solid-js";
+import { accessWith } from "@solid-primitives/utils";
+
+export interface CreateControllableSignalProps<T> {
+  /** The value to be used in controlled mode. */
+  value?: Accessor<T | undefined>;
+
+  /** The initial value to be used in uncontrolled mode. */
+  defaultValue?: Accessor<T | undefined>;
+
+  /** Called when the value changes. */
+  onChange?: (value: T) => void;
+}
+
+/**
+ * Creates a reactive signal that can operate in either controlled or uncontrolled mode.
+ *
+ * In **uncontrolled** mode (no `value` prop), the signal manages its own internal state
+ * starting from `defaultValue`. In **controlled** mode (`value` prop provided and not
+ * `undefined`), the signal defers to the external value and calls `onChange` instead of
+ * updating internal state.
+ *
+ * @see https://github.com/solidjs-community/solid-primitives/tree/main/packages/controlled-signal
+ */
+export function createControllableSignal<T>(props: CreateControllableSignalProps<T>) {
+  // Read defaultValue once, untracked, so it doesn't create a dependency during init.
+  // Cast: createSignal's overload requires Exclude<T, Function>; the caller is responsible
+  // for not passing function-typed T values as defaultValue (same assumption Kobalte makes).
+  // ownedWrite: true because setValue intentionally writes this from inside reactive scopes.
+  const [_value, _setValue] = createSignal<T | undefined>(
+    untrack(() => props.defaultValue?.()) as Exclude<T, Function> | undefined,
+    { ownedWrite: true },
+  );
+
+  const isControlled = createMemo(() => props.value?.() !== undefined);
+  const value = createMemo(() => (isControlled() ? props.value?.() : _value()));
+
+  const setValue = (next: Exclude<T, Function> | ((prev: T) => T)) => {
+    untrack(() => {
+      // Read raw signals — not the memo — to avoid deferred-memo staleness in Solid 2.0.
+      const controlled = props.value?.() !== undefined;
+      const current = (controlled ? props.value?.() : _value()) as T;
+      const nextValue = accessWith(next, current) as T;
+
+      if (!Object.is(nextValue, current)) {
+        if (!controlled) {
+          _setValue(nextValue as Exclude<T, Function>);
+        }
+        props.onChange?.(nextValue);
+      }
+    });
+  };
+
+  return [value, setValue] as const;
+}
+
+/**
+ * Variant of {@link createControllableSignal} for boolean values.
+ * Falls back to `false` when the value is `undefined`.
+ */
+export function createControllableBooleanSignal(props: CreateControllableSignalProps<boolean>) {
+  const [_value, setValue] = createControllableSignal(props);
+  const value: Accessor<boolean> = () => _value() ?? false;
+  return [value, setValue] as const;
+}
+
+/**
+ * Variant of {@link createControllableSignal} for array values.
+ * Falls back to `[]` when the value is `undefined`.
+ */
+export function createControllableArraySignal<T>(props: CreateControllableSignalProps<Array<T>>) {
+  const [_value, setValue] = createControllableSignal(props);
+  const value: Accessor<Array<T>> = () => _value() ?? [];
+  return [value, setValue] as const;
+}
+
+/**
+ * Variant of {@link createControllableSignal} for Set values.
+ * Falls back to `new Set()` when the value is `undefined`.
+ */
+export function createControllableSetSignal<T>(props: CreateControllableSignalProps<Set<T>>) {
+  const [_value, setValue] = createControllableSignal(props);
+  const value: Accessor<Set<T>> = () => _value() ?? new Set();
+  return [value, setValue] as const;
+}

--- a/packages/controlled-signal/test/index.test.ts
+++ b/packages/controlled-signal/test/index.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, vi } from "vitest";
+import { type Accessor, createRoot, createSignal, flush } from "solid-js";
+import {
+  createControllableSignal,
+  createControllableBooleanSignal,
+  createControllableArraySignal,
+  createControllableSetSignal,
+} from "../src/index.js";
+
+describe("createControllableSignal", () => {
+  describe("uncontrolled mode", () => {
+    it("initializes with undefined when no defaultValue given", () => {
+      createRoot(dispose => {
+        const [value] = createControllableSignal<string>({});
+        expect(value()).toBeUndefined();
+        dispose();
+      });
+    });
+
+    it("initializes with defaultValue", () => {
+      createRoot(dispose => {
+        const [value] = createControllableSignal({ defaultValue: () => "hello" });
+        expect(value()).toBe("hello");
+        dispose();
+      });
+    });
+
+    it("updates internal state on setValue", () => {
+      createRoot(dispose => {
+        const [value, setValue] = createControllableSignal({ defaultValue: () => "hello" });
+        setValue("world");
+        flush();
+        expect(value()).toBe("world");
+        dispose();
+      });
+    });
+
+    it("supports functional setter form", () => {
+      createRoot(dispose => {
+        const [value, setValue] = createControllableSignal({ defaultValue: () => 10 });
+        setValue(prev => prev + 5);
+        flush();
+        expect(value()).toBe(15);
+        dispose();
+      });
+    });
+
+    it("accumulates functional updates correctly", () => {
+      createRoot(dispose => {
+        const [value, setValue] = createControllableSignal({ defaultValue: () => 0 });
+        setValue(prev => prev + 1);
+        flush();
+        setValue(prev => prev + 1);
+        flush();
+        setValue(prev => prev + 1);
+        flush();
+        expect(value()).toBe(3);
+        dispose();
+      });
+    });
+
+    it("calls onChange on value change", () => {
+      createRoot(dispose => {
+        const onChange = vi.fn();
+        const [, setValue] = createControllableSignal({ defaultValue: () => 0, onChange });
+        setValue(42);
+        expect(onChange).toHaveBeenCalledOnce();
+        expect(onChange).toHaveBeenCalledWith(42);
+        dispose();
+      });
+    });
+
+    it("does not call onChange when value is unchanged (Object.is check)", () => {
+      createRoot(dispose => {
+        const onChange = vi.fn();
+        const [, setValue] = createControllableSignal({
+          defaultValue: () => "same",
+          onChange,
+        });
+        setValue("same");
+        expect(onChange).not.toHaveBeenCalled();
+        dispose();
+      });
+    });
+
+    it("correctly deduplicates NaN values via Object.is", () => {
+      createRoot(dispose => {
+        const onChange = vi.fn();
+        const [, setValue] = createControllableSignal({ defaultValue: () => NaN, onChange });
+        setValue(NaN);
+        expect(onChange).not.toHaveBeenCalled();
+        dispose();
+      });
+    });
+
+    it("treats -0 and +0 as different via Object.is", () => {
+      createRoot(dispose => {
+        const onChange = vi.fn();
+        const [, setValue] = createControllableSignal({ defaultValue: () => -0, onChange });
+        setValue(+0);
+        expect(onChange).toHaveBeenCalledOnce();
+        dispose();
+      });
+    });
+  });
+
+  describe("controlled mode", () => {
+    it("returns the externally controlled value", () => {
+      createRoot(dispose => {
+        const [external] = createSignal("controlled");
+        const [value] = createControllableSignal({ value: external });
+        flush();
+        expect(value()).toBe("controlled");
+        dispose();
+      });
+    });
+
+    it("calls onChange but does not update internal state", () => {
+      createRoot(dispose => {
+        const [external] = createSignal("controlled");
+        const onChange = vi.fn();
+        const [value, setValue] = createControllableSignal({ value: external, onChange });
+        flush();
+        setValue("new-value");
+        flush();
+        expect(value()).toBe("controlled");
+        expect(onChange).toHaveBeenCalledWith("new-value");
+        dispose();
+      });
+    });
+
+    it("reflects changes to the external signal", () => {
+      const [external, setExternal] = createSignal("initial");
+      let value!: Accessor<string | undefined>;
+      const dispose = createRoot(d => {
+        [value] = createControllableSignal({ value: external });
+        return d;
+      });
+      flush();
+      expect(value()).toBe("initial");
+      setExternal("updated");
+      flush();
+      expect(value()).toBe("updated");
+      dispose();
+    });
+
+    it("wires onChange back to external signal for full controlled loop", () => {
+      const [external, setExternal] = createSignal("initial");
+      let value!: Accessor<string | undefined>;
+      let setValue!: (next: string | ((prev: string) => string)) => void;
+      const dispose = createRoot(d => {
+        [value, setValue] = createControllableSignal({ value: external, onChange: setExternal });
+        return d;
+      });
+      flush();
+      setValue("updated");
+      flush();
+      expect(external()).toBe("updated");
+      expect(value()).toBe("updated");
+      dispose();
+    });
+
+    it("does not call onChange when controlled value is the same", () => {
+      createRoot(dispose => {
+        const [external] = createSignal("same");
+        const onChange = vi.fn();
+        const [, setValue] = createControllableSignal({ value: external, onChange });
+        flush();
+        setValue("same");
+        expect(onChange).not.toHaveBeenCalled();
+        dispose();
+      });
+    });
+
+    it("treats undefined controlled value as uncontrolled (falls back to defaultValue)", () => {
+      createRoot(dispose => {
+        const [value] = createControllableSignal({
+          value: () => undefined,
+          defaultValue: () => "default",
+        });
+        flush();
+        expect(value()).toBe("default");
+        dispose();
+      });
+    });
+
+    it("switches from controlled to uncontrolled when external value becomes undefined", () => {
+      const [external, setExternal] = createSignal<string | undefined>("controlled");
+      let value!: Accessor<string | undefined>;
+      let setValue!: (next: string | ((prev: string) => string)) => void;
+      const dispose = createRoot(d => {
+        [value, setValue] = createControllableSignal({
+          value: external,
+          defaultValue: () => "default",
+        });
+        return d;
+      });
+      flush();
+      expect(value()).toBe("controlled");
+      setExternal(undefined);
+      flush();
+      expect(value()).toBe("default");
+      // Now behaves as uncontrolled
+      setValue("internal");
+      flush();
+      expect(value()).toBe("internal");
+      dispose();
+    });
+  });
+});
+
+describe("createControllableBooleanSignal", () => {
+  it("defaults to false when no props given", () => {
+    createRoot(dispose => {
+      const [value] = createControllableBooleanSignal({});
+      expect(value()).toBe(false);
+      dispose();
+    });
+  });
+
+  it("uses defaultValue when provided", () => {
+    createRoot(dispose => {
+      const [value] = createControllableBooleanSignal({ defaultValue: () => true });
+      expect(value()).toBe(true);
+      dispose();
+    });
+  });
+
+  it("toggles correctly", () => {
+    createRoot(dispose => {
+      const [value, setValue] = createControllableBooleanSignal({ defaultValue: () => false });
+      setValue(prev => !prev);
+      flush();
+      expect(value()).toBe(true);
+      setValue(prev => !prev);
+      flush();
+      expect(value()).toBe(false);
+      dispose();
+    });
+  });
+
+  it("always returns boolean (never undefined)", () => {
+    createRoot(dispose => {
+      const [value] = createControllableBooleanSignal({});
+      expect(typeof value()).toBe("boolean");
+      dispose();
+    });
+  });
+});
+
+describe("createControllableArraySignal", () => {
+  it("defaults to empty array when no props given", () => {
+    createRoot(dispose => {
+      const [value] = createControllableArraySignal<string>({});
+      expect(value()).toEqual([]);
+      dispose();
+    });
+  });
+
+  it("uses defaultValue when provided", () => {
+    createRoot(dispose => {
+      const [value] = createControllableArraySignal({ defaultValue: () => [1, 2, 3] });
+      expect(value()).toEqual([1, 2, 3]);
+      dispose();
+    });
+  });
+
+  it("appends items via functional setter", () => {
+    createRoot(dispose => {
+      const [value, setValue] = createControllableArraySignal<number>({
+        defaultValue: () => [1],
+      });
+      setValue(prev => [...prev, 2]);
+      flush();
+      expect(value()).toEqual([1, 2]);
+      dispose();
+    });
+  });
+
+  it("always returns an array (never undefined)", () => {
+    createRoot(dispose => {
+      const [value] = createControllableArraySignal<string>({});
+      expect(Array.isArray(value())).toBe(true);
+      dispose();
+    });
+  });
+});
+
+describe("createControllableSetSignal", () => {
+  it("defaults to empty Set when no props given", () => {
+    createRoot(dispose => {
+      const [value] = createControllableSetSignal<string>({});
+      expect(value()).toEqual(new Set());
+      dispose();
+    });
+  });
+
+  it("uses defaultValue when provided", () => {
+    createRoot(dispose => {
+      const [value] = createControllableSetSignal({ defaultValue: () => new Set([1, 2, 3]) });
+      expect(value()).toEqual(new Set([1, 2, 3]));
+      dispose();
+    });
+  });
+
+  it("adds items via functional setter", () => {
+    createRoot(dispose => {
+      const [value, setValue] = createControllableSetSignal<number>({
+        defaultValue: () => new Set([1]),
+      });
+      setValue(prev => new Set([...prev, 2]));
+      flush();
+      expect(value()).toEqual(new Set([1, 2]));
+      dispose();
+    });
+  });
+
+  it("always returns a Set (never undefined)", () => {
+    createRoot(dispose => {
+      const [value] = createControllableSetSignal<string>({});
+      expect(value()).toBeInstanceOf(Set);
+      dispose();
+    });
+  });
+});

--- a/packages/controlled-signal/test/server.test.ts
+++ b/packages/controlled-signal/test/server.test.ts
@@ -1,0 +1,128 @@
+import { describe, test, expect } from "vitest";
+import {
+  createControllableSignal,
+  createControllableBooleanSignal,
+  createControllableArraySignal,
+  createControllableSetSignal,
+} from "../src/index.js";
+
+describe("createControllableSignal on server", () => {
+  test("returns undefined without defaultValue", () => {
+    const [value] = createControllableSignal<string>({});
+    expect(value()).toBeUndefined();
+  });
+
+  test("returns defaultValue in uncontrolled mode", () => {
+    const [value] = createControllableSignal({ defaultValue: () => "hello" });
+    expect(value()).toBe("hello");
+  });
+
+  test("returns controlled value", () => {
+    const [value] = createControllableSignal({ value: () => "world" });
+    expect(value()).toBe("world");
+  });
+
+  test("controlled value takes precedence over defaultValue", () => {
+    const [value] = createControllableSignal({
+      value: () => "controlled",
+      defaultValue: () => "default",
+    });
+    expect(value()).toBe("controlled");
+  });
+
+  test("undefined controlled value falls back to defaultValue", () => {
+    const [value] = createControllableSignal({
+      value: () => undefined,
+      defaultValue: () => "fallback",
+    });
+    expect(value()).toBe("fallback");
+  });
+
+  test("setValue calls onChange synchronously", () => {
+    let received: string | undefined;
+    const [, setValue] = createControllableSignal<string>({
+      defaultValue: () => "initial",
+      onChange: v => {
+        received = v;
+      },
+    });
+    setValue("changed");
+    expect(received).toBe("changed");
+  });
+
+  test("setValue does not call onChange when value is unchanged", () => {
+    let callCount = 0;
+    const [, setValue] = createControllableSignal<string>({
+      defaultValue: () => "same",
+      onChange: () => callCount++,
+    });
+    setValue("same");
+    expect(callCount).toBe(0);
+  });
+});
+
+describe("createControllableBooleanSignal on server", () => {
+  test("returns false with no props", () => {
+    const [value] = createControllableBooleanSignal({});
+    expect(value()).toBe(false);
+  });
+
+  test("returns defaultValue when provided", () => {
+    const [value] = createControllableBooleanSignal({ defaultValue: () => true });
+    expect(value()).toBe(true);
+  });
+
+  test("returns controlled value", () => {
+    const [value] = createControllableBooleanSignal({ value: () => true });
+    expect(value()).toBe(true);
+  });
+
+  test("always returns a boolean (never undefined)", () => {
+    const [value] = createControllableBooleanSignal({});
+    expect(typeof value()).toBe("boolean");
+  });
+});
+
+describe("createControllableArraySignal on server", () => {
+  test("returns empty array with no props", () => {
+    const [value] = createControllableArraySignal<string>({});
+    expect(value()).toEqual([]);
+  });
+
+  test("returns defaultValue when provided", () => {
+    const [value] = createControllableArraySignal({ defaultValue: () => ["a", "b"] });
+    expect(value()).toEqual(["a", "b"]);
+  });
+
+  test("returns controlled value", () => {
+    const [value] = createControllableArraySignal({ value: () => [1, 2, 3] });
+    expect(value()).toEqual([1, 2, 3]);
+  });
+
+  test("always returns an array (never undefined)", () => {
+    const [value] = createControllableArraySignal<string>({});
+    expect(Array.isArray(value())).toBe(true);
+  });
+});
+
+describe("createControllableSetSignal on server", () => {
+  test("returns empty Set with no props", () => {
+    const [value] = createControllableSetSignal<string>({});
+    expect(value()).toEqual(new Set());
+  });
+
+  test("returns defaultValue when provided", () => {
+    const [value] = createControllableSetSignal({ defaultValue: () => new Set(["a", "b"]) });
+    expect(value()).toEqual(new Set(["a", "b"]));
+  });
+
+  test("returns controlled value", () => {
+    const [value] = createControllableSetSignal({ value: () => new Set([1, 2]) });
+    expect(value()).toEqual(new Set([1, 2]));
+  });
+
+  test("always returns a Set (never undefined)", () => {
+    const [value] = createControllableSetSignal<string>({});
+    expect(value()).toBeInstanceOf(Set);
+  });
+});

--- a/packages/controlled-signal/tsconfig.json
+++ b/packages/controlled-signal/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "references": [
+    {
+      "path": "../utils"
+    }
+  ],
+  "include": [
+    "src"
+  ]
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -2,11 +2,8 @@ import {
   getOwner,
   onCleanup,
   createSignal,
-  createStore,
   type Accessor,
   untrack,
-  type AccessorArray,
-  type EffectFunction,
   type ComputeFunction,
   type NoInfer,
   type Setter,
@@ -15,10 +12,12 @@ import {
   type Store,
   type StoreSetter,
   sharedConfig,
-  onMount,
+  onSettled,
   DEV,
-  equalFn,
 } from "solid-js";
+
+// AccessorArray was removed in Solid 2.0 — define locally
+type AccessorArray<S> = Accessor<S>[];
 // isServer moved from solid-js/web (1.x) to @solidjs/web (2.x).
 // typeof window is a universal fallback compatible with both versions.
 const isServer = typeof window === "undefined";
@@ -47,11 +46,11 @@ export const noop = (() => void 0) as Noop;
 export const trueFn: () => boolean = () => true;
 export const falseFn: () => boolean = () => false;
 
-/** @deprecated use {@link equalFn} from "solid-js" */
-export const defaultEquals = equalFn;
+/** @deprecated use Object.is instead */
+export const defaultEquals: (a: unknown, b: unknown) => boolean = Object.is;
 
 export const EQUALS_FALSE_OPTIONS = { equals: false } as const satisfies SignalOptions<unknown>;
-export const INTERNAL_OPTIONS = { internal: true } as const satisfies SignalOptions<unknown>;
+export const INTERNAL_OPTIONS = { ownedWrite: true } as const satisfies SignalOptions<unknown>;
 
 /**
  * Check if the value is an instance of ___
@@ -266,7 +265,9 @@ export function createHydratableSignal<T>(
   }
   if (sharedConfig.hydrating) {
     const [state, setState] = createSignal(serverValue as Exclude<T, Function>, options);
-    onSettled(() => { setState(() => update()); });
+    onSettled(() => {
+      setState(() => update());
+    });
     return [state, setState];
   }
   return createSignal(update() as Exclude<T, Function>, options);
@@ -411,25 +412,43 @@ export function pipe<A, B>(a: (raw: string) => A, b: (a: A) => B): (raw: string)
  *
  * ```ts
  * const [data, setData] = wrapSetter(
- *   createSignal(initialData), 
+ *   createSignal(initialData),
  *   (setter) => (next) => { console.log(next); return setter(next); },
  * );
  * ```
  * If you destructure signal or store in a longer tuple, you need to use a const assertion for the types to work.
  */
-export function wrapSetter<T>(signal: Signal<T>, wrapper: (setter: Setter<T>) => Setter<T>): Signal<T>;
-export function wrapSetter<T>(store: [Store<T>, StoreSetter<T>], wrapper: (setter: StoreSetter<T>) => StoreSetter<T>): [Store<T>, StoreSetter<T>];
-export function wrapSetter<T, S extends Signal<T> | [Store<T>, StoreSetter<T>] | [...Signal<T>, ...any[]] | [Store<T>, StoreSetter<T>, ...any[]]>(
-  signalOrStore: S,
-  wrapper: (setter: S[1]) => S[1]
-): S;
-export function wrapSetter<T, S extends Signal<T> | [Store<T>, StoreSetter<T>] | readonly [...Signal<T>, ...any[]] | readonly [Store<T>, StoreSetter<T>, ...any[]]>(
-  signalOrStore: S,
-  wrapper: (setter: S[1]) => S[1]
-): S;
-export function wrapSetter<T, S extends Signal<T> | [Store<T>, StoreSetter<T>] | [...Signal<T>, ...any[]] | [Store<T>, StoreSetter<T>, ...any[]]>(
-  signalOrStore: S,
-  wrapper: (setter: S[1]) => S[1]
-): S {
+export function wrapSetter<T>(
+  signal: Signal<T>,
+  wrapper: (setter: Setter<T>) => Setter<T>,
+): Signal<T>;
+export function wrapSetter<T>(
+  store: [Store<T>, StoreSetter<T>],
+  wrapper: (setter: StoreSetter<T>) => StoreSetter<T>,
+): [Store<T>, StoreSetter<T>];
+export function wrapSetter<
+  T,
+  S extends
+    | Signal<T>
+    | [Store<T>, StoreSetter<T>]
+    | [...Signal<T>, ...any[]]
+    | [Store<T>, StoreSetter<T>, ...any[]],
+>(signalOrStore: S, wrapper: (setter: S[1]) => S[1]): S;
+export function wrapSetter<
+  T,
+  S extends
+    | Signal<T>
+    | [Store<T>, StoreSetter<T>]
+    | readonly [...Signal<T>, ...any[]]
+    | readonly [Store<T>, StoreSetter<T>, ...any[]],
+>(signalOrStore: S, wrapper: (setter: S[1]) => S[1]): S;
+export function wrapSetter<
+  T,
+  S extends
+    | Signal<T>
+    | [Store<T>, StoreSetter<T>]
+    | [...Signal<T>, ...any[]]
+    | [Store<T>, StoreSetter<T>, ...any[]],
+>(signalOrStore: S, wrapper: (setter: S[1]) => S[1]): S {
   return [signalOrStore[0], wrapper(signalOrStore[1]), ...signalOrStore.slice(2)] as S;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,16 @@ importers:
         specifier: ^1.9.7
         version: 1.9.7
 
+  packages/controlled-signal:
+    dependencies:
+      '@solid-primitives/utils':
+        specifier: workspace:^
+        version: link:../utils
+    devDependencies:
+      solid-js:
+        specifier: 2.0.0-beta.12
+        version: 2.0.0-beta.12
+
   packages/cookies:
     devDependencies:
       solid-js:


### PR DESCRIPTION
Summary

- Adds a new `@solid-primitives/controlled-signal` package porting Kobalte's `createControllableSignal` to Solid 2.0 Beta 12
- Fixes pre-existing Solid 2.0 compatibility gaps in `@solid-primitives/utils`
- Credits original Kobalte contributors in `package.json`, `LICENSE`, and `README`

### New package: `controlled-signal`

Implements the controlled/uncontrolled state pattern used by headless UI components — when an external `value` prop is provided, the primitive defers to it and fires `onChange`; otherwise it manages its own internal state from `defaultValue`.

**Exports:**
- `createControllableSignal<T>(props)` — base primitive
- `createControllableBooleanSignal(props)` — coerces `undefined` to `false`
- `createControllableArraySignal<T>(props)` — coerces `undefined` to `[]`
- `createControllableSetSignal<T>(props)` — coerces `undefined` to `new Set()`

**Solid 2.0 adaptations:**
- `{ ownedWrite: true }` on the internal signal (required when setter is callable from reactive owner scopes)
- `createMemo` for control-mode detection (replaces `createComputed`, removed in 2.0)
- Raw signal read inside `setValue` to avoid deferred-memo staleness
- `accessWith` from `@solid-primitives/utils` for the value-or-updater function pattern