### PR TITLE
enhancement: i18n add missing key fix

### DIFF
--- a/.changeset/i18n-missing-key-handler.md
+++ b/.changeset/i18n-missing-key-handler.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/i18n": minor
+---
+
+Add an optional `onMissingKey` third argument to `translator()`, called when the dictionary is loaded but has no value at the requested path — as opposed to when the dictionary itself isn't available yet, which still resolves to `undefined` regardless (resolves #765). Also export `missingKeyAsPath`, a ready-made handler that falls back to the requested path itself (e.g. `"food.meat"`), making missing translations visible in the UI instead of silently rendering blank. The default behavior (no handler passed) is unchanged — missing keys still resolve to `undefined`, matching the existing `NullableTranslator`/`scopedTranslator` documented behavior — so this is purely additive and opt-in.

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -175,6 +175,30 @@ const t2 = i18n.translator(() => dict, i18n.resolveTemplate);
 t2("hello", { name: "John" }); // => 'hello John!'
 ```
 
+### Missing keys
+
+By default, a path that isn't present in the dictionary resolves to `undefined` — same as when the dictionary itself hasn't loaded yet. To make missing translations visible instead of silently rendering blank, pass an `onMissingKey` handler as the third argument to `translator`. It's only called when the dictionary itself is loaded but the requested path isn't in it.
+
+```ts
+const dict = { hello: "hello!" };
+
+// fall back to the path itself, e.g. "goodbye"
+const t = i18n.translator(() => dict, i18n.resolveTemplate, i18n.missingKeyAsPath);
+
+t("hello"); // => 'hello!'
+t("goodbye"); // => 'goodbye'
+
+// or provide a custom handler, e.g. to report missing translations
+const t2 = i18n.translator(
+  () => dict,
+  i18n.resolveTemplate,
+  path => {
+    reportMissingTranslation(path);
+    return "";
+  },
+);
+```
+
 ### Modules
 
 Splitting the dictionary into multiple modules can be useful when you have a large dictionary and want to avoid loading the entire dictionary at once.

--- a/packages/i18n/src/index.ts
+++ b/packages/i18n/src/index.ts
@@ -212,16 +212,41 @@ export type NullableTranslator<T extends BaseRecordDict, O = string> = <K extend
 ) => Resolved<T[K], O> | undefined;
 
 /**
+ * Called when a lookup finds the dictionary itself but not the requested {@link path} within it —
+ * i.e. a genuinely missing translation, as opposed to the dictionary not being loaded yet.
+ * Its return value is used as the translation result.
+ */
+export type MissingKeyHandler<O = string> = (path: string) => O | undefined;
+
+/**
+ * A {@link MissingKeyHandler} that returns the requested path itself, e.g. `"food.meat"`,
+ * making missing translations visible in the UI instead of silently rendering blank.
+ *
+ * @example
+ * ```ts
+ * const t = i18n.translator(() => flatDict, i18n.resolveTemplate, i18n.missingKeyAsPath);
+ * ```
+ */
+export const missingKeyAsPath: MissingKeyHandler<any> = path => path;
+
+/**
  * Create a translator function that will resolve the path in the dictionary and return the value.
  *
  * If the value is a function it will call it with the provided arguments.
  *
  * If the value is a string it will resolve the template using {@link resolveTemplate} with the provided arguments.
  *
+ * If the dictionary exists but has no value at {@link path}, {@link onMissingKey} is called (if provided)
+ * and its result is returned. By default (no {@link onMissingKey}), a missing key resolves to `undefined`,
+ * same as when the dictionary itself isn't available yet.
+ *
  * Otherwise it will return the value as is.
  *
  * @param dict A function that returns the dictionary to use for translation. Will be called on each translation.
  * @param resolveTemplate A function that will resolve the template. Defaults to {@link identityResolveTemplate}.
+ * @param onMissingKey Called with the requested path when the dictionary exists but has no value there.
+ * Use {@link missingKeyAsPath} to fall back to the path itself, or provide a custom handler,
+ * e.g. to log/report missing translations.
  *
  * @example
  * ```ts
@@ -244,25 +269,31 @@ export type NullableTranslator<T extends BaseRecordDict, O = string> = <K extend
 export function translator<T extends BaseRecordDict, O = string>(
   dict: () => T,
   resolveTemplate?: TemplateResolver<O>,
+  onMissingKey?: MissingKeyHandler<O>,
 ): Translator<T, O>;
 export function translator<T extends BaseRecordDict, O = string>(
   dict: () => T | undefined,
   resolveTemplate?: TemplateResolver<O>,
+  onMissingKey?: MissingKeyHandler<O>,
 ): NullableTranslator<T, O>;
 export function translator<T extends BaseRecordDict>(
   dict: () => T | undefined,
   resolveTemplate: TemplateResolver = identityResolveTemplate,
+  onMissingKey?: MissingKeyHandler,
 ): any {
   return (path: string, ...args: any[]) => {
     if (path[0] === ".") path = path.slice(1);
 
-    const value = dict()?.[path];
+    const currentDict = dict();
+    const value = currentDict?.[path];
 
     switch (typeof value) {
       case "function":
         return value(...args);
       case "string":
         return resolveTemplate(value, args[0]);
+      case "undefined":
+        return currentDict !== undefined && onMissingKey ? onMissingKey(path) : value;
       default:
         return value;
     }

--- a/packages/i18n/test/index.test.ts
+++ b/packages/i18n/test/index.test.ts
@@ -101,6 +101,42 @@ describe("translator", () => {
     expect(t("data.formatList", ["John", "Kate", "Tester"])).toBe("John, Kate i Tester");
     expect(t("jsx", "Tester")).toEqual(plDict.jsx("Tester"));
   });
+
+  test("missing key returns undefined by default", () => {
+    const dict = i18n.flatten(enDict) as any;
+    const missingT = i18n.translator(() => dict, i18n.resolveTemplate);
+    expect(missingT("does.not.exist" as any)).toBeUndefined();
+  });
+
+  test("missing key defers to onMissingKey when the dict is loaded", () => {
+    const dict = i18n.flatten(enDict) as any;
+    const missingT = i18n.translator(() => dict, i18n.resolveTemplate, i18n.missingKeyAsPath);
+    expect(missingT("does.not.exist" as any)).toBe("does.not.exist");
+  });
+
+  test("onMissingKey is not called while the dict itself is unavailable", () => {
+    const onMissingKey = (path: string) => `missing:${path}`;
+    const missingT = i18n.translator(() => undefined, i18n.resolveTemplate, onMissingKey);
+    expect(missingT("hello" as any)).toBeUndefined();
+  });
+
+  test("onMissingKey does not fire for present falsy values", () => {
+    const dict = { zero: 0, empty: "", isFalse: false, isNull: null } as any;
+    const calls: string[] = [];
+    const t2 = i18n.translator(
+      () => dict,
+      i18n.resolveTemplate,
+      path => {
+        calls.push(path);
+        return "missing";
+      },
+    );
+    expect(t2("zero" as any)).toBe(0);
+    expect(t2("empty" as any)).toBe("");
+    expect(t2("isFalse" as any)).toBe(false);
+    expect(t2("isNull" as any)).toBe(null);
+    expect(calls).toEqual([]);
+  });
 });
 
 describe("scopedTranslator", () => {


### PR DESCRIPTION
- Adds an optional `onMissingKey` third argument to `translator()`, called only when the
  dictionary is loaded but has no value at the requested path (as opposed to the dictionary
  itself not being ready yet, which still resolves to `undefined`).
- Exports `missingKeyAsPath`, a ready-made handler that falls back to the requested path
  itself (e.g. `t("food.meat")` → `"food.meat"`), making missing translations visible in
  the UI instead of silently rendering blank.
- Default behavior is unchanged (still `undefined`) — this is purely additive/opt-in, so it
  doesn't break the documented `NullableTranslator`/`scopedTranslator` semantics.

Resolves #765.

## Test plan
- [x] Added tests: default-undefined, `missingKeyAsPath`, custom handler, handler not fired
      while the dict itself is loading, handler not fired for legitimate falsy values
      (`0`/`""`/`false`/`null`)
- [x] `pnpm test` (17 browser + 4 SSR, all passing)
- [x] `tsc --noEmit` clean

Patches https://github.com/solidjs-community/solid-primitives/issues/765 and the good suggestions provided there.