### PR TITLE
Add Publish JSR workflow (dispatch-only, no automatic triggers)

### DIFF
--- a/.github/workflows/jsr-publish.yml
+++ b/.github/workflows/jsr-publish.yml
@@ -1,0 +1,62 @@
+name: Publish JSR
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Run the real JSR publish after the dry run passes
+        required: true
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+jobs:
+  publish:
+    name: Publish JSR workspace
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Install Dependencies
+        run: pnpm i
+
+      - name: Install Deno dependencies
+        run: |
+          if [ -f deno.lock ]; then
+            deno ci
+          else
+            deno install
+          fi
+
+      - name: Sync deno.jsonc versions from package.json
+        run: pnpm jsr:sync-versions
+
+      - name: Build packages
+        run: pnpm build
+
+      - name: Publish dry run
+        run: deno publish --dry-run --check --allow-slow-types
+
+      - name: Publish to JSR
+        if: ${{ inputs.publish == 'true' }}
+        run: deno publish --check --allow-slow-types


### PR DESCRIPTION
Lets maintainers manually run JSR publishing against the next (2.0) branch. workflow_dispatch-only, so it never runs automatically and does not affect main/1.0 CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a manually triggered release workflow for publishing packages to JSR.
  * Added validation and build checks before publication.
  * Supports dry-run verification, with actual publishing enabled only when explicitly selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->