### PR TITLE
enhancement: adding firstIndex and lastIndex to virtual

### DIFF
--- a/.changeset/virtual-first-last-index.md
+++ b/.changeset/virtual-first-last-index.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/virtual": patch
+---
+
+expose `firstIndex` and `lastIndex` in virtual lists, to support counting

--- a/packages/virtual/README.md
+++ b/packages/virtual/README.md
@@ -28,7 +28,12 @@ pnpm add @solid-primitives/virtual
 
 `createVirtualList` is a headless utility for constructing your own virtualized list components with maximum flexibility.
 
-`virtual` is an accessor returning `{ containerHeight, viewerTop, visibleItems }` — call it to read the current values. When rendering `visibleItems` with `<For>`, pass `keyed={false}` so each item is provided as an `Accessor` (`<For>` defaults to `keyed={true}`, which passes raw values instead).
+`virtual` is an accessor returning `{ containerHeight, viewerTop, visibleItems, firstIndex, lastIndex }` — call it to read the current values. When rendering `visibleItems` with `<For>`, pass `keyed={false}` so each item is provided as an `Accessor` (`<For>` defaults to `keyed={true}`, which passes raw values instead).
+
+- `firstIndex` is the index (into the original `items` list) of the first rendered item.
+- `lastIndex` is the index of the last rendered item, or `undefined` if the list is empty.
+
+Together they're useful for things like "showing items X-Y of Z" counters, since `visibleItems` alone doesn't tell you where those items sit in the original list.
 
 ```tsx
 function MyComp(): JSX.Element {

--- a/packages/virtual/src/index.tsx
+++ b/packages/virtual/src/index.tsx
@@ -16,6 +16,8 @@ type VirtualListReturn<T extends readonly any[]> = [
     containerHeight: number;
     viewerTop: number;
     visibleItems: T;
+    firstIndex: number;
+    lastIndex: number | undefined;
   }>,
   onScroll: (e: Event) => void,
 ];
@@ -57,6 +59,9 @@ export function createVirtualList<T extends readonly any[]>({
         containerHeight: resolvedItems.length * rowH,
         viewerTop: firstIdx * rowH,
         visibleItems: resolvedItems.slice(firstIdx, lastIdx) as unknown as T,
+        firstIndex: firstIdx,
+        // -1 because slice is an exclusive range
+        lastIndex: lastIdx > 0 ? lastIdx - 1 : undefined,
       };
     },
     e => {

--- a/packages/virtual/test/index.test.tsx
+++ b/packages/virtual/test/index.test.tsx
@@ -57,6 +57,30 @@ describe("createVirtualList", () => {
       dispose();
     }));
 
+  test("returns firstIndex representing the first index of the visibleList", () =>
+    createRoot(dispose => {
+      const [virtual] = createVirtualList({
+        items: TEST_LIST,
+        rootHeight: 20,
+        rowHeight: 10,
+      });
+
+      expect(virtual().firstIndex).toEqual(0);
+      dispose();
+    }));
+
+  test("returns lastIndex representing the last item in the visibleList's index", () =>
+    createRoot(dispose => {
+      const [virtual] = createVirtualList({
+        items: TEST_LIST,
+        rootHeight: 20,
+        rowHeight: 10,
+      });
+
+      expect(virtual().lastIndex).toEqual(2);
+      dispose();
+    }));
+
   test("returns onScroll which sets viewerTop and visibleItems based on rootElement's scrolltop", () =>
     createRoot(dispose => {
       const el = document.createElement("div");
@@ -69,18 +93,24 @@ describe("createVirtualList", () => {
 
       expect(virtual().visibleItems).toEqual([0, 1, 2]);
       expect(virtual().viewerTop).toEqual(0);
+      expect(virtual().firstIndex).toEqual(0);
+      expect(virtual().lastIndex).toEqual(2);
 
       el.scrollTop += 10;
 
       // no change until onScroll is called
       expect(virtual().visibleItems).toEqual([0, 1, 2]);
       expect(virtual().viewerTop).toEqual(0);
+      expect(virtual().firstIndex).toEqual(0);
+      expect(virtual().lastIndex).toEqual(2);
 
       onScroll(TARGETED_SCROLL_EVENT(el));
       flush();
 
       expect(virtual().visibleItems).toEqual([0, 1, 2, 3]);
       expect(virtual().viewerTop).toEqual(0);
+      expect(virtual().firstIndex).toEqual(0);
+      expect(virtual().lastIndex).toEqual(3);
 
       el.scrollTop += 10;
       onScroll(TARGETED_SCROLL_EVENT(el));
@@ -88,6 +118,8 @@ describe("createVirtualList", () => {
 
       expect(virtual().visibleItems).toEqual([1, 2, 3, 4]);
       expect(virtual().viewerTop).toEqual(10);
+      expect(virtual().firstIndex).toEqual(1);
+      expect(virtual().lastIndex).toEqual(4);
 
       el.scrollTop -= 10;
       onScroll(TARGETED_SCROLL_EVENT(el));
@@ -95,6 +127,8 @@ describe("createVirtualList", () => {
 
       expect(virtual().visibleItems).toEqual([0, 1, 2, 3]);
       expect(virtual().viewerTop).toEqual(0);
+      expect(virtual().firstIndex).toEqual(0);
+      expect(virtual().lastIndex).toEqual(3);
 
       el.scrollTop -= 10;
       onScroll(TARGETED_SCROLL_EVENT(el));
@@ -102,6 +136,8 @@ describe("createVirtualList", () => {
 
       expect(virtual().visibleItems).toEqual([0, 1, 2]);
       expect(virtual().viewerTop).toEqual(0);
+      expect(virtual().firstIndex).toEqual(0);
+      expect(virtual().lastIndex).toEqual(2);
 
       dispose();
     }));
@@ -125,6 +161,8 @@ describe("createVirtualList", () => {
 
       expect(virtual().visibleItems).toEqual([997, 998, 999]);
       expect(virtual().viewerTop).toEqual(9_970);
+      expect(virtual().firstIndex).toEqual(997);
+      expect(virtual().lastIndex).toEqual(999);
 
       dispose();
     }));
@@ -145,6 +183,8 @@ describe("createVirtualList", () => {
       flush();
 
       expect(virtual().visibleItems).toEqual([8, 9, 10, 11, 12, 13]);
+      expect(virtual().firstIndex).toEqual(8);
+      expect(virtual().lastIndex).toEqual(13);
 
       dispose();
     }));
@@ -183,6 +223,50 @@ describe("createVirtualList", () => {
       expect(virtual().containerHeight).toEqual(0);
       expect(virtual().viewerTop).toEqual(0);
       expect(virtual().visibleItems).toEqual([]);
+      expect(virtual().firstIndex).toEqual(0);
+      expect(virtual().lastIndex).toEqual(undefined);
+
+      dispose();
+    }));
+
+  test("lastIndex is undefined in an empty list", () =>
+    createRoot(dispose => {
+      const [virtual] = createVirtualList({
+        items: [],
+        rootHeight: 20,
+        rowHeight: 10,
+      });
+
+      expect(virtual().lastIndex).toEqual(undefined);
+      dispose();
+    }));
+
+  test("lastIndex is 0 in a singleton list", () =>
+    createRoot(dispose => {
+      const [virtual] = createVirtualList({
+        items: [10],
+        rootHeight: 20,
+        rowHeight: 10,
+      });
+
+      expect(virtual().lastIndex).toEqual(0);
+      dispose();
+    }));
+
+  test("handles singleton list", () =>
+    createRoot(dispose => {
+      const [virtual] = createVirtualList({
+        items: [10],
+        rootHeight: 20,
+        rowHeight: 10,
+        overscanCount: 0,
+      });
+
+      expect(virtual().containerHeight).toEqual(10);
+      expect(virtual().viewerTop).toEqual(0);
+      expect(virtual().visibleItems).toEqual([10]);
+      expect(virtual().firstIndex).toEqual(0);
+      expect(virtual().lastIndex).toEqual(0);
 
       dispose();
     }));


### PR DESCRIPTION
- packages/virtual/src/index.tsx`: added `firstIndex: number` and `lastIndex: number | undefined` to `VirtualListReturn`'s type and the returned object. `lastIndex` is `lastIdx - 1` (since slicing is exclusive) and `undefined` for an empty list.
- `packages/virtual/test/index.test.tsx`: added the equivalent test cases from the PR (basic values, scroll updates, overscan, bottom-of-list, empty list, singleton list), adapted to this repo's `createRoot`/`flush` test pattern for Solid 2.0.
- Added a changeset (`patch` bump for `@solid-primitives/virtual`).