### PR TITLE
upgrade: keyed package upgrade for Solid 2.0

### DIFF
--- a/.changeset/keyed-solid2-migration.md
+++ b/.changeset/keyed-solid2-migration.md
@@ -1,0 +1,14 @@
+---
+"@solid-primitives/keyed": major
+---
+
+Migrate to Solid.js v2.0 (beta.13)
+
+## Breaking Changes
+
+**Peer dependencies**: `solid-js@^2.0.0-beta.13` and `@solidjs/web@^2.0.0-beta.13` are now required.
+
+- `isServer` is now imported from `@solidjs/web` (was `solid-js/web`)
+- `JSX` type is now imported from `@solidjs/web` (was `solid-js`)
+- `Rerun` props: `on` type changed from `AccessorArray<S> | Accessor<S>` to `Accessor<S>[] | Accessor<S>` (`AccessorArray` was removed from `solid-js`)
+- Internal signals in `keyArray` now use `ownedWrite: true` to satisfy Solid 2.0's owned-scope write restrictions

--- a/packages/keyed/package.json
+++ b/packages/keyed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solid-primitives/keyed",
-  "version": "1.5.3",
+  "version": "2.0.0",
   "description": "Control Flow primitives and components that require specifying explicit keys to identify or rerender elements.",
   "author": "Damian Tarnawski @thetarnav <gthetarnav@gmail.com>",
   "license": "MIT",
@@ -46,18 +46,18 @@
   "scripts": {
     "dev": "node --import=@nothing-but/node-resolve-ts --experimental-transform-types ../../scripts/dev.ts",
     "build": "node --import=@nothing-but/node-resolve-ts --experimental-transform-types ../../scripts/build.ts",
-    "vitest": "vitest -c ../../configs/vitest.config.ts",
+    "vitest": "vitest -c ../../configs/vitest.config.solid2.ts",
     "test": "pnpm run vitest",
     "test:ssr": "pnpm run vitest --mode ssr"
   },
   "devDependencies": {
-    "@solid-primitives/refs": "workspace:^",
     "@solid-primitives/utils": "workspace:^",
-    "solid-js": "^1.9.7",
-    "solid-transition-group": "^0.2.3"
+    "@solidjs/web": "2.0.0-beta.13",
+    "solid-js": "2.0.0-beta.13"
   },
   "peerDependencies": {
-    "solid-js": "^1.6.12"
+    "@solidjs/web": "^2.0.0-beta.13",
+    "solid-js": "^2.0.0-beta.13"
   },
   "typesVersions": {}
 }

--- a/packages/keyed/src/index.ts
+++ b/packages/keyed/src/index.ts
@@ -3,16 +3,15 @@ import {
   createMemo,
   createRoot,
   createSignal,
-  type JSX,
-  on,
   onCleanup,
   type Setter,
   untrack,
   $TRACK,
   mapArray,
-  type AccessorArray,
 } from "solid-js";
-import { isServer } from "solid-js/web";
+import type { JSX } from "@solidjs/web";
+import { isServer } from "@solidjs/web";
+import { INTERNAL_OPTIONS } from "@solid-primitives/utils";
 
 const FALLBACK = Symbol("fallback");
 
@@ -114,10 +113,10 @@ export function keyArray<T, U, K>(
 
   function addNewItem(list: U[], item: T, i: number, key: K): void {
     createRoot(dispose => {
-      const [getItem, setItem] = createSignal(item);
+      const [getItem, setItem] = createSignal(item as Exclude<T, Function>, INTERNAL_OPTIONS);
       const save = { setItem, dispose } as Save;
       if (mapFn.length > 1) {
-        const [index, setIndex] = createSignal(i);
+        const [index, setIndex] = createSignal(i, INTERNAL_OPTIONS);
         save.setIndex = setIndex;
         save.mapped = mapFn(getItem, index);
       } else save.mapped = (mapFn as any)(getItem);
@@ -277,18 +276,31 @@ export type RerunChildren<T> = ((input: T, prevInput: T | undefined) => JSX.Elem
  * @see https://github.com/solidjs-community/solid-primitives/tree/main/packages/refs#Rerun
  */
 export function Rerun<S>(props: {
-  on: AccessorArray<S> | Accessor<S>;
+  on: Accessor<S>[] | Accessor<S>;
   children: RerunChildren<S>;
 }): JSX.Element;
 export function Rerun<
   S extends (object | string | bigint | number | boolean) & { length?: never },
 >(props: { on: S; children: RerunChildren<S> }): JSX.Element;
 export function Rerun(props: { on: any; children: RerunChildren<any> }): JSX.Element {
-  const key = typeof props.on === "function" || Array.isArray(props.on) ? props.on : () => props.on;
+  const key =
+    typeof props.on === "function" || Array.isArray(props.on) ? props.on : () => props.on;
+  const getKey = Array.isArray(key)
+    ? () => (key as Accessor<unknown>[]).map(fn => fn())
+    : (key as Accessor<unknown>);
+
+  let prevKey: unknown;
   return createMemo(
-    on(key, (a, b) => {
+    () => {
+      const currentKey = getKey();
       const child = props.children;
-      return typeof child === "function" && child.length > 0 ? (child as any)(a, b) : child;
-    }),
+      const el =
+        typeof child === "function" && (child as Function).length > 0
+          ? (child as any)(currentKey, prevKey)
+          : child;
+      prevKey = currentKey;
+      return el;
+    },
+    { equals: false },
   ) as unknown as JSX.Element;
 }

--- a/packages/keyed/src/index.ts
+++ b/packages/keyed/src/index.ts
@@ -293,11 +293,12 @@ export function Rerun(props: { on: any; children: RerunChildren<any> }): JSX.Ele
   return createMemo(
     () => {
       const currentKey = getKey();
-      const child = props.children;
-      const el =
-        typeof child === "function" && (child as Function).length > 0
+      const el = untrack(() => {
+        const child = props.children;
+        return typeof child === "function" && (child as Function).length > 0
           ? (child as any)(currentKey, prevKey)
           : child;
+      });
       prevKey = currentKey;
       return el;
     },

--- a/packages/keyed/test/index.test.tsx
+++ b/packages/keyed/test/index.test.tsx
@@ -1,9 +1,8 @@
-import { createComputed, createMemo, createRoot, createSignal } from "solid-js";
-import { createStore } from "solid-js/store";
+import { createMemo, createRoot, createSignal, flush, createStore } from "solid-js";
 import { update } from "@solid-primitives/utils/immutable";
 import { describe, expect, test } from "vitest";
 import { keyArray, MapEntries, SetValues } from "../src/index.js";
-import { render } from "solid-js/web";
+import { render } from "@solidjs/web";
 
 const el1 = { id: 1, value: "bread" };
 const el2 = { id: 2, value: "milk" };
@@ -26,187 +25,176 @@ describe("keyArray", () => {
       dispose();
     }));
 
-  test("cloning list should have no effect", () =>
-    createRoot(dispose => {
-      const [list, setList] = createSignal([el1, el2, el3]);
-      let changes = 0;
-      const mapped = keyArray(
-        list,
-        v => v.id,
-        v => v().id,
-      );
-      createComputed(() => mapped(), changes++);
-      expect(mapped()).toEqual([1, 2, 3]);
-      expect(changes).toBe(1);
-
-      setList(p => p.slice());
-      expect(mapped()).toEqual([1, 2, 3]);
-      expect(changes).toBe(1);
-
-      dispose();
+  test("cloning list should have no effect", () => {
+    // Signal created outside createRoot so writes don't throw SIGNAL_WRITE_IN_OWNED_SCOPE
+    const [list, setList] = createSignal([el1, el2, el3]);
+    const { mapped, dispose } = createRoot(d => ({
+      mapped: keyArray(list, v => v.id, v => v().id),
+      dispose: d,
     }));
 
-  test("mapFn is reactive", () =>
-    createRoot(dispose => {
-      const [list, setList] = createSignal([el1, el2, el3]);
-      let changes = 0;
-      const mapped = keyArray(
-        list,
-        v => v.id,
-        v => {
-          const item = { value: v().value };
-          createComputed(() => (item.value = v().value));
-          return item;
-        },
-      );
-      createComputed(() => mapped(), changes++);
+    expect(mapped()).toEqual([1, 2, 3]);
 
-      expect(mapped()).toEqual([{ value: "bread" }, { value: "milk" }, { value: "honey" }]);
-      expect(changes).toBe(1);
+    setList(p => p.slice());
+    flush();
+    expect(mapped()).toEqual([1, 2, 3]);
 
-      setList(p => update(p, 0, "value", "bananas"));
-      expect(mapped()).toEqual([{ value: "bananas" }, { value: "milk" }, { value: "honey" }]);
-      expect(changes).toBe(1);
+    dispose();
+  });
 
-      dispose();
-
-      setList(p => update(p, 1, "value", "orange juice"));
-      expect(mapped()).toEqual([{ value: "bananas" }, { value: "milk" }, { value: "honey" }]);
-      expect(changes).toBe(1);
-      expect(changes).toBe(1);
-    }));
-
-  test("index is reactive", () =>
-    createRoot(dispose => {
-      const [list, setList] = createSignal([el1, el2, el3]);
-      let changes = 0;
-      let maprun = 0;
-      const mapped = keyArray(
-        list,
-        v => v.id,
-        (v, i) => {
-          maprun++;
-          const item = { i: i(), v: v().value };
-          createComputed(() => (item.i = i()), (item.v = v().value));
-          return item;
-        },
-      );
-      createComputed(() => {
-        mapped();
-        changes++;
-      });
-
-      expect(mapped()).toEqual([
-        { i: 0, v: "bread" },
-        { i: 1, v: "milk" },
-        { i: 2, v: "honey" },
-      ]);
-      expect(changes).toBe(1);
-      expect(maprun).toBe(3);
-
-      setList([el1, el3, el2]);
-      expect(mapped()).toEqual([
-        { i: 0, v: "bread" },
-        { i: 1, v: "honey" },
-        { i: 2, v: "milk" },
-      ]);
-      expect(changes).toBe(2);
-      expect(maprun).toBe(3);
-
-      setList([el1, el4, el3, el2]);
-      expect(mapped()).toEqual([
-        { i: 0, v: "bread" },
-        { i: 1, v: "chips" },
-        { i: 2, v: "honey" },
-        { i: 3, v: "milk" },
-      ]);
-      expect(changes).toBe(3);
-      expect(maprun).toBe(4);
-
-      dispose();
-    }));
-
-  test("supports top-level store arrays", () =>
-    createRoot(dispose => {
-      const [list, setList] = createStore([
-        { i: 0, v: "foo" },
-        { i: 1, v: "bar" },
-        { i: 2, v: "baz" },
-      ]);
-
-      const mapped = keyArray(
-        () => list,
-        e => e.i,
-        (item, index) => [item, index] as const,
-      );
-
-      const getUnwrapped = (): [number, string, number][] =>
-        mapped().map(([e, index]) => {
-          const { i, v } = e();
-          return [i, v, index()];
-        });
-
-      expect(mapped().length).toBe(3);
-      expect(getUnwrapped()).toEqual([
-        [0, "foo", 0],
-        [1, "bar", 1],
-        [2, "baz", 2],
-      ]);
-
-      const [a0, a1, a2] = mapped();
-
-      setList([
-        { i: 2, v: "foo" },
-        { i: 0, v: "bar" },
-        { i: 1, v: "baz" },
-      ]);
-
-      expect(mapped().length).toBe(3);
-      expect(getUnwrapped()).toEqual([
-        [2, "foo", 0],
-        [0, "bar", 1],
-        [1, "baz", 2],
-      ]);
-
-      const [b0, b1, b2] = mapped();
-      expect(a0).toBe(b1);
-      expect(a1).toBe(b2);
-      expect(a2).toBe(b0);
-
-      dispose();
-    }));
-
-  test("key entries by prop name", () =>
-    createRoot(dispose => {
-      const entriesFrom: [string, {}][] = [
-        ["0", 0],
-        ["1", 1],
-        ["2", 2],
-        ["3", 3],
-      ];
-      const entriesTo: [string, {}][] = [
-        ["0", 0],
-        ["1", 1],
-        ["2", 2],
-      ];
-
-      const [list, setList] = createSignal<[string, {}][]>(entriesFrom);
-      const mapped = createMemo(
+  test("mapFn is reactive", () => {
+    const [list, setList] = createSignal([el1, el2, el3]);
+    const { mapped, dispose } = createRoot(d => ({
+      mapped: createMemo(
         keyArray(
           list,
-          v => v[0],
-          v => v()[1],
+          v => v.id,
+          // Use a getter so item.value reads the signal directly without needing effects
+          v => ({ get value() { return v().value; } }),
         ),
-      );
-      expect(mapped().length).toBe(4);
-      expect(mapped()).toEqual([0, 1, 2, 3]);
-
-      setList(entriesTo);
-      expect(mapped().length).toBe(3);
-      expect(mapped()).toEqual([0, 1, 2]);
-
-      dispose();
+      ),
+      dispose: d,
     }));
+
+    expect(mapped()).toEqual([{ value: "bread" }, { value: "milk" }, { value: "honey" }]);
+
+    setList(p => update(p, 0, "value", "bananas"));
+    flush();
+    expect(mapped()).toEqual([{ value: "bananas" }, { value: "milk" }, { value: "honey" }]);
+
+    dispose();
+
+    setList(p => update(p, 1, "value", "orange juice"));
+    expect(mapped()).toEqual([{ value: "bananas" }, { value: "milk" }, { value: "honey" }]);
+  });
+
+  test("index is reactive", () => {
+    const [list, setList] = createSignal([el1, el2, el3]);
+    let changes = 0;
+    let maprun = 0;
+
+    const { rawMapped, dispose } = createRoot(d => {
+      const rawMapped = keyArray(list, v => v.id, (v, i) => {
+        maprun++;
+        return { get i() { return i(); }, v: v().value };
+      });
+      // createMemo runs synchronously within flush — no deferred apply needed
+      createMemo(() => { rawMapped(); changes++; }, undefined, { equals: false });
+      return { rawMapped, dispose: d };
+    });
+
+    expect(rawMapped()).toEqual([
+      { i: 0, v: "bread" },
+      { i: 1, v: "milk" },
+      { i: 2, v: "honey" },
+    ]);
+    expect(changes).toBe(1);
+    expect(maprun).toBe(3);
+
+    setList([el1, el3, el2]);
+    flush();
+    expect(rawMapped()).toEqual([
+      { i: 0, v: "bread" },
+      { i: 1, v: "honey" },
+      { i: 2, v: "milk" },
+    ]);
+    expect(changes).toBe(2);
+    expect(maprun).toBe(3);
+
+    setList([el1, el4, el3, el2]);
+    flush();
+    expect(rawMapped()).toEqual([
+      { i: 0, v: "bread" },
+      { i: 1, v: "chips" },
+      { i: 2, v: "honey" },
+      { i: 3, v: "milk" },
+    ]);
+    expect(changes).toBe(3);
+    expect(maprun).toBe(4);
+
+    dispose();
+  });
+
+  test("supports top-level store arrays", () => {
+    // Store created outside createRoot so writes don't throw
+    const [list, setList] = createStore([
+      { i: 0, v: "foo" },
+      { i: 1, v: "bar" },
+      { i: 2, v: "baz" },
+    ]);
+
+    const { mapped, dispose } = createRoot(d => ({
+      mapped: createMemo(keyArray(() => list, e => e.i, (item, index) => [item, index] as const)),
+      dispose: d,
+    }));
+
+    const getUnwrapped = (): [number, string, number][] =>
+      mapped().map(([e, index]) => {
+        const { i, v } = e();
+        return [i, v, index()];
+      });
+
+    expect(mapped().length).toBe(3);
+    expect(getUnwrapped()).toEqual([
+      [0, "foo", 0],
+      [1, "bar", 1],
+      [2, "baz", 2],
+    ]);
+
+    const [a0, a1, a2] = mapped();
+
+    // In Solid 2.0 store setters are draft-first; return a value to perform replacement
+    setList(() => [
+      { i: 2, v: "foo" },
+      { i: 0, v: "bar" },
+      { i: 1, v: "baz" },
+    ]);
+    flush();
+
+    expect(mapped().length).toBe(3);
+    expect(getUnwrapped()).toEqual([
+      [2, "foo", 0],
+      [0, "bar", 1],
+      [1, "baz", 2],
+    ]);
+
+    const [b0, b1, b2] = mapped();
+    expect(a0).toBe(b1);
+    expect(a1).toBe(b2);
+    expect(a2).toBe(b0);
+
+    dispose();
+  });
+
+  test("key entries by prop name", () => {
+    const entriesFrom: [string, {}][] = [
+      ["0", 0],
+      ["1", 1],
+      ["2", 2],
+      ["3", 3],
+    ];
+    const entriesTo: [string, {}][] = [
+      ["0", 0],
+      ["1", 1],
+      ["2", 2],
+    ];
+
+    const [list, setList] = createSignal<[string, {}][]>(entriesFrom);
+    const { mapped, dispose } = createRoot(d => ({
+      mapped: createMemo(keyArray(list, v => v[0], v => v()[1])),
+      dispose: d,
+    }));
+
+    expect(mapped().length).toBe(4);
+    expect(mapped()).toEqual([0, 1, 2, 3]);
+
+    setList(entriesTo);
+    flush();
+    expect(mapped().length).toBe(3);
+    expect(mapped()).toEqual([0, 1, 2]);
+
+    dispose();
+  });
 });
 
 describe("MapEntries", () => {
@@ -273,6 +261,7 @@ describe("MapEntries", () => {
     });
 
     set(new Map(startingMap));
+    flush();
 
     container.childNodes.forEach((v, i) => {
       const k = Array.from(startingMap.keys())[i]!;
@@ -320,6 +309,7 @@ describe("MapEntries", () => {
       [3, "3"],
     ]);
     set(nextMap);
+    flush();
 
     container.childNodes.forEach((v, i) => {
       const k = Array.from(nextMap.keys())[i]!;
@@ -369,6 +359,7 @@ describe("MapEntries", () => {
       [5, "5"],
     ]);
     set(nextMap);
+    flush();
 
     const newMapped: ChildNode[] = new Array(container.childNodes.length);
     container.childNodes.forEach((v, i) => {
@@ -423,6 +414,7 @@ describe("MapEntries", () => {
       [3, "3"],
     ]);
     set(nextMap);
+    flush();
 
     const newMapped: ChildNode[] = new Array(container.childNodes.length);
     container.childNodes.forEach((v, i) => {
@@ -497,6 +489,7 @@ describe("SetValues", () => {
     });
 
     set(new Set(startingMap));
+    flush();
 
     container.childNodes.forEach((n, i) => {
       const v = Array.from(startingMap.values())[i]!;
@@ -536,6 +529,7 @@ describe("SetValues", () => {
 
     const nextMap = new Set(["1", "2", "3", "4", "5"]);
     set(nextMap);
+    flush();
 
     const newMapped: ChildNode[] = new Array(container.childNodes.length);
     container.childNodes.forEach((n, i) => {
@@ -582,6 +576,7 @@ describe("SetValues", () => {
 
     const nextMap = new Set(["0", "3"]);
     set(nextMap);
+    flush();
 
     const newMapped: ChildNode[] = new Array(container.childNodes.length);
     container.childNodes.forEach((n, i) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       '@types/jsdom':
         specifier: ^21.1.7
         version: 21.1.7
@@ -33,14 +33,14 @@ importers:
         specifier: ^8.34.0
         version: 8.34.0(eslint@9.28.0(jiti@1.21.7))(typescript@5.8.3)
       babel-preset-solid:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(@babel/core@7.27.4)(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(@babel/core@7.27.4)(solid-js@2.0.0-beta.14)
       esbuild:
         specifier: ^0.25.5
         version: 0.25.5
       esbuild-plugin-solid:
         specifier: ^0.6.0
-        version: 0.6.0(esbuild@0.25.5)(solid-js@2.0.0-beta.10)
+        version: 0.6.0(esbuild@0.25.5)(solid-js@2.0.0-beta.14)
       eslint:
         specifier: ^9.28.0
         version: 9.28.0(jiti@1.21.7)
@@ -75,8 +75,8 @@ importers:
         specifier: ^4.0.1
         version: 4.0.1
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -85,7 +85,7 @@ importers:
         version: 6.3.5(@types/node@22.15.31)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)
       vite-plugin-solid:
         specifier: 3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite@6.3.5(@types/node@22.15.31)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.14(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite@6.3.5(@types/node@22.15.31)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@22.15.31)(jsdom@25.0.1)(lightningcss@1.32.0)(sass@1.77.8)
@@ -119,11 +119,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/autofocus:
     dependencies:
@@ -132,11 +132,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/bounds:
     dependencies:
@@ -151,20 +151,20 @@ importers:
         specifier: workspace:^
         version: link:../scheduled
       '@solidjs/web':
-        specifier: ^2.0.0-beta.12
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: ^2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: ^2.0.0-beta.12
-        version: 2.0.0-beta.13
+        specifier: ^2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/broadcast-channel:
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/clipboard:
     dependencies:
@@ -173,11 +173,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/connectivity:
     dependencies:
@@ -218,8 +218,8 @@ importers:
         version: link:../utils
     devDependencies:
       solid-js:
-        specifier: 2.0.0-beta.12
-        version: 2.0.0-beta.12
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/cookies:
     devDependencies:
@@ -289,8 +289,8 @@ importers:
         version: link:../utils
     devDependencies:
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/devices:
     devDependencies:
@@ -305,8 +305,8 @@ importers:
         version: link:../utils
     devDependencies:
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/event-dispatcher:
     devDependencies:
@@ -321,17 +321,17 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/event-props:
     devDependencies:
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/fetch:
     dependencies:
@@ -384,8 +384,8 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       '@types/leaflet':
         specifier: ^1.9.8
         version: 1.9.12
@@ -393,8 +393,8 @@ importers:
         specifier: ^1.9.4
         version: 1.9.4
       solid-js:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/gestures:
     devDependencies:
@@ -480,8 +480,8 @@ importers:
   packages/input-mask:
     devDependencies:
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/interaction:
     dependencies:
@@ -490,11 +490,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/intersection-observer:
     dependencies:
@@ -506,11 +506,11 @@ importers:
         specifier: workspace:^
         version: link:../range
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/jsx-tokenizer:
     dependencies:
@@ -535,11 +535,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/keyed:
     devDependencies:
@@ -572,11 +572,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.12
-        version: 2.0.0-beta.12(solid-js@2.0.0-beta.12)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.12
-        version: 2.0.0-beta.12
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/map:
     dependencies:
@@ -591,8 +591,8 @@ importers:
   packages/marker:
     devDependencies:
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/masonry:
     dependencies:
@@ -604,8 +604,8 @@ importers:
         specifier: workspace:^
         version: link:../media
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/match:
     devDependencies:
@@ -629,11 +629,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/memo:
     dependencies:
@@ -642,11 +642,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/mouse:
     dependencies:
@@ -683,11 +683,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/orientation:
     dependencies:
@@ -696,11 +696,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/page-visibility:
     dependencies:
@@ -737,11 +737,11 @@ importers:
   packages/platform:
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/pointer:
     dependencies:
@@ -756,11 +756,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/presence:
     dependencies:
@@ -769,8 +769,8 @@ importers:
         version: link:../utils
     devDependencies:
       solid-js:
-        specifier: ^2.0.0-beta.12
-        version: 2.0.0-beta.13
+        specifier: ^2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/promise:
     dependencies:
@@ -799,11 +799,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/range:
     dependencies:
@@ -825,14 +825,14 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
       solid-transition-group:
         specifier: ^0.2.3
-        version: 0.2.3(solid-js@2.0.0-beta.13)
+        version: 0.2.3(solid-js@2.0.0-beta.14)
 
   packages/resize-observer:
     dependencies:
@@ -850,11 +850,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/resource:
     devDependencies:
@@ -869,11 +869,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/scheduled:
     devDependencies:
@@ -884,20 +884,20 @@ importers:
         specifier: workspace:^
         version: link:../timer
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/script-loader:
     devDependencies:
       '@solidjs/web':
-        specifier: ^2.0.0-beta.12
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: ^2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: ^2.0.0-beta.12
-        version: 2.0.0-beta.13
+        specifier: ^2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/scroll:
     dependencies:
@@ -915,11 +915,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.12
-        version: 2.0.0-beta.12(solid-js@2.0.0-beta.12)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.12
-        version: 2.0.0-beta.12
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/selection:
     devDependencies:
@@ -982,11 +982,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/storage:
     dependencies:
@@ -1021,11 +1021,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/timer:
     devDependencies:
@@ -1052,20 +1052,20 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/tween:
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/upload:
     dependencies:
@@ -1080,11 +1080,11 @@ importers:
   packages/utils:
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/vibrate:
     dependencies:
@@ -1093,11 +1093,11 @@ importers:
         version: link:../utils
     devDependencies:
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/virtual:
     dependencies:
@@ -1109,14 +1109,14 @@ importers:
         specifier: ^7.27.0
         version: 7.27.4
       '@solidjs/web':
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       babel-preset-solid:
-        specifier: 2.0.0-beta.10
-        version: 2.0.0-beta.10(@babel/core@7.27.4)(solid-js@2.0.0-beta.13)
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14(@babel/core@7.27.4)(solid-js@2.0.0-beta.14)
       solid-js:
-        specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13
+        specifier: 2.0.0-beta.14
+        version: 2.0.0-beta.14
 
   packages/websocket:
     devDependencies:
@@ -1185,13 +1185,13 @@ importers:
         version: link:../packages/utils
       '@solidjs/web':
         specifier: 2.0.0-beta.13
-        version: 2.0.0-beta.13(solid-js@2.0.0-beta.10)
+        version: 2.0.0-beta.13(solid-js@2.0.0-beta.14)
       '@tanstack/solid-router':
         specifier: ^2.0.0-beta.17
-        version: 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)
+        version: 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)
       '@tanstack/solid-start':
         specifier: ^2.0.0-beta.17
-        version: 2.0.0-beta.18(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
+        version: 2.0.0-beta.18(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
       clsx:
         specifier: ^2.0.0
         version: 2.1.1
@@ -1252,7 +1252,7 @@ importers:
         version: 8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)
       vite-plugin-solid:
         specifier: 3.0.0-next.5
-        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
+        version: 3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
 
 packages:
 
@@ -2719,20 +2719,18 @@ packages:
   '@solidjs/signals@2.0.0-beta.13':
     resolution: {integrity: sha512-jc+wLRK+eyUFerH8Mjed4HikdJwz3z95TT7tqyG+K00IV9jfgZWvR1nZDUEZc6kXffmtW/z+w6PNn62ea5KjIw==}
 
-  '@solidjs/web@2.0.0-beta.10':
-    resolution: {integrity: sha512-Ox7MBv19kuxHoHhWoLCCcc6aykSgaqzWvWT7RB66VqlFnQ8Lid2ncd30g5L4XC0GB+MN/WZVb68tiYrAFUDIAg==}
-    peerDependencies:
-      solid-js: ^2.0.0-beta.10
-
-  '@solidjs/web@2.0.0-beta.12':
-    resolution: {integrity: sha512-Wc+/LctUqfNQs98VnijoEu4gWFOSu/kUcZiBIjQ+S9ZUuT6Z77CRkmiZ0C8dyOhNPbTgpU2JYH6B5wqY2eqS0A==}
-    peerDependencies:
-      solid-js: ^2.0.0-beta.12
+  '@solidjs/signals@2.0.0-beta.14':
+    resolution: {integrity: sha512-y72nYtD7ogwX/UR5g2Y+meyeO6Q/xbQGtmvVTQX6USkMwEGOMnytqDnHj5amUzD7Fzqg32svwtCSx/q8hsOXAA==}
 
   '@solidjs/web@2.0.0-beta.13':
     resolution: {integrity: sha512-ugSnWcNc18osJZ24+op7mQpm6LlyHSgTnvSaYqEwL9PVmLxXpmAS7/dt5nc7MLLZtwgf1J1rmRfZb7mT8fTL2w==}
     peerDependencies:
       solid-js: ^2.0.0-beta.13
+
+  '@solidjs/web@2.0.0-beta.14':
+    resolution: {integrity: sha512-iYqLqYapbnYBxbX9WspujYBdFHM1HND+Pd0p18vXHHlhYi42oBmIayxH4JsqPA+abe19nnpjXLmv03X2/IpmVQ==}
+    peerDependencies:
+      solid-js: ^2.0.0-beta.14
 
   '@supabase/auth-js@2.67.3':
     resolution: {integrity: sha512-NJDaW8yXs49xMvWVOkSIr8j46jf+tYHV0wHhrwOaLLMZSFO4g6kKAf+MfzQ2RaD06OCUkUHIzctLAxjTgEVpzw==}
@@ -3196,8 +3194,8 @@ packages:
     peerDependencies:
       '@babel/core': ^7.20.12
 
-  babel-plugin-jsx-dom-expressions@0.50.0-next.6:
-    resolution: {integrity: sha512-D7SSrMu1EupiCFT3hBhWJj0EWzaI27HV1ysbLSKFcH1ROZe61DmnNVchrnr5QeAw5O8bqSdlMDLdEqMYzi4tTA==}
+  babel-plugin-jsx-dom-expressions@0.50.0-next.13:
+    resolution: {integrity: sha512-ANjSohrXkRTxqFOENz5vk57UEjLHx4lqOibSXmNZ51aNvzZ7zT22JB+kpv9AutPzhy7tcJaNtnLoq6yqlTZTzw==}
     peerDependencies:
       '@babel/core': ^7.20.12
 
@@ -3218,20 +3216,20 @@ packages:
       solid-js:
         optional: true
 
-  babel-preset-solid@2.0.0-beta.10:
-    resolution: {integrity: sha512-lzGgPsh1fVtBJDl+UWLTCgimzPMda7X2Xzq7asCCOq/zHRwiF5vF3Eb3xj65dGyi7YpgVROTwJEpj+XiroKaww==}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      solid-js: ^2.0.0-beta.10
-    peerDependenciesMeta:
-      solid-js:
-        optional: true
-
   babel-preset-solid@2.0.0-beta.13:
     resolution: {integrity: sha512-VX5fa4b6Sn92v+vFw3ITEvDv0f5vZZZhGgGcqYaAzjP7RF45+VZcZBoG0pHwCGA7UfXdYLUQuqXb4tG1uV3cQA==}
     peerDependencies:
       '@babel/core': ^7.0.0
       solid-js: ^2.0.0-beta.13
+    peerDependenciesMeta:
+      solid-js:
+        optional: true
+
+  babel-preset-solid@2.0.0-beta.14:
+    resolution: {integrity: sha512-l0eX4t+vYmANQqEbRWz0d7b9zt2SybxX7/PfA5cyWGphSGiMtGahFT6XHXktDd8x16o5t1DyPIl7yfa/HAho3A==}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+      solid-js: ^2.0.0-beta.14
     peerDependenciesMeta:
       solid-js:
         optional: true
@@ -5333,14 +5331,11 @@ packages:
   solid-js@1.9.7:
     resolution: {integrity: sha512-/saTKi8iWEM233n5OSi1YHCCuh66ZIQ7aK2hsToPe4tqGm7qAejU1SwNuTPivbWAYq7SjuHVVYxxuZQNRbICiw==}
 
-  solid-js@2.0.0-beta.10:
-    resolution: {integrity: sha512-EAfV6b1SC4c3wEBAoX4dMy063uTb4nfL5uXnN8yse4InH7RTw1LoB0I9HAy+pj3/GHqQE2tYZurlZtqU4pGyog==}
-
-  solid-js@2.0.0-beta.12:
-    resolution: {integrity: sha512-UJC4gc0Dgbm6BTBFhUdrfIEXiQ/jaQuUGxYfZnEkywwD5FX16MhlM/e6bq2+94mhXUExYI9VJoGBh7CpOZ/1XA==}
-
   solid-js@2.0.0-beta.13:
     resolution: {integrity: sha512-uAknr7Xkn25zAufBrYko4eOCbcg/gkrwnmE9KVb2Kb3vVZw2ibqseNxpjslnwJkT4gFScmFniqJtzRp7vO2klA==}
+
+  solid-js@2.0.0-beta.14:
+    resolution: {integrity: sha512-gbbvlxhs1GgL1IsnwHNtkTCRBBQcIDMwznBw3T05iYvP+fuUKMyIPku+ZLjeALyX4RaSLR99JSL6NttyHsYb8Q==}
 
   solid-refresh@0.8.0-next.7:
     resolution: {integrity: sha512-fqkPRAeiE0tqfo2ZljeQBIXwfYssU2w1FmaWFrXmnV33B/CfGfez7BjtOF0Y1/orUNRXI/DZcJlJThHllcCMsA==}
@@ -7603,160 +7598,156 @@ snapshots:
 
   '@sindresorhus/is@4.6.0': {}
 
-  '@solid-devtools/debugger@0.28.1(solid-js@2.0.0-beta.10)':
+  '@solid-devtools/debugger@0.28.1(solid-js@2.0.0-beta.14)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-beta.10)
-      '@solid-primitives/bounds': 0.1.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/keyboard': 1.3.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-beta.14)
+      '@solid-primitives/bounds': 0.1.5(solid-js@2.0.0-beta.14)
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.14)
+      '@solid-primitives/keyboard': 1.3.5(solid-js@2.0.0-beta.14)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
-  '@solid-devtools/logger@0.9.11(solid-js@2.0.0-beta.10)':
+  '@solid-devtools/logger@0.9.11(solid-js@2.0.0-beta.14)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-devtools/debugger': 0.28.1(solid-js@2.0.0-beta.10)
-      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-devtools/debugger': 0.28.1(solid-js@2.0.0-beta.14)
+      '@solid-devtools/shared': 0.20.0(solid-js@2.0.0-beta.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
-  '@solid-devtools/shared@0.20.0(solid-js@2.0.0-beta.10)':
+  '@solid-devtools/shared@0.20.0(solid-js@2.0.0-beta.14)':
     dependencies:
       '@nothing-but/utils': 0.17.0
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/media': 2.3.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/refs': 1.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/styles': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.14)
+      '@solid-primitives/media': 2.3.5(solid-js@2.0.0-beta.14)
+      '@solid-primitives/refs': 1.1.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/scheduled': 1.5.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/styles': 0.1.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
-  '@solid-primitives/bounds@0.1.5(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/bounds@0.1.5(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/resize-observer': 2.1.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.14)
+      '@solid-primitives/resize-observer': 2.1.5(solid-js@2.0.0-beta.14)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
-  '@solid-primitives/event-listener@2.4.5(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/event-listener@2.4.5(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
-  '@solid-primitives/keyboard@1.3.5(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/keyboard@1.3.5(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.14)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
-  '@solid-primitives/media@2.3.5(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/media@2.3.5(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.14)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
   '@solid-primitives/refs@1.0.8(solid-js@1.9.7)':
     dependencies:
       '@solid-primitives/utils': 6.2.3(solid-js@1.9.7)
       solid-js: 1.9.7
 
-  '@solid-primitives/refs@1.0.8(solid-js@2.0.0-beta.13)':
+  '@solid-primitives/refs@1.0.8(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solid-primitives/utils': 6.2.3(solid-js@2.0.0-beta.13)
-      solid-js: 2.0.0-beta.13
+      '@solid-primitives/utils': 6.2.3(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
-  '@solid-primitives/refs@1.1.3(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/refs@1.1.3(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
-  '@solid-primitives/resize-observer@2.1.5(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/resize-observer@2.1.5(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.10)
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/event-listener': 2.4.5(solid-js@2.0.0-beta.14)
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/static-store': 0.1.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
-  '@solid-primitives/rootless@1.5.3(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/rootless@1.5.3(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
-  '@solid-primitives/scheduled@1.5.3(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/scheduled@1.5.3(solid-js@2.0.0-beta.14)':
     dependencies:
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.14
 
-  '@solid-primitives/static-store@0.1.3(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/static-store@0.1.3(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
-  '@solid-primitives/styles@0.1.3(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/styles@0.1.3(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.10)
-      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.10)
-      solid-js: 2.0.0-beta.10
+      '@solid-primitives/rootless': 1.5.3(solid-js@2.0.0-beta.14)
+      '@solid-primitives/utils': 6.4.0(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
   '@solid-primitives/transition-group@1.0.5(solid-js@1.9.7)':
     dependencies:
       solid-js: 1.9.7
 
-  '@solid-primitives/transition-group@1.0.5(solid-js@2.0.0-beta.13)':
+  '@solid-primitives/transition-group@1.0.5(solid-js@2.0.0-beta.14)':
     dependencies:
-      solid-js: 2.0.0-beta.13
+      solid-js: 2.0.0-beta.14
 
   '@solid-primitives/utils@6.2.3(solid-js@1.9.7)':
     dependencies:
       solid-js: 1.9.7
 
-  '@solid-primitives/utils@6.2.3(solid-js@2.0.0-beta.13)':
+  '@solid-primitives/utils@6.2.3(solid-js@2.0.0-beta.14)':
     dependencies:
-      solid-js: 2.0.0-beta.13
+      solid-js: 2.0.0-beta.14
 
-  '@solid-primitives/utils@6.4.0(solid-js@2.0.0-beta.10)':
+  '@solid-primitives/utils@6.4.0(solid-js@2.0.0-beta.14)':
     dependencies:
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.14
 
-  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.10)':
+  '@solidjs/meta@0.29.4(solid-js@2.0.0-beta.14)':
     dependencies:
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.14
 
   '@solidjs/signals@2.0.0-beta.13': {}
 
-  '@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10)':
-    dependencies:
-      seroval: 1.5.4
-      seroval-plugins: 1.5.4(seroval@1.5.4)
-      solid-js: 2.0.0-beta.10
-
-  '@solidjs/web@2.0.0-beta.12(solid-js@2.0.0-beta.12)':
-    dependencies:
-      seroval: 1.5.4
-      seroval-plugins: 1.5.4(seroval@1.5.4)
-      solid-js: 2.0.0-beta.12
-
-  '@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10)':
-    dependencies:
-      seroval: 1.5.4
-      seroval-plugins: 1.5.4(seroval@1.5.4)
-      solid-js: 2.0.0-beta.10
+  '@solidjs/signals@2.0.0-beta.14': {}
 
   '@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.13)':
     dependencies:
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
       solid-js: 2.0.0-beta.13
+
+  '@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14)':
+    dependencies:
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+      solid-js: 2.0.0-beta.14
+
+  '@solidjs/web@2.0.0-beta.14(solid-js@2.0.0-beta.14)':
+    dependencies:
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+      solid-js: 2.0.0-beta.14
 
   '@supabase/auth-js@2.67.3':
     dependencies:
@@ -7834,7 +7825,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-plugin@1.167.12(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))':
+  '@tanstack/router-plugin@1.167.12(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
@@ -7851,7 +7842,7 @@ snapshots:
       zod: 3.25.63
     optionalDependencies:
       vite: 8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)
-      vite-plugin-solid: 3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
+      vite-plugin-solid: 3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -7869,48 +7860,48 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/solid-router@2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)':
+  '@tanstack/solid-router@2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solid-devtools/logger': 0.9.11(solid-js@2.0.0-beta.10)
-      '@solidjs/meta': 0.29.4(solid-js@2.0.0-beta.10)
-      '@solidjs/web': 2.0.0-beta.13(solid-js@2.0.0-beta.10)
+      '@solid-devtools/logger': 0.9.11(solid-js@2.0.0-beta.14)
+      '@solidjs/meta': 0.29.4(solid-js@2.0.0-beta.14)
+      '@solidjs/web': 2.0.0-beta.13(solid-js@2.0.0-beta.14)
       '@tanstack/history': 1.161.6
       '@tanstack/router-core': 1.168.9
       isbot: 5.1.40
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.14
 
-  '@tanstack/solid-start-client@2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)':
+  '@tanstack/solid-start-client@2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solidjs/web': 2.0.0-beta.13(solid-js@2.0.0-beta.10)
+      '@solidjs/web': 2.0.0-beta.13(solid-js@2.0.0-beta.14)
       '@tanstack/router-core': 1.168.9
-      '@tanstack/solid-router': 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)
+      '@tanstack/solid-router': 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)
       '@tanstack/start-client-core': 1.167.9
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.14
 
-  '@tanstack/solid-start-server@2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)':
+  '@tanstack/solid-start-server@2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)':
     dependencies:
-      '@solidjs/meta': 0.29.4(solid-js@2.0.0-beta.10)
-      '@solidjs/web': 2.0.0-beta.13(solid-js@2.0.0-beta.10)
+      '@solidjs/meta': 0.29.4(solid-js@2.0.0-beta.14)
+      '@solidjs/web': 2.0.0-beta.13(solid-js@2.0.0-beta.14)
       '@tanstack/history': 1.161.6
       '@tanstack/router-core': 1.168.9
-      '@tanstack/solid-router': 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)
+      '@tanstack/solid-router': 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)
       '@tanstack/start-client-core': 1.167.9
       '@tanstack/start-server-core': 1.167.9
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.14
     transitivePeerDependencies:
       - crossws
 
-  '@tanstack/solid-start@2.0.0-beta.18(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))':
+  '@tanstack/solid-start@2.0.0-beta.18(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))':
     dependencies:
-      '@solidjs/web': 2.0.0-beta.13(solid-js@2.0.0-beta.10)
-      '@tanstack/solid-router': 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)
-      '@tanstack/solid-start-client': 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)
-      '@tanstack/solid-start-server': 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)
+      '@solidjs/web': 2.0.0-beta.13(solid-js@2.0.0-beta.14)
+      '@tanstack/solid-router': 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)
+      '@tanstack/solid-start-client': 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)
+      '@tanstack/solid-start-server': 2.0.0-beta.17(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)
       '@tanstack/start-client-core': 1.167.9
-      '@tanstack/start-plugin-core': 1.167.17(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
+      '@tanstack/start-plugin-core': 1.167.17(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
       '@tanstack/start-server-core': 1.167.9
       pathe: 2.0.3
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.14
       vite: 8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)
     transitivePeerDependencies:
       - '@rsbuild/core'
@@ -7929,7 +7920,7 @@ snapshots:
 
   '@tanstack/start-fn-stubs@1.161.6': {}
 
-  '@tanstack/start-plugin-core@1.167.17(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))':
+  '@tanstack/start-plugin-core@1.167.17(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/core': 7.29.0
@@ -7937,7 +7928,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.40
       '@tanstack/router-core': 1.168.9
       '@tanstack/router-generator': 1.166.24
-      '@tanstack/router-plugin': 1.167.12(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
+      '@tanstack/router-plugin': 1.167.12(vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)))(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
       '@tanstack/router-utils': 1.161.6
       '@tanstack/start-client-core': 1.167.9
       '@tanstack/start-server-core': 1.167.9
@@ -8365,16 +8356,6 @@ snapshots:
       html-entities: 2.3.3
       parse5: 7.3.0
 
-  babel-plugin-jsx-dom-expressions@0.50.0-next.11(@babel/core@7.27.4):
-    dependencies:
-      '@babel/core': 7.27.4
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.27.4)
-      '@babel/types': 7.29.0
-      html-entities: 2.3.3
-      parse5: 7.3.0
-      validate-html-nesting: 1.2.4
-
   babel-plugin-jsx-dom-expressions@0.50.0-next.11(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -8385,7 +8366,7 @@ snapshots:
       parse5: 7.3.0
       validate-html-nesting: 1.2.4
 
-  babel-plugin-jsx-dom-expressions@0.50.0-next.6(@babel/core@7.27.4):
+  babel-plugin-jsx-dom-expressions@0.50.0-next.13(@babel/core@7.27.4):
     dependencies:
       '@babel/core': 7.27.4
       '@babel/helper-module-imports': 7.18.6
@@ -8430,33 +8411,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-preset-solid@1.9.12(@babel/core@7.27.4)(solid-js@2.0.0-beta.10):
+  babel-preset-solid@1.9.12(@babel/core@7.27.4)(solid-js@2.0.0-beta.14):
     dependencies:
       '@babel/core': 7.27.4
       babel-plugin-jsx-dom-expressions: 0.40.7(@babel/core@7.27.4)
     optionalDependencies:
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.14
 
-  babel-preset-solid@2.0.0-beta.10(@babel/core@7.27.4)(solid-js@2.0.0-beta.13):
-    dependencies:
-      '@babel/core': 7.27.4
-      babel-plugin-jsx-dom-expressions: 0.50.0-next.6(@babel/core@7.27.4)
-    optionalDependencies:
-      solid-js: 2.0.0-beta.13
-
-  babel-preset-solid@2.0.0-beta.13(@babel/core@7.27.4)(solid-js@2.0.0-beta.10):
-    dependencies:
-      '@babel/core': 7.27.4
-      babel-plugin-jsx-dom-expressions: 0.50.0-next.11(@babel/core@7.27.4)
-    optionalDependencies:
-      solid-js: 2.0.0-beta.10
-
-  babel-preset-solid@2.0.0-beta.13(@babel/core@7.29.0)(solid-js@2.0.0-beta.10):
+  babel-preset-solid@2.0.0-beta.13(@babel/core@7.29.0)(solid-js@2.0.0-beta.14):
     dependencies:
       '@babel/core': 7.29.0
       babel-plugin-jsx-dom-expressions: 0.50.0-next.11(@babel/core@7.29.0)
     optionalDependencies:
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.14
+
+  babel-preset-solid@2.0.0-beta.14(@babel/core@7.27.4)(solid-js@2.0.0-beta.14):
+    dependencies:
+      '@babel/core': 7.27.4
+      babel-plugin-jsx-dom-expressions: 0.50.0-next.13(@babel/core@7.27.4)
+    optionalDependencies:
+      solid-js: 2.0.0-beta.14
 
   bail@2.0.2: {}
 
@@ -8911,13 +8885,13 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
-  esbuild-plugin-solid@0.6.0(esbuild@0.25.5)(solid-js@2.0.0-beta.10):
+  esbuild-plugin-solid@0.6.0(esbuild@0.25.5)(solid-js@2.0.0-beta.14):
     dependencies:
       '@babel/core': 7.27.4
       '@babel/preset-typescript': 7.27.1(@babel/core@7.27.4)
-      babel-preset-solid: 1.9.12(@babel/core@7.27.4)(solid-js@2.0.0-beta.10)
+      babel-preset-solid: 1.9.12(@babel/core@7.27.4)(solid-js@2.0.0-beta.14)
       esbuild: 0.25.5
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.14
     transitivePeerDependencies:
       - supports-color
 
@@ -10792,20 +10766,6 @@ snapshots:
       seroval: 1.3.2
       seroval-plugins: 1.3.2(seroval@1.3.2)
 
-  solid-js@2.0.0-beta.10:
-    dependencies:
-      '@solidjs/signals': 2.0.0-beta.13
-      csstype: 3.1.3
-      seroval: 1.5.4
-      seroval-plugins: 1.5.4(seroval@1.5.4)
-
-  solid-js@2.0.0-beta.12:
-    dependencies:
-      '@solidjs/signals': 2.0.0-beta.13
-      csstype: 3.1.3
-      seroval: 1.5.4
-      seroval-plugins: 1.5.4(seroval@1.5.4)
-
   solid-js@2.0.0-beta.13:
     dependencies:
       '@solidjs/signals': 2.0.0-beta.13
@@ -10813,11 +10773,18 @@ snapshots:
       seroval: 1.5.4
       seroval-plugins: 1.5.4(seroval@1.5.4)
 
-  solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.10):
+  solid-js@2.0.0-beta.14:
+    dependencies:
+      '@solidjs/signals': 2.0.0-beta.14
+      csstype: 3.1.3
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.14):
     dependencies:
       '@babel/generator': 7.29.1
       '@babel/types': 7.29.0
-      solid-js: 2.0.0-beta.10
+      solid-js: 2.0.0-beta.14
 
   solid-transition-group@0.2.3(solid-js@1.9.7):
     dependencies:
@@ -10825,11 +10792,11 @@ snapshots:
       '@solid-primitives/transition-group': 1.0.5(solid-js@1.9.7)
       solid-js: 1.9.7
 
-  solid-transition-group@0.2.3(solid-js@2.0.0-beta.13):
+  solid-transition-group@0.2.3(solid-js@2.0.0-beta.14):
     dependencies:
-      '@solid-primitives/refs': 1.0.8(solid-js@2.0.0-beta.13)
-      '@solid-primitives/transition-group': 1.0.5(solid-js@2.0.0-beta.13)
-      solid-js: 2.0.0-beta.13
+      '@solid-primitives/refs': 1.0.8(solid-js@2.0.0-beta.14)
+      '@solid-primitives/transition-group': 1.0.5(solid-js@2.0.0-beta.14)
+      solid-js: 2.0.0-beta.14
 
   source-map-js@1.2.1: {}
 
@@ -11194,31 +11161,31 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.10(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite@6.3.5(@types/node@22.15.31)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)):
+  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)):
     dependencies:
       '@babel/core': 7.29.0
-      '@solidjs/web': 2.0.0-beta.10(solid-js@2.0.0-beta.10)
+      '@solidjs/web': 2.0.0-beta.13(solid-js@2.0.0-beta.14)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.13(@babel/core@7.29.0)(solid-js@2.0.0-beta.10)
+      babel-preset-solid: 2.0.0-beta.13(@babel/core@7.29.0)(solid-js@2.0.0-beta.14)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.10
-      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.10)
-      vite: 6.3.5(@types/node@22.15.31)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)
-      vitefu: 1.1.3(vite@6.3.5(@types/node@22.15.31)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
+      solid-js: 2.0.0-beta.14
+      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.14)
+      vite: 8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)
+      vitefu: 1.1.3(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10))(solid-js@2.0.0-beta.10)(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)):
+  vite-plugin-solid@3.0.0-next.5(@solidjs/web@2.0.0-beta.14(solid-js@2.0.0-beta.14))(solid-js@2.0.0-beta.14)(vite@6.3.5(@types/node@22.15.31)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)):
     dependencies:
       '@babel/core': 7.29.0
-      '@solidjs/web': 2.0.0-beta.13(solid-js@2.0.0-beta.10)
+      '@solidjs/web': 2.0.0-beta.14(solid-js@2.0.0-beta.14)
       '@types/babel__core': 7.20.5
-      babel-preset-solid: 2.0.0-beta.13(@babel/core@7.29.0)(solid-js@2.0.0-beta.10)
+      babel-preset-solid: 2.0.0-beta.13(@babel/core@7.29.0)(solid-js@2.0.0-beta.14)
       merge-anything: 5.1.7
-      solid-js: 2.0.0-beta.10
-      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.10)
-      vite: 8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)
-      vitefu: 1.1.3(vite@8.0.13(@types/node@22.15.31)(esbuild@0.25.5)(jiti@1.21.7)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
+      solid-js: 2.0.0-beta.14
+      solid-refresh: 0.8.0-next.7(solid-js@2.0.0-beta.14)
+      vite: 6.3.5(@types/node@22.15.31)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0)
+      vitefu: 1.1.3(vite@6.3.5(@types/node@22.15.31)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.77.8)(tsx@4.20.2)(yaml@2.5.0))
     transitivePeerDependencies:
       - supports-color
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -543,18 +543,15 @@ importers:
 
   packages/keyed:
     devDependencies:
-      '@solid-primitives/refs':
-        specifier: workspace:^
-        version: link:../refs
       '@solid-primitives/utils':
         specifier: workspace:^
         version: link:../utils
+      '@solidjs/web':
+        specifier: 2.0.0-beta.13
+        version: 2.0.0-beta.13(solid-js@2.0.0-beta.13)
       solid-js:
-        specifier: ^1.9.7
-        version: 1.9.7
-      solid-transition-group:
-        specifier: ^0.2.3
-        version: 0.2.3(solid-js@1.9.7)
+        specifier: 2.0.0-beta.13
+        version: 2.0.0-beta.13
 
   packages/lifecycle:
     devDependencies:
@@ -5267,12 +5264,6 @@ packages:
     peerDependencies:
       seroval: ^1.0
 
-  seroval-plugins@1.5.2:
-    resolution: {integrity: sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      seroval: ^1.0
-
   seroval-plugins@1.5.4:
     resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
     engines: {node: '>=10'}
@@ -5281,10 +5272,6 @@ packages:
 
   seroval@1.3.2:
     resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==}
-    engines: {node: '>=10'}
-
-  seroval@1.5.2:
-    resolution: {integrity: sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q==}
     engines: {node: '>=10'}
 
   seroval@1.5.4:
@@ -7761,14 +7748,14 @@ snapshots:
 
   '@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.10)':
     dependencies:
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
       solid-js: 2.0.0-beta.10
 
   '@solidjs/web@2.0.0-beta.13(solid-js@2.0.0-beta.13)':
     dependencies:
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
       solid-js: 2.0.0-beta.13
 
   '@supabase/auth-js@2.67.3':
@@ -10744,17 +10731,11 @@ snapshots:
     dependencies:
       seroval: 1.3.2
 
-  seroval-plugins@1.5.2(seroval@1.5.2):
-    dependencies:
-      seroval: 1.5.2
-
   seroval-plugins@1.5.4(seroval@1.5.4):
     dependencies:
       seroval: 1.5.4
 
   seroval@1.3.2: {}
-
-  seroval@1.5.2: {}
 
   seroval@1.5.4: {}
 
@@ -10829,8 +10810,8 @@ snapshots:
     dependencies:
       '@solidjs/signals': 2.0.0-beta.13
       csstype: 3.1.3
-      seroval: 1.5.2
-      seroval-plugins: 1.5.2(seroval@1.5.2)
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
 
   solid-refresh@0.8.0-next.7(solid-js@2.0.0-beta.10):
     dependencies:


### PR DESCRIPTION
**src/index.ts`**
- `isServer` and `JSX` type now imported from `@solidjs/web`
- Removed `on` helper (removed in 2.0) and `AccessorArray` (removed in 2.0)
- `addNewItem`: added `INTERNAL_OPTIONS` (`ownedWrite: true`) to both `createSignal` calls for item and index, satisfying Solid 2.0's owned-scope write restriction; also added `as Exclude<T, Function>` cast required by the new `createSignal` overloads
- `Rerun`: rewrote without the `on` helper — tracks `prevKey` manually in a `createMemo({ equals: false })`; `AccessorArray<S>` replaced with `Accessor<S>[]`

**`package.json`**
- Bumped `solid-js` and `@solidjs/web` to `2.0.0-beta.13`
- Added `@solidjs/web` as both dev and peer dependency
- Test script points to `vitest -c ../../configs/vitest.config.solid2.ts` (shared config, no local `vitest.config.ts`)

**`test/index.test.tsx`**
- Signals and stores created **outside** `createRoot` to avoid `SIGNAL_WRITE_IN_OWNED_SCOPE` errors
- Store setter uses draft-function form `setList(() => [...])` for Solid 2.0
- Tests 3 & 4 replaced mutable-object + `createEffect` update pattern with **reactive getters** (`{ get value() { return v().value; } }`, `{ get i() { return i(); } }`) — getters read signals synchronously without needing deferred effect applies
- Test 4's change counter uses `createMemo` (synchronous) instead of `createEffect` (deferred apply)
- `render` imported from `@solidjs/web`

**`.changeset/keyed-solid2-migration.md`** — changeset created marking this as a major version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Major version bump to 2.0.0; now requires Solid.js 2.0 beta.13
  * Import paths for `isServer` and `JSX` have changed to `@solidjs/web`
  * `Rerun` component props have been updated

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/solidjs-community/solid-primitives/pull/910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->