### PR TITLE
enhancement: add anyOrder to createShortcut

### DIFF
--- a/.changeset/keyboard-any-order-shortcut.md
+++ b/.changeset/keyboard-any-order-shortcut.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/keyboard": minor
+---
+
+Add an `anyOrder` option to `createShortcut` (resolves #663). When `true`, the keys can be pressed in any order — e.g. `Shift+Control+M` as well as `Control+Shift+M` — as long as they all end up held down together, matching how most editors (like VS Code) handle shortcuts. Disabled by default, so this is non-breaking; `keys` still has to be pressed in the given order unless the option is set.

--- a/packages/keyboard/README.md
+++ b/packages/keyboard/README.md
@@ -157,6 +157,7 @@ Creates a keyboard shortcut observer. The provided callback will be called when 
   - `preventDefault` — call `e.preventDefault()` on the keyboard event, when the specified key is pressed. _(Defaults to `true`)_
   - `requireReset` — If `true`, the shortcut will only be triggered once until all of the keys stop being pressed. Disabled by default.
   - `ignoreWithinInputs` — If `true`, the shortcut is ignored while focus is on an `input`, `textarea`, `select`, or `contenteditable` element, so it doesn't interrupt typing. Disabled by default.
+  - `anyOrder` — If `true`, the keys can be pressed in any order (e.g. `Shift + Control` as well as `Control + Shift`), as long as they all end up held down together. Disabled by default, requiring `keys` to be pressed in order.
 
 ```tsx
 import { createShortcut } from "@solid-primitives/keyboard";
@@ -186,6 +187,15 @@ createShortcut(["S"], () => console.log("S was pressed"), { ignoreWithinInputs: 
 ```
 
 Combos that include a modifier (e.g. `Control + S`) don't have this problem, since the modifier itself prevents a character from being typed — `ignoreWithinInputs` is usually unnecessary for those.
+
+### Matching keys in any order
+
+By default, `keys` must be pressed in the order given — `["Control", "Shift", "M"]` only matches Control, then Shift, then M. Set `anyOrder: true` to match the combo regardless of press order, similar to how most editors handle shortcuts:
+
+```tsx
+// triggers for both Control+Shift+M and Shift+Control+M
+createShortcut(["Control", "Shift", "M"], () => console.log("M was pressed"), { anyOrder: true });
+```
 
 ## `createKeyDown`
 

--- a/packages/keyboard/src/index.ts
+++ b/packages/keyboard/src/index.ts
@@ -15,6 +15,16 @@ function equalsKeyHoldSequence(sequence: string[][], model: string[]): boolean {
   return true;
 }
 
+/** Does `subset` contain only keys that are also present in `superset`? */
+function isKeySubset(subset: string[], superset: string[]): boolean {
+  return new Set(subset).isSubsetOf(new Set(superset));
+}
+
+/** Do `a` and `b` contain exactly the same keys, regardless of order? */
+function isSameKeySet(a: string[], b: string[]): boolean {
+  return new Set(a).symmetricDifference(new Set(b)).size === 0;
+}
+
 /** Is the event target an editable form control, or inside a `contenteditable` element? */
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
@@ -290,6 +300,8 @@ export function createKeyHold(
  *   or `contenteditable` element, so typing isn't interrupted. Disabled by default — enable it for shortcuts
  *   made of plain, unmodified keys (e.g. a single letter); combos like `Control+S` are usually fine either way,
  *   since the modifier prevents a character from being typed.
+ * - `anyOrder` — If `true`, the keys can be pressed in any order (e.g. `Shift+Control` as well as `Control+Shift`),
+ *   as long as they all end up held down together. Disabled by default, requiring `keys` to be pressed in order.
  *
  * @example
  * ```ts
@@ -299,6 +311,9 @@ export function createKeyHold(
  *
  * // won't fire while typing in a text field
  * createShortcut(["S"], () => console.log("S was pressed"), { ignoreWithinInputs: true });
+ *
+ * // triggers for both Control+Shift+M and Shift+Control+M
+ * createShortcut(["Control", "Shift", "M"], () => console.log("M was pressed"), { anyOrder: true });
  * ```
  */
 export function createShortcut(
@@ -308,6 +323,7 @@ export function createShortcut(
     preventDefault?: boolean;
     requireReset?: boolean;
     ignoreWithinInputs?: boolean;
+    anyOrder?: boolean;
   } = {},
 ): void {
   if (isServer || !keys.length) {
@@ -315,7 +331,12 @@ export function createShortcut(
   }
 
   keys = keys.map(key => key.toUpperCase());
-  const { preventDefault = true, requireReset = false, ignoreWithinInputs = false } = options;
+  const {
+    preventDefault = true,
+    requireReset = false,
+    ignoreWithinInputs = false,
+    anyOrder = false,
+  } = options;
 
   // Track pressed keys and sequence locally with plain JS state rather than
   // reactive signals. A signal reads from event listeners return
@@ -359,14 +380,20 @@ export function createShortcut(
     if (requireReset) {
       if (reset) return;
       if (sequence.length < keys.length) {
-        if (equalsKeyHoldSequence(sequence, keys.slice(0, sequence.length))) {
+        const holding = sequence.at(-1) ?? [];
+        const matches = anyOrder
+          ? isKeySubset(holding, keys)
+          : equalsKeyHoldSequence(sequence, keys.slice(0, sequence.length));
+        if (matches) {
           preventDefault && e.preventDefault();
         } else {
           reset = true;
         }
       } else {
         reset = true;
-        if (equalsKeyHoldSequence(sequence, keys)) {
+        const holding = sequence.at(-1) ?? [];
+        const matches = anyOrder ? isSameKeySet(holding, keys) : equalsKeyHoldSequence(sequence, keys);
+        if (matches) {
           preventDefault && e.preventDefault();
           callback(e);
         }
@@ -376,14 +403,21 @@ export function createShortcut(
       if (!last) return;
 
       if (preventDefault && last.length < keys.length) {
-        if (arrayEquals(last, keys.slice(0, keys.length - 1))) {
+        const isOneKeyAway = anyOrder
+          ? last.length === keys.length - 1 && isKeySubset(last, keys)
+          : arrayEquals(last, keys.slice(0, keys.length - 1));
+        if (isOneKeyAway) {
           e.preventDefault();
         }
         return;
       }
-      if (arrayEquals(last, keys)) {
+      const isComplete = anyOrder ? isSameKeySet(last, keys) : arrayEquals(last, keys);
+      if (isComplete) {
         const prev = sequence.at(-2);
-        if (!prev || arrayEquals(prev, keys.slice(0, keys.length - 1))) {
+        const prevWasOneKeyAway = anyOrder
+          ? !!prev && prev.length === keys.length - 1 && isKeySubset(prev, keys)
+          : !!prev && arrayEquals(prev, keys.slice(0, keys.length - 1));
+        if (!prev || prevWasOneKeyAway) {
           preventDefault && e.preventDefault();
           callback(e);
         }

--- a/packages/keyboard/test/index.test.ts
+++ b/packages/keyboard/test/index.test.ts
@@ -444,4 +444,91 @@ describe("createShortcut", () => {
         dispose();
       }));
   });
+
+  // https://github.com/solidjs-community/solid-primitives/issues/663
+  describe("anyOrder", () => {
+    test("fires regardless of which modifier is pressed first", () =>
+      createRoot(dispose => {
+        let fired = 0;
+        createShortcut(["Shift", "Control", "M"], () => fired++, { anyOrder: true });
+
+        dispatchKeyEvent("Control", "keydown");
+        dispatchKeyEvent("Shift", "keydown");
+        dispatchKeyEvent("m", "keydown");
+        expect(fired).toBe(1);
+
+        dispatchKeyEvent("m", "keyup");
+        dispatchKeyEvent("Shift", "keyup");
+        dispatchKeyEvent("Control", "keyup");
+        dispose();
+      }));
+
+    test("does not fire for a partial or unrelated key set", () =>
+      createRoot(dispose => {
+        let fired = 0;
+        createShortcut(["Control", "Shift", "M"], () => fired++, { anyOrder: true });
+
+        dispatchKeyEvent("Shift", "keydown");
+        expect(fired).toBe(0);
+
+        dispatchKeyEvent("q", "keydown");
+        dispatchKeyEvent("Control", "keydown");
+        dispatchKeyEvent("m", "keydown");
+        expect(fired).toBe(0);
+
+        dispatchKeyEvent("q", "keyup");
+        dispatchKeyEvent("Shift", "keyup");
+        dispatchKeyEvent("Control", "keyup");
+        dispatchKeyEvent("m", "keyup");
+        dispose();
+      }));
+
+    test("requireReset — fires only once until keys are released, in any order", () =>
+      createRoot(dispose => {
+        let fired = 0;
+        createShortcut(["Control", "Shift", "M"], () => fired++, {
+          anyOrder: true,
+          requireReset: true,
+        });
+
+        dispatchKeyEvent("Shift", "keydown");
+        dispatchKeyEvent("Control", "keydown");
+        dispatchKeyEvent("m", "keydown");
+        expect(fired).toBe(1);
+
+        // still held — shouldn't refire
+        dispatchKeyEvent("m", "keydown", { repeat: true });
+        expect(fired).toBe(1);
+
+        dispatchKeyEvent("m", "keyup");
+        dispatchKeyEvent("Shift", "keyup");
+        dispatchKeyEvent("Control", "keyup");
+
+        dispatchKeyEvent("Control", "keydown");
+        dispatchKeyEvent("Shift", "keydown");
+        dispatchKeyEvent("m", "keydown");
+        expect(fired).toBe(2);
+
+        dispatchKeyEvent("m", "keyup");
+        dispatchKeyEvent("Shift", "keyup");
+        dispatchKeyEvent("Control", "keyup");
+        dispose();
+      }));
+
+    test("defaults to order-sensitive matching when not set", () =>
+      createRoot(dispose => {
+        let fired = 0;
+        createShortcut(["Control", "Shift", "M"], () => fired++);
+
+        dispatchKeyEvent("Shift", "keydown");
+        dispatchKeyEvent("Control", "keydown");
+        dispatchKeyEvent("m", "keydown");
+        expect(fired).toBe(0);
+
+        dispatchKeyEvent("m", "keyup");
+        dispatchKeyEvent("Shift", "keyup");
+        dispatchKeyEvent("Control", "keyup");
+        dispose();
+      }));
+  });
 });


### PR DESCRIPTION
Summary of changes for issue #663:

- **`packages/keyboard/src/index.ts`** — added an opt-in `anyOrder?: boolean` option to `createShortcut` (default `false`, fully backward compatible). Added `isKeySubset`/`isSameKeySet` helpers and swapped the order-sensitive comparisons for set-based ones only when `anyOrder` is enabled, in both the `requireReset` and default matching paths.
- **`packages/keyboard/test/index.test.ts`** — added a 4-test `anyOrder` suite (fires regardless of press order, ignores partial/unrelated key sets, works with `requireReset`, and confirms order-sensitive behavior is unchanged by default). All 25 tests in the package pass; typecheck is clean.
- **`packages/keyboard/README.md`** — documented the new option and added a "Matching keys in any order" example.
- **`.changeset/keyboard-any-order-shortcut.md`** — new `minor` changeset for `@solid-primitives/keyboard`, referencing issue #663.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `createShortcut` now supports an `anyOrder` option, allowing shortcut keys to be pressed in any order as long as they’re all held together.
  * This new behavior is opt-in, so existing order-based shortcuts continue to work as before.

* **Bug Fixes**
  * Improved shortcut matching for key combinations with modifier keys and repeated key presses.
  * Added coverage to ensure partial or unrelated key sequences do not trigger shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->