### PR TITLE
patch: don't fire outside-interaction

### DIFF
--- a/.changeset/interaction-orphaned-listener-fix.md
+++ b/.changeset/interaction-orphaned-listener-fix.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/interaction": patch
+---
+
+fix: `makeInteractOutside`/`createInteractOutside` firing outside-interaction callbacks from an orphaned instance whose watched element was removed from the document before its reactive owner disposed (a common race when a dismissable layer closes and a new one opens in quick succession)

--- a/packages/interaction/src/index.ts
+++ b/packages/interaction/src/index.ts
@@ -325,6 +325,16 @@ export function makeInteractOutside<T extends Element>(
   let ownerDoc: Document = el.ownerDocument;
 
   const isEventOutside = (e: Event): boolean => {
+    // `el` can be removed from the document by its owner (e.g. a `<Show>`
+    // unmounting a dismissable layer) before this instance's reactive owner
+    // gets around to calling the cleanup this function returns (listener
+    // removal is tied to `onCleanup`, which can lag a tick behind the DOM
+    // change that triggered it). Once `el` is disconnected there's nothing
+    // left to protect, and `el.contains(target)` would incorrectly read as
+    // "not contained" for every target — including ones legitimately inside
+    // a *new* instance that opened in that same window — misreporting them
+    // as outside interactions on this now-orphaned instance.
+    if (!el.isConnected) return false;
     const target = e.target as Element | null;
     if (!(target instanceof Element)) return false;
     if (!ownerDoc.contains(target)) return false;

--- a/packages/interaction/test/interact-outside.test.ts
+++ b/packages/interaction/test/interact-outside.test.ts
@@ -283,5 +283,36 @@ describe("createInteractOutside", () => {
       outside.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
       expect(mocks.onFocusOutside).not.toHaveBeenCalled();
     });
+
+    it("does not fire for a still-mounted instance whose watched element was removed from the document before its reactive root disposed", () => {
+      // Reproduces a real-world race: a dismissable layer's DOM subtree is
+      // removed synchronously (e.g. by a Solid `<Show>`) when it closes, but
+      // the reactive owner that will call `onCleanup` (removing this
+      // instance's document-level listeners) can be scheduled to run a tick
+      // later. A second layer opening in that window must not have its
+      // legitimate "inside" interactions misread as "outside" by the first,
+      // now-orphaned instance.
+      const first = setupTest("div", "div");
+
+      // Simulate the DOM removal that happens immediately on close, while
+      // deliberately *not* calling `first.cleanup()` yet — this is the gap
+      // between DOM removal and reactive disposal that the real bug lives in.
+      first.inside.remove();
+
+      const second = setupTest("div", "div");
+
+      // An interaction with the second (live) instance's own content.
+      second.inside.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+
+      // The second instance's own element is "inside" itself, so it must not
+      // fire. The first (orphaned) instance's callbacks must not fire either
+      // — its watched element is disconnected, so it has nothing left to
+      // protect.
+      expect(second.mocks.onFocusOutside).not.toHaveBeenCalled();
+      expect(first.mocks.onFocusOutside).not.toHaveBeenCalled();
+
+      first.cleanup();
+      second.cleanup();
+    });
   });
 });


### PR DESCRIPTION
makeInteractOutside` (used by Kobalte's `DismissableLayer` for outside-click/focus detection) registers its `document`-level `focusin`/`pointerdown` listeners immediately, but tears them down via `onCleanup`, tied to reactive owner disposal. When a watched element is removed from the document synchronously (e.g. a `<Show>` unmounting on close) but the owner's actual disposal runs a tick later, the old instance's listener is still live. Since its `el` no longer contains anything, it reads *every* subsequent event as "outside" — including ones legitimately inside a brand-new instance that opened in that same window — firing a spurious dismiss.