### PR TITLE
feat: add toggle primitives for issue 280

### DIFF
--- a/.changeset/controlled-signal-toggle-state.md
+++ b/.changeset/controlled-signal-toggle-state.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/controlled-signal": minor
+---
+
+Add `createToggleState` — controllable state for toggle components (checkboxes, switches, toggle buttons), with `isSelected`/`setIsSelected`/`toggle` plus `isDisabled`/`isReadOnly` guards, built on top of `createControllableBooleanSignal`. Adapted from Kobalte's `createToggleState`, which independently needed this exact primitive. See https://github.com/solidjs-community/solid-primitives/issues/280.

--- a/.changeset/signal-builders-toggle.md
+++ b/.changeset/signal-builders-toggle.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/signal-builders": minor
+---
+
+Add `toggle` — wraps a boolean setter with a function that flips the current value, so you don't have to write `setValue(v => !v)` every time. See https://github.com/solidjs-community/solid-primitives/issues/280.

--- a/packages/controlled-signal/README.md
+++ b/packages/controlled-signal/README.md
@@ -111,29 +111,37 @@ setSelected(prev => new Set([...prev, 3]));
 
 ---
 
-## Building a headless component
+### `createToggleState`
 
-```tsx
-import { createControllableBooleanSignal } from "@solid-primitives/controlled-signal";
+Controllable state for toggle components — checkboxes, switches, toggle buttons — built on top of `createControllableBooleanSignal`. Adapted from [Kobalte's `createToggleState`](https://github.com/kobaltedev/kobalte/tree/main/packages/core/src/primitives/create-toggle-state).
 
-function createToggle(props: {
-  pressed?: Accessor<boolean | undefined>;
-  defaultPressed?: Accessor<boolean | undefined>;
-  onChange?: (pressed: boolean) => void;
-}) {
-  const [pressed, setPressed] = createControllableBooleanSignal({
-    value: props.pressed,
-    defaultValue: props.defaultPressed,
-    onChange: props.onChange,
-  });
+```ts
+import { createToggleState } from "@solid-primitives/controlled-signal";
 
-  return { pressed, toggle: () => setPressed(p => !p) };
-}
+const { isSelected, setIsSelected, toggle } = createToggleState({
+  defaultIsSelected: () => false,
+});
+
+toggle(); // isSelected() === true
 ```
+
+**Props:**
+
+| Prop                | Type                       | Description                                             |
+| ------------------- | -------------------------- | --------------------------------------------------------- |
+| `isSelected`        | `Accessor<boolean \| undefined>` | Controlled selected state. When defined, enables controlled mode. |
+| `defaultIsSelected` | `Accessor<boolean \| undefined>` | Initial selected state for uncontrolled mode.        |
+| `isDisabled`        | `Accessor<boolean \| undefined>` | While `true`, `toggle()` and `setIsSelected()` are no-ops. |
+| `isReadOnly`        | `Accessor<boolean \| undefined>` | While `true`, `toggle()` and `setIsSelected()` are no-ops. |
+| `onSelectedChange`  | `(isSelected: boolean) => void`  | Called whenever the selected state would change.     |
+
+**Returns:** `{ isSelected: Accessor<boolean>, setIsSelected: (v: boolean) => void, toggle: () => void }`
+
+Just like `createControllableSignal`, `isSelected` can be omitted for uncontrolled usage, or provided (alongside `onSelectedChange`) to let a parent component drive the state.
 
 ## Credits
 
-This primitive is adapted from the [`create-controllable-signal`](https://github.com/kobaltedev/kobalte/tree/main/packages/core/src/primitives/create-controllable-signal) implementation in [Kobalte](https://github.com/kobaltedev/kobalte) by the Kobalte Contributors, used under the [MIT License](https://github.com/kobaltedev/kobalte/blob/main/LICENSE).
+This primitive is adapted from the [`create-controllable-signal`](https://github.com/kobaltedev/kobalte/tree/main/packages/core/src/primitives/create-controllable-signal) and [`create-toggle-state`](https://github.com/kobaltedev/kobalte/tree/main/packages/core/src/primitives/create-toggle-state) implementations in [Kobalte](https://github.com/kobaltedev/kobalte) by the Kobalte Contributors, used under the [MIT License](https://github.com/kobaltedev/kobalte/blob/main/LICENSE).
 
 ## Changelog
 

--- a/packages/controlled-signal/package.json
+++ b/packages/controlled-signal/package.json
@@ -22,7 +22,8 @@
       "createControllableSignal",
       "createControllableBooleanSignal",
       "createControllableArraySignal",
-      "createControllableSetSignal"
+      "createControllableSetSignal",
+      "createToggleState"
     ],
     "category": "Reactivity",
     "gzip": 395

--- a/packages/controlled-signal/src/index.ts
+++ b/packages/controlled-signal/src/index.ts
@@ -90,3 +90,65 @@ export function createControllableSetSignal<T>(props: CreateControllableSignalPr
   const value: Accessor<Set<T>> = () => _value() ?? new Set();
   return [value, setValue] as const;
 }
+
+export interface CreateToggleStateProps {
+  /** The controlled selected state. */
+  isSelected?: Accessor<boolean | undefined>;
+
+  /**
+   * The default selected state when initially rendered.
+   * Useful when you do not need to control the selected state.
+   */
+  defaultIsSelected?: Accessor<boolean | undefined>;
+
+  /** Whether the selected state cannot be changed by the user. */
+  isDisabled?: Accessor<boolean | undefined>;
+
+  /** Whether the selected state cannot be changed by the user. */
+  isReadOnly?: Accessor<boolean | undefined>;
+
+  /** Called when the selected state changes. */
+  onSelectedChange?: (isSelected: boolean) => void;
+}
+
+export interface ToggleState {
+  /** The selected state. */
+  isSelected: Accessor<boolean>;
+
+  /** Updates the selected state. Ignored while `isDisabled` or `isReadOnly`. */
+  setIsSelected: (isSelected: boolean) => void;
+
+  /** Flips the selected state. Ignored while `isDisabled` or `isReadOnly`. */
+  toggle: () => void;
+}
+
+/**
+ * Provides controllable state management for toggle components — checkboxes, switches,
+ * toggle buttons — built on top of {@link createControllableBooleanSignal}.
+ *
+ * Adapted from Kobalte's `createToggleState`:
+ * https://github.com/kobaltedev/kobalte/tree/main/packages/core/src/primitives/create-toggle-state
+ *
+ * @see https://github.com/solidjs-community/solid-primitives/issues/280
+ */
+export function createToggleState(props: CreateToggleStateProps = {}): ToggleState {
+  const [isSelected, _setIsSelected] = createControllableBooleanSignal({
+    value: props.isSelected,
+    defaultValue: props.defaultIsSelected,
+    onChange: props.onSelectedChange,
+  });
+
+  const setIsSelected = (value: boolean) => {
+    if (!props.isReadOnly?.() && !props.isDisabled?.()) {
+      _setIsSelected(value);
+    }
+  };
+
+  const toggle = () => {
+    if (!props.isReadOnly?.() && !props.isDisabled?.()) {
+      _setIsSelected(value => !value);
+    }
+  };
+
+  return { isSelected, setIsSelected, toggle };
+}

--- a/packages/controlled-signal/test/index.test.ts
+++ b/packages/controlled-signal/test/index.test.ts
@@ -5,6 +5,7 @@ import {
   createControllableBooleanSignal,
   createControllableArraySignal,
   createControllableSetSignal,
+  createToggleState,
 } from "../src/index.js";
 
 describe("createControllableSignal", () => {
@@ -321,5 +322,113 @@ describe("createControllableSetSignal", () => {
       expect(value()).toBeInstanceOf(Set);
       dispose();
     });
+  });
+});
+
+describe("createToggleState", () => {
+  it("defaults to false when no props given", () => {
+    createRoot(dispose => {
+      const { isSelected } = createToggleState();
+      expect(isSelected()).toBe(false);
+      dispose();
+    });
+  });
+
+  it("uses defaultIsSelected when provided", () => {
+    createRoot(dispose => {
+      const { isSelected } = createToggleState({ defaultIsSelected: () => true });
+      expect(isSelected()).toBe(true);
+      dispose();
+    });
+  });
+
+  it("toggle() flips the selected state", () => {
+    createRoot(dispose => {
+      const { isSelected, toggle } = createToggleState({ defaultIsSelected: () => false });
+      toggle();
+      flush();
+      expect(isSelected()).toBe(true);
+      toggle();
+      flush();
+      expect(isSelected()).toBe(false);
+      dispose();
+    });
+  });
+
+  it("setIsSelected() sets the selected state directly", () => {
+    createRoot(dispose => {
+      const { isSelected, setIsSelected } = createToggleState();
+      setIsSelected(true);
+      flush();
+      expect(isSelected()).toBe(true);
+      dispose();
+    });
+  });
+
+  it("calls onSelectedChange when the state changes", () => {
+    createRoot(dispose => {
+      const onSelectedChange = vi.fn();
+      const { toggle } = createToggleState({ defaultIsSelected: () => false, onSelectedChange });
+      toggle();
+      expect(onSelectedChange).toHaveBeenCalledOnce();
+      expect(onSelectedChange).toHaveBeenCalledWith(true);
+      dispose();
+    });
+  });
+
+  it("ignores toggle() and setIsSelected() while isDisabled", () => {
+    createRoot(dispose => {
+      const { isSelected, toggle, setIsSelected } = createToggleState({
+        defaultIsSelected: () => false,
+        isDisabled: () => true,
+      });
+      toggle();
+      flush();
+      expect(isSelected()).toBe(false);
+      setIsSelected(true);
+      flush();
+      expect(isSelected()).toBe(false);
+      dispose();
+    });
+  });
+
+  it("ignores toggle() and setIsSelected() while isReadOnly", () => {
+    createRoot(dispose => {
+      const { isSelected, toggle, setIsSelected } = createToggleState({
+        defaultIsSelected: () => false,
+        isReadOnly: () => true,
+      });
+      toggle();
+      flush();
+      expect(isSelected()).toBe(false);
+      setIsSelected(true);
+      flush();
+      expect(isSelected()).toBe(false);
+      dispose();
+    });
+  });
+
+  it("supports controlled mode", () => {
+    const [external, setExternal] = createSignal(false);
+    const onSelectedChange = vi.fn();
+    let isSelected!: Accessor<boolean>;
+    let toggle!: () => void;
+    const dispose = createRoot(d => {
+      ({ isSelected, toggle } = createToggleState({ isSelected: external, onSelectedChange }));
+      return d;
+    });
+    flush();
+    expect(isSelected()).toBe(false);
+
+    toggle();
+    // controlled mode: internal state doesn't change, only onSelectedChange fires
+    expect(isSelected()).toBe(false);
+    expect(onSelectedChange).toHaveBeenCalledOnce();
+    expect(onSelectedChange).toHaveBeenCalledWith(true);
+
+    setExternal(true);
+    flush();
+    expect(isSelected()).toBe(true);
+    dispose();
   });
 });

--- a/packages/controlled-signal/test/server.test.ts
+++ b/packages/controlled-signal/test/server.test.ts
@@ -4,6 +4,7 @@ import {
   createControllableBooleanSignal,
   createControllableArraySignal,
   createControllableSetSignal,
+  createToggleState,
 } from "../src/index.js";
 
 describe("createControllableSignal on server", () => {
@@ -124,5 +125,27 @@ describe("createControllableSetSignal on server", () => {
   test("always returns a Set (never undefined)", () => {
     const [value] = createControllableSetSignal<string>({});
     expect(value()).toBeInstanceOf(Set);
+  });
+});
+
+describe("createToggleState on server", () => {
+  test("returns false with no props", () => {
+    const { isSelected } = createToggleState();
+    expect(isSelected()).toBe(false);
+  });
+
+  test("returns defaultIsSelected when provided", () => {
+    const { isSelected } = createToggleState({ defaultIsSelected: () => true });
+    expect(isSelected()).toBe(true);
+  });
+
+  test("returns controlled isSelected", () => {
+    const { isSelected } = createToggleState({ isSelected: () => true });
+    expect(isSelected()).toBe(true);
+  });
+
+  test("toggle() does not throw", () => {
+    const { toggle } = createToggleState();
+    expect(() => toggle()).not.toThrow();
   });
 });

--- a/packages/signal-builders/README.md
+++ b/packages/signal-builders/README.md
@@ -29,6 +29,17 @@ Each builder wraps its computation in `createMemo`, so results only update when 
 
 Because each builder returns an `Accessor<T>`, the output of one can be passed directly as input to another:
 
+### Boolean
+
+```ts
+import { toggle } from "@solid-primitives/signal-builders";
+
+const [isOpen, setIsOpen] = createSignal(false);
+const toggleOpen = toggle(setIsOpen);
+
+toggleOpen(); // isOpen() === true
+```
+
 ### Array
 
 ```ts
@@ -83,6 +94,10 @@ solidMessage(); // => "hello, solid"
 ```
 
 ## Builder Reference
+
+### Boolean
+
+- **`toggle`** — wraps a boolean setter with a function that flips the current value
 
 ### Array
 

--- a/packages/signal-builders/src/boolean.ts
+++ b/packages/signal-builders/src/boolean.ts
@@ -1,0 +1,13 @@
+import type { Setter } from "solid-js";
+
+/**
+ * Wraps a boolean setter with a `toggle` function that flips the current value.
+ * @see https://github.com/solidjs-community/solid-primitives/issues/280
+ * @example
+ * const [isOpen, setIsOpen] = createSignal(false);
+ * const toggleOpen = toggle(setIsOpen);
+ * toggleOpen(); // isOpen() === true
+ */
+export function toggle(setValue: Setter<boolean>): () => void {
+  return () => setValue(value => !value);
+}

--- a/packages/signal-builders/src/index.ts
+++ b/packages/signal-builders/src/index.ts
@@ -1,3 +1,6 @@
+// BOOLEAN
+export * from "./boolean.js";
+
 // CONVERT
 export * from "./convert.js";
 

--- a/packages/signal-builders/test/index.test.ts
+++ b/packages/signal-builders/test/index.test.ts
@@ -38,9 +38,30 @@ import {
   get,
   merge,
   update,
+  toggle,
 } from "../src/index.js";
 import { createRoot, createSignal, flush } from "solid-js";
 import { compare } from "@solid-primitives/utils";
+
+// ─── BOOLEAN ────────────────────────────────────────────────────────────────
+
+describe("toggle()", () => {
+  it("flips the current value", () =>
+    createRoot(dispose => {
+      const [isOpen, setIsOpen] = createSignal(false, { ownedWrite: true });
+      const toggleOpen = toggle(setIsOpen);
+
+      expect(isOpen()).toBe(false);
+      toggleOpen();
+      flush();
+      expect(isOpen()).toBe(true);
+      toggleOpen();
+      flush();
+      expect(isOpen()).toBe(false);
+
+      dispose();
+    }));
+});
 
 // ─── CONVERT ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
I took feedback from [the 280 issue](https://github.com/solidjs-community/solid-primitives/issues/280) and ported it to the `next` release which is part of the Solid2 migration. This reminded me that UI component libraries often have this need and sure enough Kobalte had a need for a controlled version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new toggle state primitive for controlled and uncontrolled selection, including direct set and toggle actions.
  * Added a boolean toggle helper for flipping signal values with a single call.
  * Updated documentation and examples to show how to use the new toggle APIs.

* **Bug Fixes**
  * Toggle and selection updates now respect disabled and read-only states.
  * Server-side behavior is covered for the new toggle state feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->