### PR TITLE
patch: issue 269 shortcut fix (2.0)

### DIFF
--- a/.changeset/keyboard-meta-shortcut-repeat.md
+++ b/.changeset/keyboard-meta-shortcut-repeat.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/keyboard": patch
+---
+
+Fix `createShortcut` and `useKeyDownList` (and everything built on it: `useCurrentlyHeldKey`, `useKeyDownSequence`) failing to re-trigger — and, for `createShortcut`, failing to `preventDefault` — on repeated presses of shortcuts involving the `Meta` key, e.g. `["Meta", "P"]` on macOS. macOS never fires `keyup` for other keys held down together with Meta, only for Meta itself, so both now treat Meta's `keyup` as a signal to clear all tracked keys, preventing stale key state from corrupting the next press.

--- a/packages/keyboard/src/index.ts
+++ b/packages/keyboard/src/index.ts
@@ -122,7 +122,15 @@ export const useKeyDownList = /*#__PURE__*/ createSingletonRoot<Accessor<string[
   makeEventListener(window, "keyup", e => {
     if (typeof e.key !== "string") return;
     const key = e.key.toUpperCase();
-    setPressedKeys(prev => prev.filter(_key => _key !== key));
+    // macOS never fires keyup for other keys held down together with Meta —
+    // only Meta's own keyup arrives — so its release must clear everything,
+    // or the other keys' stale state corrupts the next press.
+    // See https://github.com/solidjs-community/solid-primitives/issues/269
+    if (key === "META") {
+      reset();
+    } else {
+      setPressedKeys(prev => prev.filter(_key => _key !== key));
+    }
   });
 
   makeEventListener(window, "blur", reset);
@@ -364,6 +372,16 @@ export function createShortcut(
   makeEventListener(window, "keyup", (e: KeyboardEvent) => {
     if (typeof e.key !== "string") return;
     const key = e.key.toUpperCase();
+
+    // macOS never fires keyup for other keys held down together with Meta —
+    // only Meta's own keyup arrives. Treat it as a signal that every other
+    // tracked key must have been released too, or their stale state corrupts
+    // the next press (see https://github.com/solidjs-community/solid-primitives/issues/269).
+    if (key === "META") {
+      resetAll();
+      return;
+    }
+
     pressedKeys = pressedKeys.filter(k => k !== key);
     if (pressedKeys.length === 0) {
       sequence = [];

--- a/packages/keyboard/test/index.test.ts
+++ b/packages/keyboard/test/index.test.ts
@@ -10,10 +10,16 @@ import {
   useKeyDownSequence,
 } from "../src/index.js";
 
-const dispatchKeyEvent = (key: string, type: "keydown" | "keyup") => {
-  const ev = new Event(type) as any;
+const dispatchKeyEvent = (
+  key: string,
+  type: "keydown" | "keyup",
+  extra: Partial<KeyboardEvent> = {},
+) => {
+  const ev = new Event(type, { cancelable: true }) as any;
   ev.key = key;
+  Object.assign(ev, extra);
   window.dispatchEvent(ev);
+  return ev as KeyboardEvent;
 };
 
 describe("useKeyDownList", () => {
@@ -39,6 +45,28 @@ describe("useKeyDownList", () => {
       dispatchKeyEvent("Alt", "keyup");
       flush();
       dispatchKeyEvent("q", "keyup");
+      flush();
+      expect(keys()).toEqual([]);
+
+      dispose();
+    }));
+
+  // https://github.com/solidjs-community/solid-primitives/issues/269
+  // macOS never fires `keyup` for other keys held down together with Meta —
+  // only Meta's own keyup arrives — so releasing Meta must clear the whole
+  // list, or the other key's stale state corrupts the next press.
+  test("clears all keys when Meta is released (macOS suppresses keyup for keys held with Meta)", () =>
+    createRoot(dispose => {
+      const keys = useKeyDownList();
+
+      dispatchKeyEvent("Meta", "keydown", { metaKey: true });
+      flush();
+      dispatchKeyEvent("k", "keydown", { metaKey: true });
+      flush();
+      expect(keys()).toEqual(["META", "K"]);
+
+      // macOS quirk: only Meta's keyup fires; "k" never gets its own keyup
+      dispatchKeyEvent("Meta", "keyup");
       flush();
       expect(keys()).toEqual([]);
 
@@ -287,6 +315,32 @@ describe("createShortcut", () => {
 
       dispatchKeyEvent("Control", "keyup");
       dispatchKeyEvent("a", "keyup");
+
+      dispose();
+    }));
+
+  // https://github.com/solidjs-community/solid-primitives/issues/269
+  // macOS never fires `keyup` for other keys held down together with Meta —
+  // only Meta's own keyup arrives — so a naive implementation accumulates
+  // stale key state and fails (silently skipping preventDefault) on the
+  // second press of the same Meta shortcut.
+  test("repeated Meta shortcut presses keep working (macOS suppresses keyup for keys held with Meta)", () =>
+    createRoot(dispose => {
+      let fired = 0;
+      createShortcut(["Meta", "P"], () => fired++);
+
+      dispatchKeyEvent("Meta", "keydown", { metaKey: true });
+      const p1 = dispatchKeyEvent("p", "keydown", { metaKey: true });
+      expect(fired).toBe(1);
+      expect(p1.defaultPrevented).toBe(true);
+
+      // macOS quirk: only Meta's keyup fires; "p" never gets its own keyup
+      dispatchKeyEvent("Meta", "keyup");
+
+      dispatchKeyEvent("Meta", "keydown", { metaKey: true });
+      const p2 = dispatchKeyEvent("p", "keydown", { metaKey: true });
+      expect(fired).toBe(2);
+      expect(p2.defaultPrevented).toBe(true);
 
       dispose();
     }));


### PR DESCRIPTION
This fixes the meta command issue as described in https://github.com/solidjs-community/solid-primitives/issues/269 for the Solid Primitives 2.0 release.