### PR TITLE
patch: general improvements and fixes

### DIFF
--- a/.changeset/a11y-dataset-hydration-safety.md
+++ b/.changeset/a11y-dataset-hydration-safety.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/a11y": patch
+---
+
+`createFormControl`'s `dataset` accessor is now a plain getter instead of a `createMemo` — no behavior or type change, but it removes an unnecessary render-body compute-form memo (memoizing a handful of cheap string/undefined fields buys nothing) that would otherwise consume a hydration id in every consuming app.

--- a/.changeset/controlled-props-void-component-types.md
+++ b/.changeset/controlled-props-void-component-types.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/controlled-props": patch
+---
+
+`BoolProp`, `NumberProp`, `RangeProp`, and `StringProp` are now typed `VoidComponent` instead of `Component`, since none of them accept or render children. Type-only change, no behavior difference.

--- a/.changeset/focus-restore-primitive.md
+++ b/.changeset/focus-restore-primitive.md
@@ -1,0 +1,7 @@
+---
+"@solid-primitives/focus": minor
+---
+
+Add `createFocusRestore` — saves the currently focused element while active and restores focus to it once deactivated, without trapping focus or managing tab order. For non-modal surfaces (Popover, Tooltip, Menu) that should return focus to their trigger on close but must not intercept Tab navigation while open; for modal dialogs needing both behaviors, use `createFocusTrap`'s existing `restoreFocus` option instead.
+
+Also fixed a stale-closure race shared between `createFocusTrap` and the new `createFocusRestore`: the restore target used to be read from a mutable outer variable inside a deferred `afterPaint` callback, so a fast reactivate-before-restore-fires cycle could restore focus to the wrong element. Both primitives now share one internal helper that captures the target synchronously at deactivation time.

--- a/.changeset/interaction-inert-option.md
+++ b/.changeset/interaction-inert-option.md
@@ -1,0 +1,7 @@
+---
+"@solid-primitives/interaction": minor
+---
+
+`createHideOutside`/`ariaHideOutside` gain an opt-in `inert` option — in addition to `aria-hidden`, also sets the `inert` attribute on hidden elements, ref-counted alongside `aria-hidden`. `aria-hidden` alone only affects the accessibility tree; `inert` additionally removes hidden content from focus order, tab order, and pointer/text-selection interaction. Defaults to `false` (no behavior change for existing callers).
+
+Also hardened the module-scope ref-counting/observer-stack state (used internally by both the existing `aria-hidden` tracking and the new `inert` tracking) against duplicate installed copies of this package, via the same `globalRegistry` pattern used in `@solid-primitives/scroll`.

--- a/.changeset/intersection-observer-notreadyerror-fix.md
+++ b/.changeset/intersection-observer-notreadyerror-fix.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/intersection-observer": patch
+---
+
+Fix `isVisible()`/`createVisibilityObserver()`'s `visible()` throwing a locally-defined `NotReadyError` lookalike class instead of the real one exported from `solid-js`. Because the local class wasn't `instanceof` the real `NotReadyError`, `<Loading>` boundaries never actually caught it — despite the documented `<Loading>` integration, calling `isVisible`/`visible` before the first observation would crash rendering instead of showing the Loading fallback. `NotReadyError` is now imported and re-exported from `solid-js` directly, so `<Loading>` (and any `instanceof` check) works as documented.

--- a/.changeset/notification-affects-pending.md
+++ b/.changeset/notification-affects-pending.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/notification": patch
+---
+
+`createNotificationPermission`'s `requestPermission` now calls `affects(permission)`, so `isPending(permission)` reads `true` for the duration of the request — the standard Solid 2.0 idiom for callers who don't want the existing bespoke `pending` accessor, which is unchanged and kept for backward compatibility.

--- a/.changeset/scroll-duplicate-copy-safety.md
+++ b/.changeset/scroll-duplicate-copy-safety.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/scroll": patch
+---
+
+`createPreventScroll`'s active-instance stack and body-style ref-counts now live in a `globalRegistry` (keyed on `globalThis`, not module-scope bindings), so they stay correct even if the app's dependency graph ends up with more than one copy of this package installed — module-scope state would otherwise be split across copies, breaking the "topmost instance" ref-counting. Also replaced a hand-rolled `contains()` helper with the equivalent one already exported from `@solid-primitives/utils`. No API changes.

--- a/.changeset/utils-global-registry.md
+++ b/.changeset/utils-global-registry.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/utils": minor
+---
+
+Add `globalRegistry(key, init)` — returns a singleton value keyed by `key` on `globalThis` (via `Symbol.for`), shared across every copy of the calling module loaded in the same JS realm. Use it instead of a plain module-scope `let`/`const` for state (ref-counts, active-instance stacks) that must stay consistent even if the app's dependency graph ends up with more than one installed copy of a package.

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ pages
 
 # temp
 _temp_*
+.hydration-harness-*
 
 # Local Netlify folder
 .netlify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,19 @@ Solid uses the `create` prefix to define a primitive that provides reactive util
 
 Solid Primitives is mostly about supplying 80-90% of the common-use cases for the end-user. We prefer to be less prescriptive than other hook libraries such as VueUse and supply granular solutions as opposed to monolithic primitives. The remaining 10-20% of complex use cases are likely not to be covered with this library. This is on purpose to limit the potential of bloat and extended complexity. This project strives to provide foundations and not cumulative solutions. We expect the broader ecosystem will fill the remaining need as further composition to this projects effort. This allows for just the right amount of prescription and opinion.
 
+### Hydration Safety
+
+A primitive that creates a **compute-form** `createSignal(fn)` or `createMemo(fn)` in a component's render body participates in Solid's per-owner hydration id allocation, the same as a DOM element the JSX compiler stamps a hydration key onto. Most primitives that return a derived reactive value (`createPagination`, `createHideOutside`'s internals, anything backed by `createMemo`) fall into this category — it's the norm, not the exception, and on its own isn't a defect. Classify each package's primitives as one of:
+
+- **Effect-only** — no render-body `createSignal(fn)`/`createMemo`, only `createEffect`/`createSignal(value)`/plain functions. Always hydration-safe.
+- **Creates a render-body compute signal/memo** — returns state derived via `createSignal(fn)` or `createMemo`. Verify it with a real hydration round trip (see below) rather than assuming it's fine.
+
+Prefer a plain (non-memoized) getter function over `createMemo` when the derived value is cheap to recompute (a handful of object fields, a short string) — it avoids consuming a hydration id for no measurable perf benefit. Reach for `createMemo` when the computation is genuinely non-trivial.
+
+Use [`scripts/test-utils/hydration-harness.ts`](scripts/test-utils/hydration-harness.ts)'s `renderHydrationRoundTrip()` to verify a package end-to-end: it renders a small fixture component through a real `node` subprocess (so `@solid-primitives/*` and `@solidjs/web` resolve to their published `dist` builds, exactly as an installed consumer gets them — not this monorepo's `@solid-primitives/source` workspace alias that regular `test/server.test.ts` files resolve through), then hydrates the result in-process and asserts no console error/warning. See `packages/controlled-signal/test/hydration.test.tsx` and `packages/a11y/test/hydration.test.tsx` for examples. Add one of these for any primitive whose public API returns a `createMemo`/compute-form-`createSignal` value that a consumer is expected to read directly in a render body.
+
+**Rebuild before trusting a result.** The harness's server half resolves the target package's published `dist`, but its client half resolves workspace `src` (through this monorepo's own alias). If you edit a package's `src` without rebuilding `dist`, the two halves are running genuinely different code, which can desync owner-id allocation for real and produce a false-positive "unclaimed server-rendered node" warning that has nothing to do with the hazard under test. Run `pnpm -w build` (or scope it to the packages you touched) before running a hydration test that depends on your changes.
+
 ## NPM Release and Repository Structure
 
 Solid Primitives is a large and growing project and the way we manage and release updates has been setup to suit the projects scope. The approach we've taken with organizing our packages and npm releases is more granular than other projects such as VueUse which ship all updates in a single release.

--- a/packages/a11y/src/form-control.ts
+++ b/packages/a11y/src/form-control.ts
@@ -16,7 +16,6 @@ import type { Context } from "solid-js";
 import {
   createContext,
   createEffect,
-  createMemo,
   createSignal,
   createUniqueId,
   useContext,
@@ -140,13 +139,16 @@ export function createFormControl(props: CreateFormControlProps): FormControlCon
     );
   };
 
-  const dataset = createMemo<FormControlDataSet>(() => ({
+  // Plain getter, not createMemo: the object is cheap to rebuild on every read, and a
+  // render-body compute-form memo would consume a hydration id in every consuming app —
+  // see the transform-boundary hydration hazard this pattern is designed to avoid.
+  const dataset = (): FormControlDataSet => ({
     "data-valid": access(props.validationState) === "valid" ? "" : undefined,
     "data-invalid": access(props.validationState) === "invalid" ? "" : undefined,
     "data-required": access(props.required) ? "" : undefined,
     "data-disabled": access(props.disabled) ? "" : undefined,
     "data-readonly": access(props.readOnly) ? "" : undefined,
-  }));
+  });
 
   return {
     name: () => access(props.name) ?? id(),

--- a/packages/a11y/stories/a11y.stories.tsx
+++ b/packages/a11y/stories/a11y.stories.tsx
@@ -27,8 +27,6 @@ import {
   radii,
 } from "../../../.storybook/ui/index.js";
 
-// ─── Local helpers ────────────────────────────────────────────────────────────
-
 const MonoValue = (props: { children: Element }) => (
   <span
     style={{
@@ -91,8 +89,6 @@ const AriaDebug = (props: { entries: { attr: string; value: string | undefined }
   </div>
 );
 
-// ─── Meta ─────────────────────────────────────────────────────────────────────
-
 const meta = preview.meta({
   title: "Inputs/a11y",
   tags: ["autodocs"],
@@ -107,8 +103,6 @@ const meta = preview.meta({
 });
 
 export default meta;
-
-// ─── createAnnounce ───────────────────────────────────────────────────────────
 
 export const Announce = meta.story({
   name: "Screen reader announcements",
@@ -207,8 +201,6 @@ export const Announce = meta.story({
   },
 });
 
-// ─── createReducedMotion ──────────────────────────────────────────────────────
-
 export const ReducedMotion = meta.story({
   name: "Reduced motion preference",
   parameters: {
@@ -282,8 +274,6 @@ export const ReducedMotion = meta.story({
     );
   },
 });
-
-// ─── Accessible field (raw API) ───────────────────────────────────────────────
 
 export const StandaloneField = meta.story({
   name: "Accessible field",
@@ -373,8 +363,6 @@ export const StandaloneField = meta.story({
   },
 });
 
-// ─── Sub-component pattern ────────────────────────────────────────────────────
-
 export const SubComponentPattern = meta.story({
   name: "Sub-component pattern",
   parameters: {
@@ -416,8 +404,6 @@ export const SubComponentPattern = meta.story({
   },
 });
 
-// ─── Context provider pattern ─────────────────────────────────────────────────
-
 export const ContextProviderPattern = meta.story({
   name: "Context provider pattern",
   parameters: {
@@ -432,8 +418,6 @@ export const ContextProviderPattern = meta.story({
     const [validationState, setValidationState] = createSignal<"valid" | "invalid" | undefined>(
       undefined,
     );
-
-    // ── Sub-components built inline to show the raw wiring ───────────────────
 
     const Label = (props: { children: Element }) => {
       const ctx = useFormControl();
@@ -497,8 +481,6 @@ export const ContextProviderPattern = meta.story({
       );
     };
 
-    // ── Root: creates context, provides it ───────────────────────────────────
-
     const ctx = createFormControl({ id: "ctx-demo", validationState, required: true });
 
     return (
@@ -528,8 +510,6 @@ export const ContextProviderPattern = meta.story({
     );
   },
 });
-
-// ─── Validation states ────────────────────────────────────────────────────────
 
 export const ValidationStates = meta.story({
   name: "Validation states",
@@ -593,8 +573,6 @@ export const ValidationStates = meta.story({
     );
   },
 });
-
-// ─── aria-labelledby chain ────────────────────────────────────────────────────
 
 export const AriaLabelledByChain = meta.story({
   name: "Label chain resolution",

--- a/packages/a11y/test/hydration.test.tsx
+++ b/packages/a11y/test/hydration.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  renderHydrationRoundTrip,
+  type HydrationRoundTripResult,
+} from "../../../scripts/test-utils/hydration-harness.ts";
+
+// createFormControl backs its labelId/fieldId/descriptionId/errorMessageId with
+// createSignal(undefined, { ownedWrite: true }) internal signals created in the render body —
+// the same class of construct hope-ui's solid-primitives-eval.md flags as a hydration-id hazard.
+// Renders through the real, standard @solidjs/web renderToString + hydrate pipeline (not our own
+// SSR harness) with the package resolved from its published `dist` build.
+const APP_SOURCE = `
+import { createFormControl, FormControlContext } from "@solid-primitives/a11y";
+
+export default function App() {
+  const ctx = createFormControl({ id: "email", required: true });
+  ctx.registerLabel("email-label");
+
+  return (
+    <FormControlContext value={ctx}>
+      <div id="out">
+        <label id="email-label">Email</label>
+        <input
+          id="email-input"
+          aria-labelledby={ctx.getAriaLabelledBy("email-input", undefined, undefined)}
+          aria-describedby={ctx.getAriaDescribedBy(undefined)}
+          data-required={ctx.dataset()["data-required"]}
+        />
+      </div>
+    </FormControlContext>
+  );
+}
+`;
+
+describe("createFormControl hydration round trip", () => {
+  let result: HydrationRoundTripResult | undefined;
+
+  afterEach(() => {
+    result?.cleanup();
+    result = undefined;
+  });
+
+  it("server-renders the required dataset attribute", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    expect(result.html).toContain('data-required=""');
+  });
+
+  it("hydrates without any console error or warning", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    expect(result.consoleMessages).toEqual([]);
+  });
+
+  it("hydrates the DOM with the correct aria attributes", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    const input = result.container.querySelector("#email-input");
+    expect(input?.getAttribute("aria-labelledby")).toBe("email-label");
+    expect(input?.getAttribute("data-required")).toBe("");
+  });
+});

--- a/packages/a11y/test/index.test.tsx
+++ b/packages/a11y/test/index.test.tsx
@@ -12,8 +12,6 @@ import {
   createReducedMotion,
 } from "../src/index.js";
 
-// ─── createFormControl ────────────────────────────────────────────────────────
-
 describe("createFormControl", () => {
   it("auto-generates a stable id when none provided", () => {
     createRoot(dispose => {
@@ -72,8 +70,6 @@ describe("createFormControl", () => {
       dispose();
     });
   });
-
-  // ─── dataset ───────────────────────────────────────────────────────────────
 
   it("dataset: undefined validationState sets no data attributes", () => {
     createRoot(dispose => {
@@ -147,8 +143,6 @@ describe("createFormControl", () => {
     dispose();
   });
 
-  // ─── state accessors ───────────────────────────────────────────────────────
-
   it("state accessors reflect props reactively", () => {
     const [required, setRequired] = createSignal<boolean | undefined>(false);
     const [disabled, setDisabled] = createSignal<boolean | undefined>(false);
@@ -166,8 +160,6 @@ describe("createFormControl", () => {
     expect(ctx.isDisabled()).toBe(true);
     dispose();
   });
-
-  // ─── registration ──────────────────────────────────────────────────────────
 
   it("registerLabel sets labelId and cleanup deregisters", () => {
     createRoot(dispose => {
@@ -208,8 +200,6 @@ describe("createFormControl", () => {
       dispose();
     });
   });
-
-  // ─── ARIA computation ──────────────────────────────────────────────────────
 
   it("getAriaLabelledBy: returns undefined with no label registered", () => {
     createRoot(dispose => {
@@ -309,8 +299,6 @@ describe("createFormControl", () => {
     dispose();
   });
 });
-
-// ─── createFormControlInput ───────────────────────────────────────────────────
 
 describe("createFormControlInput", () => {
   function withControl(
@@ -448,8 +436,6 @@ describe("createFormControlInput", () => {
   });
 });
 
-// ─── useFormControl ───────────────────────────────────────────────────────────
-
 describe("useFormControl", () => {
   it("throws when called outside a FormControlContext", () => {
     createRoot(dispose => {
@@ -478,8 +464,6 @@ describe("useFormControl", () => {
     dispose();
   });
 });
-
-// ─── makeAnnounce / createAnnounce ────────────────────────────────────────────
 
 describe("makeAnnounce", () => {
   beforeEach(() => vi.useFakeTimers());
@@ -574,8 +558,6 @@ describe("createAnnounce", () => {
     });
   });
 });
-
-// ─── createReducedMotion ──────────────────────────────────────────────────────
 
 describe("createReducedMotion", () => {
   let changeListeners: Array<(e: MediaQueryListEvent) => void> = [];

--- a/packages/analytics/test/index.test.ts
+++ b/packages/analytics/test/index.test.ts
@@ -12,8 +12,6 @@ function makeReadyPlugin(overrides: Partial<AnalyticsPlugin> = {}): AnalyticsPlu
 beforeEach(() => vi.useFakeTimers());
 afterEach(() => vi.useRealTimers());
 
-// ─── makeAnalytics ────────────────────────────────────────────────────────────
-
 describe("makeAnalytics", () => {
   it("dispatches page events immediately to a ready plugin", async () => {
     const pageSpy = vi.fn();
@@ -177,8 +175,6 @@ describe("makeAnalytics", () => {
   });
 });
 
-// ─── createAnalytics ──────────────────────────────────────────────────────────
-
 describe("createAnalytics", () => {
   let dispose: () => void;
 
@@ -246,8 +242,6 @@ describe("createAnalytics", () => {
   });
 });
 
-// ─── drain ────────────────────────────────────────────────────────────────────
-
 describe("drain()", () => {
   it("resolves immediately when no dispatches are in flight", async () => {
     const [analytics, cleanup] = makeAnalytics([makeReadyPlugin()]);
@@ -292,8 +286,6 @@ describe("drain()", () => {
     });
   });
 });
-
-// ─── drainInterval / drainSize ────────────────────────────────────────────────
 
 describe("drainInterval / drainSize", () => {
   it("batches events and dispatches on the drain interval", async () => {
@@ -363,8 +355,6 @@ describe("drainInterval / drainSize", () => {
     cleanup();
   });
 });
-
-// ─── makeAnalyticsGuard ───────────────────────────────────────────────────────
 
 describe("makeAnalyticsGuard", () => {
   it("onBeforeLeave prevents default and retries after drain", async () => {
@@ -436,8 +426,6 @@ describe("makeAnalyticsGuard", () => {
     cleanupAnalytics();
   });
 });
-
-// ─── createAnalyticsGuard ─────────────────────────────────────────────────────
 
 describe("createAnalyticsGuard", () => {
   let dispose: () => void;

--- a/packages/analytics/test/server.test.ts
+++ b/packages/analytics/test/server.test.ts
@@ -10,8 +10,6 @@ function delay(ms = 0): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-// ─── makeAnalytics (server) ───────────────────────────────────────────────────
-
 describe("makeAnalytics (server)", () => {
   it("dispatches page events to a synchronous plugin", async () => {
     const spy = vi.fn();
@@ -134,8 +132,6 @@ describe("makeAnalytics (server)", () => {
     cleanup();
   });
 });
-
-// ─── createAnalytics (server) ─────────────────────────────────────────────────
 
 describe("createAnalytics (server)", () => {
   it("dispatches events inside a createRoot scope on the server", async () => {

--- a/packages/audio/test/index.test.ts
+++ b/packages/audio/test/index.test.ts
@@ -9,8 +9,6 @@ const testPath =
 /** Yield to the microtask queue — used alongside flush() to drain Solid 2.0 effects. */
 const tick = () => Promise.resolve();
 
-// ── makeAudio ─────────────────────────────────────────────────────────────────
-
 describe("makeAudio", () => {
   it("returns a player and cleanup tuple", () => {
     const [player, cleanup] = makeAudio(testPath);
@@ -48,8 +46,6 @@ describe("makeAudio", () => {
   });
 });
 
-// ── makeAudioPlayer ───────────────────────────────────────────────────────────
-
 describe("makeAudioPlayer", () => {
   it("returns controls and cleanup tuple", () => {
     const [controls, cleanup] = makeAudioPlayer(testPath);
@@ -81,8 +77,6 @@ describe("makeAudioPlayer", () => {
     cleanup();
   });
 });
-
-// ── createAudio ───────────────────────────────────────────────────────────────
 
 describe("createAudio", () => {
   it("returns flat object with expected shape", () =>

--- a/packages/controlled-props/src/index.tsx
+++ b/packages/controlled-props/src/index.tsx
@@ -1,5 +1,5 @@
 import { createMemo, createSignal, For } from "solid-js";
-import type { Accessor, Component, Setter } from "solid-js";
+import type { Accessor, Component, Setter, VoidComponent } from "solid-js";
 import type { JSX } from "@solidjs/web";
 import { INTERNAL_OPTIONS } from "@solid-primitives/utils";
 
@@ -28,7 +28,7 @@ export type TestPropProps<T> = {
   step?: T extends number ? number : undefined;
 };
 
-export const BoolProp: Component<TestPropProps<boolean>> = props => (
+export const BoolProp: VoidComponent<TestPropProps<boolean>> = props => (
   <label>
     <input
       type="checkbox"
@@ -40,7 +40,7 @@ export const BoolProp: Component<TestPropProps<boolean>> = props => (
   </label>
 );
 
-export const NumberProp: Component<TestPropProps<number>> = props => (
+export const NumberProp: VoidComponent<TestPropProps<number>> = props => (
   <label>
     <span>{props.name}</span>{" "}
     <input
@@ -55,7 +55,7 @@ export const NumberProp: Component<TestPropProps<number>> = props => (
   </label>
 );
 
-export const RangeProp: Component<TestPropProps<number>> = props => (
+export const RangeProp: VoidComponent<TestPropProps<number>> = props => (
   <label>
     <span>{props.name}</span>{" "}
     <input
@@ -72,7 +72,7 @@ export const RangeProp: Component<TestPropProps<number>> = props => (
   </label>
 );
 
-export const StringProp: Component<TestPropProps<string>> = props => (
+export const StringProp: VoidComponent<TestPropProps<string>> = props => (
   <label>
     <span>{props.name}</span>{" "}
     <input

--- a/packages/controlled-props/stories/controlled-props.stories.tsx
+++ b/packages/controlled-props/stories/controlled-props.stories.tsx
@@ -28,8 +28,6 @@ const meta = preview.meta({
 
 export default meta;
 
-/* ── 1. Bool · number · string ───────────────────────────────────────────────── */
-
 export const ScalarControls = meta.story({
   name: "Bool · number · string",
   parameters: {
@@ -80,8 +78,6 @@ export const ScalarControls = meta.story({
     );
   },
 });
-
-/* ── 2. Array & enum select ──────────────────────────────────────────────────── */
 
 export const SelectControls = meta.story({
   name: "Array & enum select",
@@ -152,8 +148,6 @@ export const SelectControls = meta.story({
   },
 });
 
-/* ── 3. Range slider with step ──────────────────────────────────────────────── */
-
 export const RangeControls = meta.story({
   name: "Range slider with step",
   parameters: {
@@ -223,8 +217,6 @@ export const RangeControls = meta.story({
     );
   },
 });
-
-/* ── 4. Live component preview ───────────────────────────────────────────────── */
 
 export const ComponentPropPanel = meta.story({
   name: "Live component preview",

--- a/packages/controlled-signal/test/hydration.test.tsx
+++ b/packages/controlled-signal/test/hydration.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  renderHydrationRoundTrip,
+  type HydrationRoundTripResult,
+} from "../../../scripts/test-utils/hydration-harness.ts";
+
+// `createControllableSignal` backs its state with a compute-form `createSignal(fn, { ownedWrite: true })`
+// created in the component's render body — exactly the pattern hope-ui's solid-primitives-eval.md flags
+// as a hydration-id hazard when the primitive lives in an un-transformed node_modules dependency. This
+// renders through the real, standard @solidjs/web renderToString + hydrate pipeline (not our own SSR
+// harness) with the package resolved from its published `dist` build, to check whether that hazard
+// actually reproduces here.
+const APP_SOURCE = `
+import { createControllableSignal } from "@solid-primitives/controlled-signal";
+
+export default function App() {
+  const [value] = createControllableSignal<string>({ defaultValue: () => "hello" });
+  return (
+    <div id="out" data-testid="out">
+      <span>{value()}</span>
+      <button type="button">toggle</button>
+    </div>
+  );
+}
+`;
+
+describe("createControllableSignal hydration round trip", () => {
+  let result: HydrationRoundTripResult | undefined;
+
+  afterEach(() => {
+    result?.cleanup();
+    result = undefined;
+  });
+
+  it("server-renders the defaultValue", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    expect(result.html).toContain("hello");
+  });
+
+  it("hydrates without any console error or warning", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    expect(result.consoleMessages).toEqual([]);
+  });
+
+  it("hydrates the DOM into an interactive tree with the correct value", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    const span = result.container.querySelector("span");
+    expect(span?.textContent).toBe("hello");
+  });
+});

--- a/packages/cookies/test/index.test.ts
+++ b/packages/cookies/test/index.test.ts
@@ -9,8 +9,6 @@ beforeEach(() => {
   });
 });
 
-// ── parseCookie ───────────────────────────────────────────────────────────────
-
 describe("parseCookie", () => {
   it("extracts a value by key", () => {
     expect(parseCookie("foo=bar", "foo")).toBe("bar");
@@ -29,16 +27,12 @@ describe("parseCookie", () => {
   });
 });
 
-// ── getCookiesString ──────────────────────────────────────────────────────────
-
 describe("getCookiesString", () => {
   it("returns document.cookie on the client", () => {
     document.cookie = "ck_test=hello";
     expect(getCookiesString()).toContain("ck_test=hello");
   });
 });
-
-// ── createServerCookie ────────────────────────────────────────────────────────
 
 describe("createServerCookie", () => {
   it("initializes signal from the current cookie value", () => {
@@ -163,8 +157,6 @@ describe("createServerCookie", () => {
     dispose();
   });
 });
-
-// ── createUserTheme ───────────────────────────────────────────────────────────
 
 describe("createUserTheme", () => {
   it("reads a stored theme from the cookie", () => {

--- a/packages/cursor/stories/cursor.stories.tsx
+++ b/packages/cursor/stories/cursor.stories.tsx
@@ -26,8 +26,6 @@ const meta = preview.meta({
 
 export default meta;
 
-// ─── makeBodyCursor ───────────────────────────────────────────────────────────
-
 export const LoadingState = meta.story({
   name: "Loading state",
   parameters: {
@@ -71,8 +69,6 @@ export const LoadingState = meta.story({
     );
   },
 });
-
-// ─── createBodyCursor ─────────────────────────────────────────────────────────
 
 const BODY_CURSORS: CursorProperty[] = [
   "pointer",
@@ -128,8 +124,6 @@ export const BodyCursorReactive = meta.story({
     );
   },
 });
-
-// ─── createElementCursor ──────────────────────────────────────────────────────
 
 const ELEMENT_CURSORS: CursorProperty[] = [
   "pointer",
@@ -213,8 +207,6 @@ export const ElementCursorToggle = meta.story({
   },
 });
 
-// ─── createDragCursor ─────────────────────────────────────────────────────────
-
 export const DragHandle = meta.story({
   name: "Grab/grabbing on drag",
   parameters: {
@@ -293,8 +285,6 @@ export const DragHandle = meta.story({
     );
   },
 });
-
-// ─── cursorRef ────────────────────────────────────────────────────────────────
 
 const SHOWCASE_CURSORS: CursorProperty[] = [
   "pointer",

--- a/packages/deep/stories/deep.stories.tsx
+++ b/packages/deep/stories/deep.stories.tsx
@@ -30,8 +30,6 @@ const meta = preview.meta({
 
 export default meta;
 
-// ─── trackDeep ───────────────────────────────────────────────────────────────
-
 export const TrackDeepMultiple = meta.story({
   name: "One effect, two stores",
   parameters: {
@@ -119,8 +117,6 @@ export const TrackDeepMultiple = meta.story({
     );
   },
 });
-
-// ─── trackStore ──────────────────────────────────────────────────────────────
 
 export const TrackStoreWholeTree = meta.story({
   name: "Sync on any nested change",
@@ -236,8 +232,6 @@ export const TrackStoreWholeTree = meta.story({
     );
   },
 });
-
-// ─── captureStoreUpdates ─────────────────────────────────────────────────────
 
 export const StoreDeltaStory = meta.story({
   name: "Which path changed?",

--- a/packages/flux-store/stories/flux-store.stories.tsx
+++ b/packages/flux-store/stories/flux-store.stories.tsx
@@ -38,8 +38,6 @@ const meta = preview.meta({
 
 export default meta;
 
-// ── Story 1: createFluxStore — derived state via getters ─────────────────────
-
 export const BudgetTracker = meta.story({
   name: "Getters derive from reactive state",
   parameters: {
@@ -100,8 +98,6 @@ export const BudgetTracker = meta.story({
     );
   },
 });
-
-// ── Story 2: createFluxStoreFactory — isolated instances ─────────────────────
 
 export const IsolatedInstances = meta.story({
   name: "Isolated instances from one factory",
@@ -225,8 +221,6 @@ export const IsolatedInstances = meta.story({
   },
 });
 
-// ── Story 3: createActions — wrapping functions to run untracked ──────────────
-
 export const UntrackWrappers = meta.story({
   name: "Wrapping setters as untracked actions",
   parameters: {
@@ -296,8 +290,6 @@ export const UntrackWrappers = meta.story({
     );
   },
 });
-
-// ── Story 4: createAction — single untracked function wrapper ─────────────────
 
 export const SingleActionWrapper = meta.story({
   name: "Single function wrapped as action",

--- a/packages/focus/README.md
+++ b/packages/focus/README.md
@@ -16,6 +16,7 @@ The native `autofocus` attribute only works on page load, which makes it incompa
 - [`autofocus`](#autofocus) - Ref callback factory to autofocus an element on render.
 - [`createAutofocus`](#createautofocus) - Reactive primitive to autofocus an element on render.
 - [`createFocusTrap`](#createfocustrap) - Traps focus inside a given DOM element.
+- [`createFocusRestore`](#createfocusrestore) - Restores focus to the previously focused element, without trapping.
 
 ## Installation
 
@@ -150,6 +151,35 @@ createFocusTrap({
   },
 });
 ```
+
+## `createFocusRestore`
+
+`createFocusRestore` saves the currently focused element while active and restores focus to it once deactivated — without trapping focus or managing tab order. Use it for non-modal surfaces (Popover, Tooltip, Menu) that should return focus to their trigger on close but must not intercept Tab navigation while open. For modal dialogs that need both behaviors, use [`createFocusTrap`](#createfocustrap)'s `restoreFocus` option instead.
+
+### How to use it
+
+```tsx
+import { createFocusRestore } from "@solid-primitives/focus";
+
+const Popover: Component<{ open: boolean }> = props => {
+  createFocusRestore({ enabled: () => props.open });
+
+  return (
+    <Show when={props.open}>
+      <div role="dialog">...</div>
+    </Show>
+  );
+};
+```
+
+### Props
+
+| Prop                | Type                               | Default                    | Description                                                             |
+| ------------------- | ----------------------------------- | -------------------------- | ------------------------------------------------------------------------ |
+| `enabled`           | `MaybeAccessor<boolean>`           | `true`                     | Whether focus-restore is active.                                       |
+| `element`           | `MaybeAccessor<HTMLElement\|null>` | `document.body`            | Element to dispatch the `onFinalFocus` event on.                       |
+| `finalFocusElement` | `MaybeAccessor<HTMLElement\|null>` | Previously focused element | Element to focus when deactivated.                                     |
+| `onFinalFocus`      | `(event: Event) => void`           | —                          | Callback when focus restores. Call `event.preventDefault()` to cancel. |
 
 ## Credits
 

--- a/packages/focus/src/focusRestore.ts
+++ b/packages/focus/src/focusRestore.ts
@@ -1,0 +1,74 @@
+/*
+ * Adapted for @solid-primitives/focus by the Solid Primitives Working Group.
+ * Reuses the restore-focus half of createFocusTrap (see focusTrap.ts) as a
+ * standalone primitive for non-modal surfaces (Popover, Tooltip) that must
+ * return focus to their trigger on close but must not intercept Tab
+ * navigation the way a full focus trap does.
+ */
+
+import { access, type MaybeAccessor } from "@solid-primitives/utils";
+import { createEffect } from "solid-js";
+import { scheduleFocusRestore } from "./restoreFocus.ts";
+
+const EVENT_FINAL_FOCUS = "focusRestore.finalFocus";
+
+export type CreateFocusRestoreProps = {
+  /** Whether focus-restore is active. Default: `true` */
+  enabled?: MaybeAccessor<boolean>;
+  /**
+   * Element to dispatch the `onFinalFocus` event on. Defaults to `document.body`.
+   */
+  element?: MaybeAccessor<HTMLElement | undefined>;
+  /**
+   * Element to focus when deactivated.
+   * Default: the element that was focused when activated.
+   */
+  finalFocusElement?: MaybeAccessor<HTMLElement | undefined>;
+  /**
+   * Callback fired when focus is restored.
+   * Call `event.preventDefault()` to suppress the focus move.
+   */
+  onFinalFocus?: (event: Event) => void;
+};
+
+/**
+ * Saves the currently focused element while active and restores focus to it
+ * once deactivated — without trapping focus or managing tab order.
+ *
+ * For a non-modal Popover/Tooltip/Menu that should return focus to its trigger
+ * on close but must not intercept Tab navigation while open. For the full
+ * trap-and-restore behavior (modal dialogs) use {@link createFocusTrap}, whose
+ * `restoreFocus` option covers the same restore behavior alongside trapping.
+ *
+ * @example
+ * ```tsx
+ * const [ref, setRef] = createSignal<HTMLElement>();
+ * createFocusRestore({ enabled: () => isOpen(), element: ref });
+ * <div ref={setRef}>...</div>
+ * ```
+ */
+export const createFocusRestore = (props: CreateFocusRestoreProps = {}): void => {
+  let originalFocusedElement: HTMLElement | null = null;
+
+  createEffect(
+    () => access(props.enabled ?? true),
+    enabled => {
+      if (!enabled) return;
+
+      originalFocusedElement = document.activeElement as HTMLElement | null;
+
+      return () => {
+        scheduleFocusRestore({
+          resolveEventTarget: () => access(props.element) ?? document.body,
+          eventName: EVENT_FINAL_FOCUS,
+          resolveTarget: () => access(props.finalFocusElement) ?? null,
+          // Snapshot now, synchronously — the restore is scheduled via afterPaint (deferred by a
+          // couple of animation frames), and a later activation before it fires would otherwise
+          // overwrite originalFocusedElement out from under the still-pending restore.
+          fallbackTarget: originalFocusedElement,
+          onFinalFocus: props.onFinalFocus,
+        });
+      };
+    },
+  );
+};

--- a/packages/focus/src/focusTrap.ts
+++ b/packages/focus/src/focusTrap.ts
@@ -6,6 +6,7 @@
 
 import { access, afterPaint, INTERNAL_OPTIONS, type MaybeAccessor } from "@solid-primitives/utils";
 import { createEffect, createMemo, createSignal } from "solid-js";
+import { scheduleFocusRestore } from "./restoreFocus.ts";
 
 const FOCUSABLE_SELECTOR =
   'a[href]:not([tabindex="-1"]), button:not([tabindex="-1"]), input:not([tabindex="-1"]), textarea:not([tabindex="-1"]), select:not([tabindex="-1"]), details:not([tabindex="-1"]), [tabindex]:not([tabindex="-1"])';
@@ -107,20 +108,14 @@ export const createFocusTrap = (props: CreateFocusTrapProps): void => {
     });
   };
 
-  const triggerRestoreFocus = (container: HTMLElement) => {
-    afterPaint(() => {
-      if (!access(props.restoreFocus ?? true)) return;
-      const target = access(props.finalFocusElement ?? null) ?? originalFocusedElement;
-      if (!target) return;
-      const { onFinalFocus } = props;
-      if (onFinalFocus) {
-        const event = new CustomEvent(EVENT_FINAL_FOCUS, EVENT_OPTIONS);
-        container.addEventListener(EVENT_FINAL_FOCUS, onFinalFocus);
-        container.dispatchEvent(event);
-        container.removeEventListener(EVENT_FINAL_FOCUS, onFinalFocus);
-        if (event.defaultPrevented) return;
-      }
-      target.focus();
+  const triggerRestoreFocus = (container: HTMLElement, fallbackTarget: HTMLElement | null) => {
+    scheduleFocusRestore({
+      resolveEventTarget: () => container,
+      eventName: EVENT_FINAL_FOCUS,
+      shouldRestore: () => access(props.restoreFocus ?? true),
+      resolveTarget: () => access(props.finalFocusElement) ?? null,
+      fallbackTarget,
+      onFinalFocus: props.onFinalFocus,
     });
   };
 
@@ -177,7 +172,10 @@ export const createFocusTrap = (props: CreateFocusTrapProps): void => {
       return () => {
         if (observeChanges) observer.disconnect();
         setFocusableElements(undefined);
-        triggerRestoreFocus(container);
+        // Snapshot now, synchronously — the restore is scheduled via afterPaint (deferred by a
+        // couple of animation frames), and a later activation before it fires would otherwise
+        // overwrite originalFocusedElement out from under the still-pending restore.
+        triggerRestoreFocus(container, originalFocusedElement);
       };
     },
   );

--- a/packages/focus/src/index.ts
+++ b/packages/focus/src/index.ts
@@ -2,4 +2,6 @@ export { autofocus, createAutofocus } from "./autofocus.ts";
 export type { E } from "./autofocus.ts";
 export { createFocusTrap } from "./focusTrap.ts";
 export type { CreateFocusTrapProps } from "./focusTrap.ts";
+export { createFocusRestore } from "./focusRestore.ts";
+export type { CreateFocusRestoreProps } from "./focusRestore.ts";
 export { makeFocusListener, createFocusSignal } from "./focusSignal.ts";

--- a/packages/focus/src/restoreFocus.ts
+++ b/packages/focus/src/restoreFocus.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared "restore focus on deactivation" ceremony used by both `createFocusTrap` (trap + restore)
+ * and the standalone `createFocusRestore` (restore only, no trap).
+ */
+
+import { afterPaint } from "@solid-primitives/utils";
+
+const EVENT_OPTIONS = { bubbles: false, cancelable: true } as const;
+
+export type ScheduleFocusRestoreOptions = {
+  /** Element to dispatch the cancelable `onFinalFocus` custom event on. Read live (at fire time). */
+  resolveEventTarget: () => Element;
+  eventName: string;
+  /** Read live (at fire time). Return `false` to abort the restore for this cycle. */
+  shouldRestore?: () => boolean;
+  /** Live override target (e.g. an explicit `finalFocusElement` option); wins over `fallbackTarget`. */
+  resolveTarget: () => HTMLElement | null;
+  /**
+   * The element to fall back to when `resolveTarget()` returns `null` — must be captured by the
+   * caller *synchronously*, at the moment deactivation begins (before scheduling this), not read
+   * lazily from a mutable outer variable. Otherwise a later activation cycle can reassign that
+   * variable before this runs, restoring focus to the wrong element.
+   */
+  fallbackTarget: HTMLElement | null;
+  onFinalFocus?: (event: Event) => void;
+};
+
+/**
+ * Schedules (via `afterPaint`) a cancelable-custom-event-gated focus restore.
+ */
+export function scheduleFocusRestore(options: ScheduleFocusRestoreOptions): void {
+  const { resolveEventTarget, eventName, shouldRestore, resolveTarget, fallbackTarget, onFinalFocus } =
+    options;
+  afterPaint(() => {
+    if (shouldRestore && !shouldRestore()) return;
+    const target = resolveTarget() ?? fallbackTarget;
+    if (!target) return;
+    if (onFinalFocus) {
+      const eventTarget = resolveEventTarget();
+      const event = new CustomEvent(eventName, EVENT_OPTIONS);
+      eventTarget.addEventListener(eventName, onFinalFocus);
+      eventTarget.dispatchEvent(event);
+      eventTarget.removeEventListener(eventName, onFinalFocus);
+      if (event.defaultPrevented) return;
+    }
+    target.focus();
+  });
+}

--- a/packages/focus/test/index.test.tsx
+++ b/packages/focus/test/index.test.tsx
@@ -1,8 +1,6 @@
 import { describe, test, expect, vi, beforeEach, afterAll, beforeAll } from "vitest";
 import { createRoot, createSignal, flush } from "solid-js";
-import { autofocus, createAutofocus, createFocusTrap } from "../src/index.js";
-
-// ─── Shared focus tracking ────────────────────────────────────────────────────
+import { autofocus, createAutofocus, createFocusTrap, createFocusRestore } from "../src/index.js";
 
 let focused: HTMLElement | null = null;
 
@@ -10,8 +8,6 @@ const original_focus = HTMLElement.prototype.focus;
 HTMLElement.prototype.focus = function (this: HTMLElement) {
   focused = this;
 };
-
-// ─── Fake timers + rAF stub ───────────────────────────────────────────────────
 
 beforeAll(() => {
   vi.useFakeTimers();
@@ -33,15 +29,11 @@ afterAll(() => {
   HTMLElement.prototype.focus = original_focus;
 });
 
-// ─── Helper ───────────────────────────────────────────────────────────────────
-
 /** Run all pending effects then drain all timers (including nested rAFs). */
 const settle = () => {
   flush();
   vi.runAllTimers();
 };
-
-// ─── autofocus ────────────────────────────────────────────────────────────────
 
 describe("autofocus", () => {
   test("focuses the element with autofocus attribute", () => {
@@ -73,8 +65,6 @@ describe("autofocus", () => {
     dispose();
   });
 });
-
-// ─── createAutofocus ──────────────────────────────────────────────────────────
 
 describe("createAutofocus", () => {
   const el = document.createElement("button"),
@@ -117,8 +107,6 @@ describe("createAutofocus", () => {
     expect(focused).toBe(el2); // no focus after dispose
   });
 });
-
-// ─── createFocusTrap ──────────────────────────────────────────────────────────
 
 /** Build a container with `n` focusable buttons and return them. */
 function makeContainer(n: number): { container: HTMLElement; buttons: HTMLButtonElement[] } {
@@ -434,5 +422,204 @@ describe("createFocusTrap", () => {
     settle();
     expect(focused).toBe(buttons[0]);
     dispose();
+  });
+});
+
+describe("createFocusRestore", () => {
+  test("does not move focus on activation", () => {
+    const trigger = document.createElement("button");
+    document.body.appendChild(trigger);
+    trigger.focus();
+    focused = null; // reset after the manual .focus() above
+
+    const dispose = createRoot(dispose => {
+      createFocusRestore({ enabled: true });
+      return dispose;
+    });
+
+    settle();
+    expect(focused).toBe(null); // createFocusRestore never focuses anything itself
+    dispose();
+    trigger.remove();
+  });
+
+  test("restores focus to the previously focused element on deactivation", () => {
+    const trigger = document.createElement("button");
+    const [enabled, setEnabled] = createSignal(true);
+
+    const origActiveElement = Object.getOwnPropertyDescriptor(Document.prototype, "activeElement")!;
+    Object.defineProperty(document, "activeElement", {
+      get: () => trigger,
+      configurable: true,
+    });
+
+    const dispose = createRoot(dispose => {
+      createFocusRestore({ enabled });
+      return dispose;
+    });
+
+    settle();
+    Object.defineProperty(document, "activeElement", origActiveElement);
+
+    setEnabled(false);
+    settle();
+    expect(focused).toBe(trigger);
+    dispose();
+  });
+
+  test("a reactivation before a pending restore fires does not corrupt that restore's target", () => {
+    // Regression test: the restore target used to be read lazily from a shared outer variable
+    // inside the afterPaint-deferred callback. If something reactivated focus-restore (capturing
+    // a *new* "currently focused" element) before the still-pending restore from the *previous*
+    // deactivation had a chance to fire, that pending restore would incorrectly pick up the new
+    // value instead of the one that was current when it was scheduled.
+    const trigger1 = document.createElement("button");
+    const trigger2 = document.createElement("button");
+    const [enabled, setEnabled] = createSignal(true);
+
+    const origActiveElement = Object.getOwnPropertyDescriptor(Document.prototype, "activeElement")!;
+    Object.defineProperty(document, "activeElement", { get: () => trigger1, configurable: true });
+
+    const dispose = createRoot(dispose => {
+      createFocusRestore({ enabled });
+      return dispose;
+    });
+
+    settle(); // originalFocusedElement captured as trigger1
+
+    setEnabled(false); // schedules a restore that should target trigger1
+    flush(); // runs the deactivation synchronously — the afterPaint restore is now pending, not yet fired
+
+    // Before that pending restore fires, something reactivates focus-restore against a
+    // different currently-focused element, and stays enabled (no second deactivation, so no
+    // second restore gets queued — isolates exactly the race being tested).
+    Object.defineProperty(document, "activeElement", { get: () => trigger2, configurable: true });
+    setEnabled(true);
+    flush();
+
+    Object.defineProperty(document, "activeElement", origActiveElement);
+
+    vi.runAllTimers(); // drains the still-pending first restore
+    expect(focused).toBe(trigger1); // not trigger2
+    dispose();
+  });
+
+  test("restores focus on dispose even without enabled changing first", () => {
+    const trigger = document.createElement("button");
+
+    const origActiveElement = Object.getOwnPropertyDescriptor(Document.prototype, "activeElement")!;
+    Object.defineProperty(document, "activeElement", {
+      get: () => trigger,
+      configurable: true,
+    });
+
+    const dispose = createRoot(dispose => {
+      createFocusRestore();
+      return dispose;
+    });
+
+    settle();
+    Object.defineProperty(document, "activeElement", origActiveElement);
+
+    dispose();
+    settle();
+    expect(focused).toBe(trigger);
+  });
+
+  test("uses finalFocusElement when provided", () => {
+    const trigger = document.createElement("button");
+    const customFinal = document.createElement("button");
+    const [enabled, setEnabled] = createSignal(true);
+
+    const origActiveElement = Object.getOwnPropertyDescriptor(Document.prototype, "activeElement")!;
+    Object.defineProperty(document, "activeElement", {
+      get: () => trigger,
+      configurable: true,
+    });
+
+    const dispose = createRoot(dispose => {
+      createFocusRestore({ enabled, finalFocusElement: customFinal });
+      return dispose;
+    });
+
+    settle();
+    Object.defineProperty(document, "activeElement", origActiveElement);
+
+    setEnabled(false);
+    settle();
+    expect(focused).toBe(customFinal);
+    dispose();
+  });
+
+  test("onFinalFocus callback is called on deactivation", () => {
+    const trigger = document.createElement("button");
+    const [enabled, setEnabled] = createSignal(true);
+    const onFinalFocus = vi.fn();
+
+    const origActiveElement = Object.getOwnPropertyDescriptor(Document.prototype, "activeElement")!;
+    Object.defineProperty(document, "activeElement", {
+      get: () => trigger,
+      configurable: true,
+    });
+
+    const dispose = createRoot(dispose => {
+      createFocusRestore({ enabled, onFinalFocus });
+      return dispose;
+    });
+
+    settle();
+    Object.defineProperty(document, "activeElement", origActiveElement);
+
+    setEnabled(false);
+    settle();
+    expect(onFinalFocus).toHaveBeenCalledOnce();
+    dispose();
+  });
+
+  test("onFinalFocus preventDefault suppresses focus restore", () => {
+    const trigger = document.createElement("button");
+    const [enabled, setEnabled] = createSignal(true);
+
+    const origActiveElement = Object.getOwnPropertyDescriptor(Document.prototype, "activeElement")!;
+    Object.defineProperty(document, "activeElement", {
+      get: () => trigger,
+      configurable: true,
+    });
+
+    const dispose = createRoot(dispose => {
+      createFocusRestore({ enabled, onFinalFocus: e => e.preventDefault() });
+      return dispose;
+    });
+
+    settle();
+    Object.defineProperty(document, "activeElement", origActiveElement);
+
+    focused = null;
+    setEnabled(false);
+    settle();
+    expect(focused).toBe(null); // prevented
+    dispose();
+  });
+
+  test("does not restore focus when enabled is false throughout", () => {
+    const trigger = document.createElement("button");
+
+    const origActiveElement = Object.getOwnPropertyDescriptor(Document.prototype, "activeElement")!;
+    Object.defineProperty(document, "activeElement", {
+      get: () => trigger,
+      configurable: true,
+    });
+
+    const dispose = createRoot(dispose => {
+      createFocusRestore({ enabled: false });
+      return dispose;
+    });
+
+    settle();
+    Object.defineProperty(document, "activeElement", origActiveElement);
+
+    dispose();
+    settle();
+    expect(focused).toBe(null);
   });
 });

--- a/packages/form/stories/form.stories.tsx
+++ b/packages/form/stories/form.stories.tsx
@@ -14,14 +14,10 @@ import {
   inputStyle,
 } from "../../../.storybook/ui/index.js";
 
-// ─── Validators ───────────────────────────────────────────────────────────────
-
 const required = (v: string) => (v.trim() === "" ? "Required" : null);
 const isEmail = (v: string) => (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) ? null : "Invalid email");
 const minLength = (n: number) => (v: string) => (v.length < n ? `Min ${n} chars` : null);
 const hasUppercase = (v: string) => (/[A-Z]/.test(v) ? null : "Needs an uppercase letter");
-
-// ─── Local story helpers ──────────────────────────────────────────────────────
 
 const FieldRow = (props: {
   label: string;
@@ -41,8 +37,6 @@ const FieldRow = (props: {
   </div>
 );
 
-// ─── Meta ─────────────────────────────────────────────────────────────────────
-
 const meta = preview.meta({
   title: "Forms/Form",
   tags: ["autodocs"],
@@ -57,8 +51,6 @@ const meta = preview.meta({
 });
 
 export default meta;
-
-// ─── Validate on change ───────────────────────────────────────────────────────
 
 export const ValidateOnChange = meta.story({
   name: "Validate on change",
@@ -122,8 +114,6 @@ export const ValidateOnChange = meta.story({
   },
 });
 
-// ─── Validate on blur ─────────────────────────────────────────────────────────
-
 export const ValidateOnBlur = meta.story({
   name: "Validate on blur",
   parameters: {
@@ -176,8 +166,6 @@ export const ValidateOnBlur = meta.story({
     );
   },
 });
-
-// ─── Errors on first submit ───────────────────────────────────────────────────
 
 export const ValidateOnSubmit = meta.story({
   name: "Errors on first submit",
@@ -237,8 +225,6 @@ export const ValidateOnSubmit = meta.story({
   },
 });
 
-// ─── Cross-field rule ─────────────────────────────────────────────────────────
-
 export const CrossFieldRule = meta.story({
   name: "Passwords must match",
   parameters: {
@@ -296,8 +282,6 @@ export const CrossFieldRule = meta.story({
     );
   },
 });
-
-// ─── Async availability check ─────────────────────────────────────────────────
 
 const TAKEN = new Set(["admin", "root", "solid"]);
 const checkAvailable = (username: string): Promise<string | null> =>

--- a/packages/form/test/index.test.ts
+++ b/packages/form/test/index.test.ts
@@ -2,8 +2,6 @@ import { describe, it, expect, vi } from "vitest";
 import { createRoot, createSignal, flush } from "solid-js";
 import { createForm, createFormResetListener, toFormData } from "../src/index.js";
 
-// ─── Inline validators used across tests ──────────────────────────────────────
-
 const isEmail = (v: string) =>
   /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v) ? null : "Invalid email";
 
@@ -12,8 +10,6 @@ const minLength = (n: number) => (v: string) =>
 
 const hasUppercase = (v: string) =>
   /[A-Z]/.test(v) ? null : "Must contain an uppercase letter";
-
-// ─── Field signals ────────────────────────────────────────────────────────────
 
 describe("field signals", () => {
   it("initializes field values from config", () => {
@@ -54,8 +50,6 @@ describe("field signals", () => {
     });
   });
 });
-
-// ─── Validation ───────────────────────────────────────────────────────────────
 
 describe("validation", () => {
   it("returns null error for valid field", () => {
@@ -127,8 +121,6 @@ describe("validation", () => {
     });
   });
 });
-
-// ─── Derived form state ───────────────────────────────────────────────────────
 
 describe("dirty", () => {
   it("is false initially", () => {
@@ -253,8 +245,6 @@ describe("values", () => {
     });
   });
 });
-
-// ─── Reset ────────────────────────────────────────────────────────────────────
 
 describe("reset", () => {
   it("restores all fields to initial values and clears touched", () => {
@@ -388,8 +378,6 @@ describe("reset", () => {
     });
   });
 });
-
-// ─── Submit ───────────────────────────────────────────────────────────────────
 
 describe("submit", () => {
   it("calls onSubmit with current values when valid", async () => {
@@ -570,8 +558,6 @@ describe("submit", () => {
   });
 });
 
-// ─── submitted flag ───────────────────────────────────────────────────────────
-
 describe("submitted", () => {
   it("starts false", () => {
     createRoot(dispose => {
@@ -621,8 +607,6 @@ describe("submitted", () => {
     dispose();
   });
 });
-
-// ─── validateOn ───────────────────────────────────────────────────────────────
 
 describe("validateOn", () => {
   it("change (default): error() shows immediately", () => {
@@ -743,8 +727,6 @@ describe("validateOn", () => {
     });
   });
 });
-
-// ─── Async validators ─────────────────────────────────────────────────────────
 
 describe("async validators", () => {
   it("pending becomes true while an async validator is in flight", () => {
@@ -936,8 +918,6 @@ describe("async validators", () => {
   });
 });
 
-// ─── Bind ─────────────────────────────────────────────────────────────────────
-
 describe("bind", () => {
   it("sets initial input value from signal", () => {
     createRoot(dispose => {
@@ -1112,8 +1092,6 @@ describe("bind", () => {
   });
 });
 
-// ─── Form-level validate ──────────────────────────────────────────────────────
-
 describe("validate", () => {
   it("returns null when the cross-field rule passes", () => {
     createRoot(dispose => {
@@ -1247,8 +1225,6 @@ describe("validate", () => {
   });
 });
 
-// ─── toFormData ───────────────────────────────────────────────────────────────
-
 describe("toFormData", () => {
   it("returns a FormData with all current field values", () => {
     createRoot(dispose => {
@@ -1293,8 +1269,6 @@ describe("toFormData", () => {
   });
 });
 
-// ─── formData ─────────────────────────────────────────────────────────────────
-
 describe("formData", () => {
   it("returns FormData with all current field values", () => {
     createRoot(dispose => {
@@ -1324,8 +1298,6 @@ describe("formData", () => {
     });
   });
 });
-
-// ─── setValues ───────────────────────────────────────────────────────────────
 
 describe("setValues", () => {
   it("updates multiple fields at once", () => {
@@ -1397,8 +1369,6 @@ describe("setValues", () => {
     });
   });
 });
-
-// ─── setError ────────────────────────────────────────────────────────────────
 
 describe("setError", () => {
   it("field.setError sets an external error visible via error()", () => {
@@ -1503,8 +1473,6 @@ describe("setError", () => {
   });
 });
 
-// ─── validate() reactive invalidation ────────────────────────────────────────
-
 describe("validate reactive invalidation", () => {
   it("valid() reflects a new cross-field rule added after it was first read", () => {
     createRoot(dispose => {
@@ -1528,8 +1496,6 @@ describe("validate reactive invalidation", () => {
     });
   });
 });
-
-// ─── bind with textarea ───────────────────────────────────────────────────────
 
 describe("bind with textarea", () => {
   it("sets initial value on a textarea", () => {
@@ -1562,8 +1528,6 @@ describe("bind with textarea", () => {
     });
   });
 });
-
-// ─── bind with select ────────────────────────────────────────────────────────
 
 describe("bind with select", () => {
   function makeSelect(...values: string[]): HTMLSelectElement {
@@ -1623,8 +1587,6 @@ describe("bind with select", () => {
   });
 });
 
-// ─── Form ref ─────────────────────────────────────────────────────────────────
-
 describe("form ref", () => {
   it("intercepts submit event and prevents default", async () => {
     let submitPromise: Promise<void>;
@@ -1656,8 +1618,6 @@ describe("form ref", () => {
     dispose();
   });
 });
-
-// ─── createFormResetListener ──────────────────────────────────────────────────
 
 describe("createFormResetListener", () => {
   const makeForm = () => {

--- a/packages/geolocation/test/index.test.ts
+++ b/packages/geolocation/test/index.test.ts
@@ -12,8 +12,6 @@ import {
   createWithinRadius,
 } from "../src/index.js";
 
-// ── makeGeolocation ───────────────────────────────────────────────────────────
-
 describe("makeGeolocation", () => {
   it("resolves coordinates without a Solid owner", async () => {
     const [query, cleanup] = makeGeolocation();
@@ -45,8 +43,6 @@ describe("makeGeolocation", () => {
   });
 });
 
-// ── makeGeolocationWatcher ────────────────────────────────────────────────────
-
 describe("makeGeolocationWatcher", () => {
   it("starts watching and provides initial location without a Solid owner", () => {
     const [store, cleanup] = makeGeolocationWatcher();
@@ -63,8 +59,6 @@ describe("makeGeolocationWatcher", () => {
     clearWatch.mockRestore();
   });
 });
-
-// ── createGeolocation ─────────────────────────────────────────────────────────
 
 describe("createGeolocation", () => {
   it("resolves coordinates via async accessor", () =>
@@ -124,8 +118,6 @@ describe("createGeolocation", () => {
     }));
 });
 
-// ── createGeolocation — initialLocation ──────────────────────────────────────
-
 describe("createGeolocation — initialLocation (client)", () => {
   it("initialLocation is ignored on the client — GPS is still queried", () =>
     createRoot(async dispose => {
@@ -137,8 +129,6 @@ describe("createGeolocation — initialLocation (client)", () => {
       dispose();
     }));
 });
-
-// ── createGeolocationWatcher ──────────────────────────────────────────────────
 
 describe("createGeolocationWatcher", () => {
   it("location and error are signal accessors", () =>
@@ -239,8 +229,6 @@ describe("createGeolocationWatcher", () => {
     }));
 });
 
-// ── createDistance ────────────────────────────────────────────────────────────
-
 describe("createDistance", () => {
   it("returns null before first GPS fix", () =>
     createRoot(dispose => {
@@ -302,8 +290,6 @@ describe("createDistance", () => {
       dispose();
     }));
 });
-
-// ── createWithinRadius ────────────────────────────────────────────────────────
 
 describe("createWithinRadius", () => {
   it("returns false before first GPS fix", () =>

--- a/packages/interaction/src/index.ts
+++ b/packages/interaction/src/index.ts
@@ -21,7 +21,7 @@
  */
 
 import { type Accessor, createEffect, onCleanup } from "solid-js";
-import { type MaybeAccessor, access, isServer, noop } from "@solid-primitives/utils";
+import { type MaybeAccessor, access, globalRegistry, isServer, noop } from "@solid-primitives/utils";
 
 // ---- ariaHideOutside / createHideOutside ----
 
@@ -40,11 +40,64 @@ export interface CreateHideOutsideOptions {
    * target containment (e.g. top-layer elements, live announcers). Optional.
    */
   alwaysVisibleSelector?: string;
+  /**
+   * Also set the `inert` attribute on hidden elements, in addition to `aria-hidden`.
+   * `aria-hidden` alone only affects the accessibility tree — the background stays focusable
+   * and clickable; `inert` additionally removes it from focus order, tab order, and pointer/
+   * text-selection interaction. *Default = `false`* (matches prior behavior).
+   */
+  inert?: MaybeAccessor<boolean>;
 }
 
-// Keeps a ref count of all hidden elements so nested usages don't fight.
-const refCountMap = new WeakMap<Element, number>();
-const observerStack: Array<{ observe(): void; disconnect(): void }> = [];
+// Keeps a ref count of all hidden/inerted elements so nested usages don't fight, and tracks
+// the stack of active observers. Uses globalRegistry (Symbol.for(...) on globalThis, not
+// module-scope bindings) so this stays correct even if the app's dependency graph ends up with
+// more than one copy of this package installed — module-scope state would otherwise be split
+// across copies (e.g. one copy's cleanup revealing content another copy still needs hidden).
+type HideOutsideRegistry = {
+  refCountMap: WeakMap<Element, number>;
+  inertRefCountMap: WeakMap<Element, number>;
+  observerStack: Array<{ observe(): void; disconnect(): void }>;
+};
+
+const getHideOutsideRegistry = (): HideOutsideRegistry =>
+  globalRegistry<HideOutsideRegistry>("@solid-primitives/interaction:hide-outside", () => ({
+    refCountMap: new WeakMap(),
+    inertRefCountMap: new WeakMap(),
+    observerStack: [],
+  }));
+
+/**
+ * Applies `apply` to `node` the first time it's touched (or observes that a pre-existing native
+ * state already covers it, in which case `node` is left alone entirely and untracked). Ref-counts
+ * nested calls; returns whether `node` is now managed by us (`false` means "not ours — untouched").
+ */
+function refCountedApply(
+  map: WeakMap<Element, number>,
+  tracked: Set<Element>,
+  node: Element,
+  alreadySet: boolean,
+  apply: () => void,
+): boolean {
+  const count = map.get(node) ?? 0;
+  if (alreadySet && count === 0) return false;
+  if (count === 0) apply();
+  map.set(node, count + 1);
+  tracked.add(node);
+  return true;
+}
+
+/** Reverts `unapply` once the last ref-counted hold on `node` in `map` is released. */
+function refCountedRelease(map: WeakMap<Element, number>, node: Element, unapply: () => void): void {
+  const count = map.get(node);
+  if (count == null) return;
+  if (count === 1) {
+    unapply();
+    map.delete(node);
+  } else {
+    map.set(node, count - 1);
+  }
+}
 
 /**
  * Hides all elements in the DOM outside the given `targets` from screen readers by setting
@@ -61,7 +114,8 @@ const observerStack: Array<{ observe(): void; disconnect(): void }> = [];
  * @param root - Root element to walk. Defaults to `document.body`.
  * @param alwaysVisibleSelector - Optional CSS selector for elements that must never be hidden
  *   (e.g. `"[aria-live]"` for live-region announcers or top-layer elements).
- * @returns A cleanup function that removes all `aria-hidden` attributes added by this call.
+ * @param inert - Also set the `inert` attribute on hidden elements. *Default = `false`*.
+ * @returns A cleanup function that removes all `aria-hidden`/`inert` changes added by this call.
  *
  * @example
  * ```ts
@@ -81,9 +135,12 @@ export function ariaHideOutside(
   targets: Element[],
   root: Element = document.body,
   alwaysVisibleSelector?: string,
+  inert = false,
 ): () => void {
+  const { refCountMap, inertRefCountMap, observerStack } = getHideOutsideRegistry();
   const visibleNodes = new Set<Element>(targets);
   const hiddenNodes = new Set<Element>();
+  const inertedNodes = new Set<Element>();
 
   const walk = (root: Element) => {
     if (alwaysVisibleSelector) {
@@ -117,12 +174,22 @@ export function ariaHideOutside(
     }
   };
 
+  // `inert` is only ever applied to nodes hide() actually manages (returns `true`) — a node
+  // left alone because it already carries an author-set aria-hidden must be left alone for
+  // `inert` too, for the same "not ours to manage" reason.
   const hide = (node: Element) => {
-    const refCount = refCountMap.get(node) ?? 0;
-    if (node.getAttribute("aria-hidden") === "true" && refCount === 0) return;
-    if (refCount === 0) node.setAttribute("aria-hidden", "true");
-    hiddenNodes.add(node);
-    refCountMap.set(node, refCount + 1);
+    const managed = refCountedApply(
+      refCountMap,
+      hiddenNodes,
+      node,
+      node.getAttribute("aria-hidden") === "true",
+      () => node.setAttribute("aria-hidden", "true"),
+    );
+    if (managed && inert && node instanceof HTMLElement) {
+      refCountedApply(inertRefCountMap, inertedNodes, node, node.inert, () => {
+        node.inert = true;
+      });
+    }
   };
 
   observerStack[observerStack.length - 1]?.disconnect();
@@ -156,16 +223,12 @@ export function ariaHideOutside(
 
   return () => {
     observer.disconnect();
-    hiddenNodes.forEach(node => {
-      const count = refCountMap.get(node);
-      if (count == null) return;
-      if (count === 1) {
-        node.removeAttribute("aria-hidden");
-        refCountMap.delete(node);
-      } else {
-        refCountMap.set(node, count - 1);
-      }
-    });
+    hiddenNodes.forEach(node => refCountedRelease(refCountMap, node, () => node.removeAttribute("aria-hidden")));
+    inertedNodes.forEach(node =>
+      refCountedRelease(inertRefCountMap, node, () => {
+        (node as HTMLElement).inert = false;
+      }),
+    );
     if (wrapper === observerStack[observerStack.length - 1]) {
       observerStack.pop();
       observerStack[observerStack.length - 1]?.observe();
@@ -210,10 +273,11 @@ export function createHideOutside(options: CreateHideOutsideOptions): void {
       disabled: !!access(options.disabled),
       targets: access(options.targets),
       root: access(options.root),
+      inert: !!access(options.inert),
     }),
-    ({ disabled, targets, root }) => {
+    ({ disabled, targets, root, inert }) => {
       if (disabled) return;
-      return ariaHideOutside(targets, root, options.alwaysVisibleSelector);
+      return ariaHideOutside(targets, root, options.alwaysVisibleSelector, inert);
     },
   );
 }

--- a/packages/interaction/test/hide-outside.test.ts
+++ b/packages/interaction/test/hide-outside.test.ts
@@ -2,8 +2,6 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { createRoot, createSignal, flush } from "solid-js";
 import { ariaHideOutside, createHideOutside } from "../src/index.js";
 
-// ─── ariaHideOutside ──────────────────────────────────────────────────────────
-
 describe("ariaHideOutside", () => {
   let container: HTMLDivElement;
   let target: HTMLDivElement;
@@ -110,9 +108,58 @@ describe("ariaHideOutside", () => {
     expect(sibling.getAttribute("aria-hidden")).toBe("true");
     sibling.removeAttribute("aria-hidden");
   });
-});
 
-// ─── createHideOutside ────────────────────────────────────────────────────────
+  it("does not set inert by default", () => {
+    const cleanup = ariaHideOutside([target]);
+    expect(sibling.inert).toBeFalsy();
+    cleanup();
+  });
+
+  it("sets inert on hidden elements when inert=true", () => {
+    const cleanup = ariaHideOutside([target], document.body, undefined, true);
+    expect(sibling.inert).toBe(true);
+    expect(sibling.getAttribute("aria-hidden")).toBe("true");
+    cleanup();
+    expect(sibling.inert).toBeFalsy();
+  });
+
+  it("ref-counts inert across nested calls", () => {
+    const cleanup1 = ariaHideOutside([target], document.body, undefined, true);
+    const cleanup2 = ariaHideOutside([target], document.body, undefined, true);
+
+    expect(sibling.inert).toBe(true);
+    cleanup2();
+    expect(sibling.inert).toBe(true); // outer still holds the ref
+    cleanup1();
+    expect(sibling.inert).toBeFalsy();
+  });
+
+  it("does not manage pre-existing inert elements", () => {
+    sibling.inert = true;
+
+    const cleanup = ariaHideOutside([target], document.body, undefined, true);
+    cleanup();
+
+    expect(sibling.inert).toBe(true);
+    sibling.inert = false;
+  });
+
+  it("does not set inert on a node left alone due to pre-existing aria-hidden", () => {
+    // Regression test: a node with an author-set aria-hidden is left untouched by the
+    // aria-hidden ref-counting (see "does not manage pre-existing aria-hidden elements" above).
+    // inert=true must respect that same "not ours to manage" boundary — it must not be applied
+    // to this node just because inert=true was requested for the call as a whole.
+    sibling.setAttribute("aria-hidden", "true");
+
+    const cleanup = ariaHideOutside([target], document.body, undefined, true);
+    expect(sibling.inert).toBeFalsy();
+    cleanup();
+    expect(sibling.inert).toBeFalsy();
+    expect(sibling.getAttribute("aria-hidden")).toBe("true"); // still untouched
+
+    sibling.removeAttribute("aria-hidden");
+  });
+});
 
 describe("createHideOutside", () => {
   let container: HTMLDivElement;
@@ -252,5 +299,26 @@ describe("createHideOutside", () => {
     expect(sibling.getAttribute("aria-hidden")).toBeNull();
     dispose();
     sibling.removeAttribute("aria-live");
+  });
+
+  it("sets inert alongside aria-hidden when inert=true", () => {
+    const dispose = createRoot(d => {
+      createHideOutside({ targets: [target], inert: true });
+      return d;
+    });
+    flush();
+    expect(sibling.inert).toBe(true);
+    dispose();
+    expect(sibling.inert).toBeFalsy();
+  });
+
+  it("does not set inert when inert is omitted", () => {
+    const dispose = createRoot(d => {
+      createHideOutside({ targets: [target] });
+      return d;
+    });
+    flush();
+    expect(sibling.inert).toBeFalsy();
+    dispose();
   });
 });

--- a/packages/interaction/test/interact-outside.test.ts
+++ b/packages/interaction/test/interact-outside.test.ts
@@ -5,8 +5,6 @@ import {
   type CreateInteractOutsideProps,
 } from "../src/index.js";
 
-// ─── PointerEvent polyfill (jsdom does not include it) ────────────────────────
-
 beforeAll(() => {
   if (!("PointerEvent" in window)) {
     class MockPointerEvent extends MouseEvent {
@@ -21,8 +19,6 @@ beforeAll(() => {
     (global as unknown as Record<string, unknown>)["PointerEvent"] = MockPointerEvent;
   }
 });
-
-// ─── Test helpers ─────────────────────────────────────────────────────────────
 
 type ElementKind = "div" | "svg";
 
@@ -78,16 +74,12 @@ function setupTest(
   };
 }
 
-// ─── Test configurations ──────────────────────────────────────────────────────
-
 const testConfigurations: { name: string; inside: ElementKind; outside: ElementKind }[] = [
   { name: "HTML ref with HTML outside", inside: "div", outside: "div" },
   { name: "SVG ref with HTML outside", inside: "svg", outside: "div" },
   { name: "HTML ref with SVG outside", inside: "div", outside: "svg" },
   { name: "SVG ref with SVG outside", inside: "svg", outside: "svg" },
 ];
-
-// ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe("createInteractOutside", () => {
   beforeEach(() => {

--- a/packages/intersection-observer/src/index.ts
+++ b/packages/intersection-observer/src/index.ts
@@ -6,6 +6,7 @@ import {
   runWithOwner,
   untrack,
   DEV,
+  NotReadyError,
 } from "solid-js";
 import type { Accessor } from "solid-js";
 import { isServer } from "@solidjs/web";
@@ -19,13 +20,13 @@ import {
 // Sentinel for the "not yet observed" pending state.
 const NOT_SET: unique symbol = Symbol();
 
-/** Thrown by `isVisible()` and `createVisibilityObserver()` when called before the first IntersectionObserver callback has fired. Integrates with `<Loading>`. */
-export class NotReadyError extends Error {
-  constructor(message = "Not yet observed") {
-    super(message);
-    this.name = "NotReadyError";
-  }
-}
+/**
+ * Re-exported from `solid-js`. `isVisible()`/`createVisibilityObserver()` throw this before the
+ * first IntersectionObserver callback has fired, so `<Loading>` boundaries can catch it (they
+ * check `instanceof` against this exact class — a locally-defined lookalike class would not be
+ * recognized and would crash rendering instead of showing the Loading fallback).
+ */
+export { NotReadyError };
 
 export type AddIntersectionObserverEntry = (el: Element) => void;
 export type RemoveIntersectionObserverEntry = (el: Element) => void;

--- a/packages/intersection-observer/src/index.ts
+++ b/packages/intersection-observer/src/index.ts
@@ -368,8 +368,6 @@ export function createVisibilityObserver(
   return visible;
 }
 
-// ─── Occurrence ───────────────────────────────────────────────────────────────
-
 export const Occurrence = {
   Entering: "Entering",
   Leaving: "Leaving",
@@ -423,8 +421,6 @@ export function withOccurrence<Ctx extends {}>(
     };
   };
 }
-
-// ─── Direction ────────────────────────────────────────────────────────────────
 
 export const DirectionX = {
   Left: "Left",

--- a/packages/intersection-observer/test/index.test.ts
+++ b/packages/intersection-observer/test/index.test.ts
@@ -1,4 +1,4 @@
-import { createRoot, createSignal, flush } from "solid-js";
+import { createRoot, createSignal, flush, NotReadyError } from "solid-js";
 import { describe, test, expect, beforeEach } from "vitest";
 
 import {
@@ -318,7 +318,12 @@ describe("createIntersectionObserver", () => {
 
       flush(); // let the element effect observe div
 
-      expect(() => isVisible(div), "should throw NotReadyError before first IO").toThrow();
+      // Asserting the class specifically (not just "throws something") matters here:
+      // a lookalike NotReadyError class that isn't `instanceof` the real solid-js one
+      // wouldn't be recognized by <Loading> boundaries and would crash rendering instead.
+      expect(() => isVisible(div), "should throw the real NotReadyError before first IO").toThrow(
+        NotReadyError,
+      );
 
       instance.__TEST__onChange({ isIntersecting: true });
       flush();
@@ -622,8 +627,8 @@ describe("createVisibilityObserver", () => {
 
       expect(
         () => isVisible(),
-        "should throw NotReadyError before first observation",
-      ).toThrow();
+        "should throw the real NotReadyError before first observation",
+      ).toThrow(NotReadyError);
 
       const isVisibleFalse = createVisibilityObserver(div, { initialValue: false });
       expect(isVisibleFalse(), "should return false with initialValue: false").toBe(false);

--- a/packages/jsx-tokenizer/stories/jsx-tokenizer.stories.tsx
+++ b/packages/jsx-tokenizer/stories/jsx-tokenizer.stories.tsx
@@ -34,8 +34,6 @@ const meta = preview.meta({
 
 export default meta;
 
-// ── Story 1: Tab bar from token children ──────────────────────────────────────
-
 type TabData = { id: string; label: string };
 const TabTokenizer = createTokenizer<TabData>({ name: "tabs" });
 const Tab = createToken(
@@ -114,8 +112,6 @@ export const TabBarFromTokens = meta.story({
     );
   },
 });
-
-// ── Story 2: Token as its own tokenizer (standalone token) ────────────────────
 
 type CrumbData = { label: string; href?: string };
 const Crumb = createToken(
@@ -214,8 +210,6 @@ export const StandaloneToken = meta.story({
     );
   },
 });
-
-// ── Story 3: Tokens mixed with plain JSX (includeJSXElements) ─────────────────
 
 type CalloutData = { kind: "info" | "tip" | "warning"; text: string };
 const CalloutTokenizer = createTokenizer<CalloutData>({ name: "callout" });
@@ -316,8 +310,6 @@ export const MixedTokensAndJSX = meta.story({
     );
   },
 });
-
-// ── Story 4: Array of tokenizers ──────────────────────────────────────────────
 
 type ActionData = { label: string; kbd?: string; description?: string; danger?: boolean };
 const ActionTokenizer = createTokenizer<ActionData>({ name: "action" });

--- a/packages/list/stories/list.stories.tsx
+++ b/packages/list/stories/list.stories.tsx
@@ -28,8 +28,6 @@ const meta = preview.meta({
 
 export default meta;
 
-// ── Story 1: Index tracks position ────────────────────────────────────────────
-
 export const IndexOnReorder = meta.story({
   name: "Index tracks position",
   parameters: {
@@ -108,8 +106,6 @@ export const IndexOnReorder = meta.story({
     );
   },
 });
-
-// ── Story 2: Value updates in place ───────────────────────────────────────────
 
 export const ValueInPlace = meta.story({
   name: "Value updates in place",
@@ -193,8 +189,6 @@ export const ValueInPlace = meta.story({
   },
 });
 
-// ── Story 3: Fallback when empty ──────────────────────────────────────────────
-
 export const FallbackOnEmpty = meta.story({
   name: "Fallback when empty",
   parameters: {
@@ -262,8 +256,6 @@ export const FallbackOnEmpty = meta.story({
     );
   },
 });
-
-// ── Story 4: listArray programmatic mapper ────────────────────────────────────
 
 export const ListArrayMapper = meta.story({
   name: "listArray — programmatic mapper",

--- a/packages/match/stories/match.stories.tsx
+++ b/packages/match/stories/match.stories.tsx
@@ -30,8 +30,6 @@ const meta = preview.meta({
 
 export default meta;
 
-// ── Story 1: Discriminated union by type field ────────────────────────────────
-
 type Shape =
   | { type: "circle"; radius: number }
   | { type: "rect"; width: number; height: number }
@@ -142,8 +140,6 @@ export const DiscriminatedUnion = meta.story({
   },
 });
 
-// ── Story 2: Custom tag field ─────────────────────────────────────────────────
-
 type Notification =
   | { kind: "info"; message: string }
   | { kind: "warning"; message: string; code: number }
@@ -240,8 +236,6 @@ export const CustomTagField = meta.story({
   },
 });
 
-// ── Story 3: Partial matching with fallback ───────────────────────────────────
-
 type MediaEvent =
   | { type: "play" }
   | { type: "pause" }
@@ -329,8 +323,6 @@ export const PartialMatch = meta.story({
     );
   },
 });
-
-// ── Story 4: MatchValue on union literals ─────────────────────────────────────
 
 type Status = "idle" | "loading" | "success" | "error";
 

--- a/packages/notification/src/index.ts
+++ b/packages/notification/src/index.ts
@@ -1,4 +1,4 @@
-import { action, createOptimistic, createSignal, onCleanup, type Accessor } from "solid-js";
+import { action, affects, createOptimistic, createSignal, onCleanup, type Accessor } from "solid-js";
 import { isServer } from "@solidjs/web";
 import { INTERNAL_OPTIONS, isDev, noop, access, type MaybeAccessor } from "@solid-primitives/utils";
 import { createPermission } from "@solid-primitives/permission";
@@ -223,9 +223,13 @@ export function createNotificationPermission(): {
   const permission = createPermission("notifications");
   const [pending, setPending] = createOptimistic(false, INTERNAL_OPTIONS);
 
-  // createPermission tracks state via the change event — no manual update needed
+  // createPermission tracks state via the change event — no manual update needed.
+  // affects(permission) additionally makes isPending(permission) read true for the whole
+  // request (the standard idiom for callers who don't want the bespoke `pending` accessor),
+  // alongside the existing manual `pending` signal kept for backward compatibility.
   const requestPermission = action(function* () {
     setPending(true);
+    affects(permission);
     try {
       yield Notification.requestPermission();
     } finally {

--- a/packages/notification/stories/notification.stories.tsx
+++ b/packages/notification/stories/notification.stories.tsx
@@ -40,8 +40,6 @@ function permBadge(state: string): "success" | "error" | "warning" | "default" {
  *  Necessary because Chrome blocks Notification.requestPermission() inside iframes. */
 const openInTab = () => window.open(window.location.href, "_blank");
 
-// ─── Meta ─────────────────────────────────────────────────────────────────────
-
 const meta = preview.meta({
   title: "Browser APIs/Notification",
   tags: ["autodocs"],
@@ -56,8 +54,6 @@ const meta = preview.meta({
 });
 
 export default meta;
-
-// ─── createNotificationPermission ────────────────────────────────────────────
 
 export const PermissionFlow = meta.story({
   name: "Request & live permission state",
@@ -133,8 +129,6 @@ export const PermissionFlow = meta.story({
     );
   },
 });
-
-// ─── createNotification ───────────────────────────────────────────────────────
 
 export const ReactiveInstance = meta.story({
   name: "Reactive instance & events",
@@ -249,8 +243,6 @@ export const ReactiveInstance = meta.story({
     );
   },
 });
-
-// ─── makeNotification ─────────────────────────────────────────────────────────
 
 export const ImperativeAPI = meta.story({
   name: "Imperative show & close",

--- a/packages/notification/test/index.test.ts
+++ b/packages/notification/test/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi, beforeAll, afterAll, beforeEach } from "vitest";
-import { createRoot, createSignal, flush, onCleanup } from "solid-js";
+import { createEffect, createRoot, createSignal, flush, isPending, onCleanup } from "solid-js";
 import {
   isNotificationSupported,
   makeNotification,
@@ -532,6 +532,42 @@ describe("createNotificationPermission", () => {
     await promise;
     flush();
     expect(pending()).toBe(false);
+
+    dispose();
+  });
+
+  test("isPending(permission) reads true while requestPermission is in flight (affects())", async () => {
+    let resolve!: (v: NotificationPermission) => void;
+    MockNotification.requestPermission.mockImplementation(
+      () => new Promise<NotificationPermission>(r => (resolve = r)),
+    );
+
+    // isPending must be read inside a genuinely tracked scope (an effect/JSX) to give
+    // reliable results — a bare top-level `isPending(fn)` call outside any computation
+    // does not exercise the same code path and can report stale/incorrect values.
+    const log: boolean[] = [];
+    const { requestPermission, dispose } = createRoot(dispose => {
+      const { permission, requestPermission } = createNotificationPermission();
+      createEffect(
+        () => isPending(permission),
+        p => {
+          log.push(p);
+        },
+      );
+      return { requestPermission, dispose };
+    });
+
+    flush();
+    expect(log).toEqual([false]);
+
+    const promise = requestPermission();
+    flush();
+    expect(log).toEqual([false, true]);
+
+    resolve("granted");
+    await promise;
+    flush();
+    expect(log.at(-1)).toBe(false);
 
     dispose();
   });

--- a/packages/notification/test/index.test.ts
+++ b/packages/notification/test/index.test.ts
@@ -7,8 +7,6 @@ import {
   createNotificationPermission,
 } from "../src/index.js";
 
-// ── Mock Notification API ─────────────────────────────────────────────────────
-
 class MockNotification {
   static permission: NotificationPermission = "granted";
   static requestPermission = vi.fn().mockResolvedValue("granted" as NotificationPermission);
@@ -53,8 +51,6 @@ class MockNotification {
   }
 }
 
-// ── Mock Permissions API ──────────────────────────────────────────────────────
-
 const mockPermStatus = {
   state: "granted" as PermissionState,
   _listeners: [] as (() => void)[],
@@ -70,8 +66,6 @@ const mockPermStatus = {
     this._listeners.forEach(fn => fn());
   },
 };
-
-// ── Global setup ──────────────────────────────────────────────────────────────
 
 beforeAll(() => {
   Object.defineProperty(window, "Notification", {
@@ -99,15 +93,11 @@ beforeEach(() => {
   mockPermStatus._listeners = [];
 });
 
-// ── isNotificationSupported ───────────────────────────────────────────────────
-
 describe("isNotificationSupported", () => {
   test("returns true when Notification is available", () => {
     expect(isNotificationSupported()).toBe(true);
   });
 });
-
-// ── makeNotification ──────────────────────────────────────────────────────────
 
 describe("makeNotification", () => {
   test("show creates a Notification with the given title", () => {
@@ -179,8 +169,6 @@ describe("makeNotification", () => {
     expect(instance.close).toHaveBeenCalled();
   });
 });
-
-// ── createNotification ────────────────────────────────────────────────────────
 
 describe("createNotification", () => {
   test("initial state: notification is null, supported is true", () => {
@@ -331,8 +319,6 @@ describe("createNotification", () => {
     dispose();
   });
 
-  // ── Event callbacks ─────────────────────────────────────────────────────────
-
   test("onClick fires when click event is dispatched", () => {
     const onClick = vi.fn();
 
@@ -428,8 +414,6 @@ describe("createNotification", () => {
     dispose();
   });
 });
-
-// ── createNotificationPermission ──────────────────────────────────────────────
 
 describe("createNotificationPermission", () => {
   test("permission starts as unknown before query resolves", () => {

--- a/packages/pagination/test/hydration.test.tsx
+++ b/packages/pagination/test/hydration.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  renderHydrationRoundTrip,
+  type HydrationRoundTripResult,
+} from "../../../scripts/test-utils/hydration-harness.ts";
+
+// createPagination backs its return value with several render-body createMemo calls
+// (opts, page, pages, start/showFirst/showPrev/showNext/showLast, paginationProps) — the same
+// class of construct hope-ui's solid-primitives-eval.md flags as a hydration-id hazard, and the
+// single most memo-heavy example across the packages that pattern was found in. Renders through
+// the real, standard @solidjs/web renderToString + hydrate pipeline with the package resolved
+// from its published `dist` build.
+const APP_SOURCE = `
+import { createPagination } from "@solid-primitives/pagination";
+import { For } from "solid-js";
+
+export default function App() {
+  const [paginationProps] = createPagination({ pages: 5, initialPage: 2 });
+  return (
+    <nav id="out">
+      <For each={paginationProps()}>{props => <button {...props} />}</For>
+    </nav>
+  );
+}
+`;
+
+describe("createPagination hydration round trip", () => {
+  let result: HydrationRoundTripResult | undefined;
+
+  afterEach(() => {
+    result?.cleanup();
+    result = undefined;
+  });
+
+  it("server-renders the pagination buttons", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    expect(result.html).toContain("<button");
+  });
+
+  it("hydrates without any console error or warning", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    expect(result.consoleMessages).toEqual([]);
+  });
+
+  it("hydrates the DOM with the correct current-page button marked aria-current", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    const current = result.container.querySelector('[aria-current="page"]');
+    expect(current?.textContent).toBe("2");
+  });
+});

--- a/packages/props/stories/props.stories.tsx
+++ b/packages/props/stories/props.stories.tsx
@@ -18,8 +18,6 @@ import {
 } from "../../../.storybook/ui/index.js";
 import { colors, font, radii } from "../../../.storybook/ui/tokens.js";
 
-/* ── Module-level helpers ────────────────────────────────────────────────────── */
-
 const statusColors = {
   ok: { bg: "#dcfce7", fg: "#16a34a" },
   warn: { bg: "#fef9c3", fg: "#ca8a04" },
@@ -61,8 +59,6 @@ const FILTER_DEMO_KEYS = [
   "onClick",
 ] as const;
 
-/* ── Meta ────────────────────────────────────────────────────────────────────── */
-
 const meta = preview.meta({
   title: "Utilities/Props",
   tags: ["autodocs"],
@@ -73,8 +69,6 @@ const meta = preview.meta({
 });
 
 export default meta;
-
-/* ── 1. combineProps: handler chaining ───────────────────────────────────────── */
 
 export const HandlerChaining = meta.story({
   name: "Handler chaining",
@@ -123,8 +117,6 @@ export const HandlerChaining = meta.story({
     );
   },
 });
-
-/* ── 2. combineProps: class & style merging ──────────────────────────────────── */
 
 export const StyleAndClassMerge = meta.story({
   name: "Class & style merging",
@@ -185,8 +177,6 @@ export const StyleAndClassMerge = meta.story({
   },
 });
 
-/* ── 3. combineHandlers: null skipping ───────────────────────────────────────── */
-
 export const NullHandlerSkip = meta.story({
   name: "Null handler skipping",
   parameters: {
@@ -239,8 +229,6 @@ export const NullHandlerSkip = meta.story({
   },
 });
 
-/* ── 4. filterProps: dynamic predicate ───────────────────────────────────────── */
-
 export const DynamicFilter = meta.story({
   name: "Dynamic prefix filter",
   parameters: {
@@ -272,8 +260,6 @@ export const DynamicFilter = meta.story({
     );
   },
 });
-
-/* ── 5. partitionProps: own vs DOM split ─────────────────────────────────────── */
 
 export const OwnVsDomSplit = meta.story({
   name: "Own vs DOM split",

--- a/packages/scroll/src/preventScroll.ts
+++ b/packages/scroll/src/preventScroll.ts
@@ -10,20 +10,9 @@
  * https://github.com/theKashey/react-remove-scroll
  */
 
-import { createEffect, createSignal } from "solid-js";
+import { createEffect, createSignal, type Signal } from "solid-js";
 import { isServer } from "@solidjs/web";
-import { access, type MaybeAccessor } from "@solid-primitives/utils";
-
-function contains(wrapper: HTMLElement, target: HTMLElement): boolean {
-  if (wrapper.contains(target)) return true;
-  let current: HTMLElement | null = target;
-  while (current) {
-    if (current === wrapper) return true;
-    // @ts-expect-error: _$host is a SolidJS-internal property set on portal roots
-    current = current._$host ?? current.parentElement;
-  }
-  return false;
-}
+import { access, contains, globalRegistry, type MaybeAccessor } from "@solid-primitives/utils";
 
 type Axis = "x" | "y";
 
@@ -44,21 +33,11 @@ export type CreatePreventScrollProps = {
   allowPinchZoom?: MaybeAccessor<boolean>;
 };
 
-// ─── Module-level stack ───────────────────────────────────────────────────────
-// Tracks active instances; only the topmost one installs wheel/touch handlers.
-
-const [preventScrollStack, setPreventScrollStack] = createSignal<string[]>([], {
-  ownedWrite: true,
-});
-
-const isActive = (id: string): boolean => {
-  const stack = preventScrollStack();
-  return stack.length > 0 && stack[stack.length - 1] === id;
-};
-
-// ─── Body style tracker ───────────────────────────────────────────────────────
-// Multiple nested instances share a key; the original styles are only restored
-// once the last instance cleans up.
+// Uses globalRegistry (Symbol.for(...) on globalThis, not module-scope bindings) so the
+// active-instance stack and body-style ref-counts stay correct even if the app's dependency
+// graph ends up with more than one copy of this package installed — module-scope state would
+// otherwise be split across copies and the ref-counting would break (e.g. the "topmost
+// instance" check disagreeing between copies).
 
 type ActiveStyle = {
   activeCount: number;
@@ -66,7 +45,24 @@ type ActiveStyle = {
   properties: string[];
 };
 
-const activeBodyStyles = new Map<string, ActiveStyle>();
+type PreventScrollRegistry = {
+  stack: Signal<string[]>;
+  activeBodyStyles: Map<string, ActiveStyle>;
+  /** Shared across duplicate package copies so instance ids never collide on the shared stack. */
+  nextId: number;
+};
+
+const getRegistry = (): PreventScrollRegistry =>
+  globalRegistry<PreventScrollRegistry>("@solid-primitives/scroll:prevent-scroll", () => ({
+    stack: createSignal<string[]>([], { ownedWrite: true }),
+    activeBodyStyles: new Map(),
+    nextId: 0,
+  }));
+
+const isActive = (id: string): boolean => {
+  const stack = getRegistry().stack[0]();
+  return stack.length > 0 && stack[stack.length - 1] === id;
+};
 
 function applyBodyStyle(
   key: string,
@@ -74,6 +70,8 @@ function applyBodyStyle(
   style: Partial<CSSStyleDeclaration>,
   properties: { key: string; value: string }[],
 ): () => void {
+  const activeBodyStyles = getRegistry().activeBodyStyles;
+
   const originalStyles: Partial<CSSStyleDeclaration> = {};
   for (const k in style) {
     originalStyles[k] = element.style[k as keyof CSSStyleDeclaration] as string;
@@ -115,8 +113,6 @@ function applyBodyStyle(
     }
   };
 }
-
-// ─── Scroll helpers ───────────────────────────────────────────────────────────
 
 function getScrollDimensions(element: HTMLElement, axis: Axis): [number, number, number] {
   return axis === "x"
@@ -185,10 +181,6 @@ function wouldScroll(
   return true;
 }
 
-// ─── Primitive ────────────────────────────────────────────────────────────────
-
-let _nextId = 0;
-
 /**
  * Prevents scrolling outside of the given element.
  *
@@ -198,7 +190,9 @@ let _nextId = 0;
 export const createPreventScroll = (props: CreatePreventScrollProps = {}): void => {
   if (isServer) return;
 
-  const id = String(_nextId++);
+  const registry = getRegistry();
+  const id = String(registry.nextId++);
+  const [, setPreventScrollStack] = registry.stack;
 
   let currentTouchStart: [number, number] = [0, 0];
   let currentTouchStartAxis: Axis | undefined;

--- a/packages/set/stories/set.stories.tsx
+++ b/packages/set/stories/set.stories.tsx
@@ -34,8 +34,6 @@ const meta = preview.meta({
 
 export default meta;
 
-// ─── Story 1: Key-level reactivity ──────────────────────────────────────────
-
 const FRUITS = ["apple", "banana", "cherry", "dragonfruit", "elderberry", "fig"];
 
 export const KeyLevelReactivity = meta.story({
@@ -85,8 +83,6 @@ export const KeyLevelReactivity = meta.story({
     );
   },
 });
-
-// ─── Story 2: Set algebra ────────────────────────────────────────────────────
 
 const NUMS = [1, 2, 3, 4, 5, 6, 7, 8];
 const numBtnStyle = {
@@ -218,8 +214,6 @@ export const SetAlgebra = meta.story({
     );
   },
 });
-
-// ─── Story 3: WeakSet object membership ─────────────────────────────────────
 
 type User = { name: string };
 const ALICE: User = { name: "Alice" };

--- a/packages/signal-builders/stories/signal-builders.stories.tsx
+++ b/packages/signal-builders/stories/signal-builders.stories.tsx
@@ -48,8 +48,6 @@ const meta = preview.meta({
 
 export default meta;
 
-// ── Story 1: Array pipeline ───────────────────────────────────────────────────
-
 export const ArrayPipeline = meta.story({
   name: "Sort & filter pipeline",
   parameters: {
@@ -120,8 +118,6 @@ export const ArrayPipeline = meta.story({
   },
 });
 
-// ── Story 2: String pipeline ──────────────────────────────────────────────────
-
 export const StringPipeline = meta.story({
   name: "Name badge formatter",
   parameters: {
@@ -152,8 +148,6 @@ export const StringPipeline = meta.story({
     );
   },
 });
-
-// ── Story 3: Number pipeline ──────────────────────────────────────────────────
 
 export const NumberPipeline = meta.story({
   name: "Price calculator",
@@ -236,8 +230,6 @@ export const NumberPipeline = meta.story({
   },
 });
 
-// ── Story 4: Object pipeline ──────────────────────────────────────────────────
-
 export const ObjectPipeline = meta.story({
   name: "Profile update chain",
   parameters: {
@@ -282,8 +274,6 @@ export const ObjectPipeline = meta.story({
     );
   },
 });
-
-// ── Story 5: Cross-category chain ─────────────────────────────────────────────
 
 export const ConvertAndCompute = meta.story({
   name: "Text input → clamped score",

--- a/packages/signal-builders/test/index.test.ts
+++ b/packages/signal-builders/test/index.test.ts
@@ -43,8 +43,6 @@ import {
 import { createRoot, createSignal, flush } from "solid-js";
 import { compare } from "@solid-primitives/utils";
 
-// ─── BOOLEAN ────────────────────────────────────────────────────────────────
-
 describe("toggle()", () => {
   it("flips the current value", () =>
     createRoot(dispose => {
@@ -62,8 +60,6 @@ describe("toggle()", () => {
       dispose();
     }));
 });
-
-// ─── CONVERT ────────────────────────────────────────────────────────────────
 
 describe("string()", () => {
   it("coerces a number to string", () =>
@@ -180,8 +176,6 @@ describe("join()", () => {
   });
 });
 
-// ─── STRING ─────────────────────────────────────────────────────────────────
-
 describe("lowercase()", () => {
   it("lowercases a string", () =>
     createRoot(dispose => {
@@ -291,8 +285,6 @@ describe("template`...`", () => {
     dispose();
   });
 });
-
-// ─── NUMBER ─────────────────────────────────────────────────────────────────
 
 describe("add()", () => {
   it("adds two numbers", () =>
@@ -543,8 +535,6 @@ describe("clamp()", () => {
     dispose();
   });
 });
-
-// ─── ARRAY ──────────────────────────────────────────────────────────────────
 
 describe("push()", () => {
   it("appends items to the array", () =>
@@ -919,8 +909,6 @@ describe("filterOutInstance()", () => {
     }));
 });
 
-// ─── OBJECT ─────────────────────────────────────────────────────────────────
-
 describe("omit()", () => {
   it("omits a single key", () =>
     createRoot(dispose => {
@@ -1045,8 +1033,6 @@ describe("merge()", () => {
     dispose();
   });
 });
-
-// ─── UPDATE ─────────────────────────────────────────────────────────────────
 
 describe("update()", () => {
   it("sets a top-level key to a plain value", () =>

--- a/packages/sse/src/worker-handler.ts
+++ b/packages/sse/src/worker-handler.ts
@@ -56,7 +56,6 @@ function handleMessage(data: SSEWorkerMessage, postBack: (msg: SSEWorkerMessage)
   }
 }
 
-// ── Dedicated Worker ──────────────────────────────────────────────────────────
 // `DedicatedWorkerGlobalScope.postMessage` takes one argument, but the DOM lib
 // types `self` as `Window` (which requires `targetOrigin`). Cast to the minimal
 // structural interface we actually need — the project's tsconfig does not include
@@ -66,7 +65,6 @@ self.addEventListener("message", (e: MessageEvent<SSEWorkerMessage>) => {
   handleMessage(e.data, msg => (self as unknown as DedicatedPost).postMessage(msg));
 });
 
-// ── SharedWorker — each connecting tab gets its own MessagePort ───────────────
 self.addEventListener("connect", (e: Event) => {
   const port = (e as MessageEvent).ports[0];
   if (!port) return;

--- a/packages/sse/src/worker.ts
+++ b/packages/sse/src/worker.ts
@@ -5,8 +5,6 @@ import {
   type SSESourceFn,
 } from "./sse.ts";
 
-// ─── Protocol types ───────────────────────────────────────────────────────────
-
 /**
  * Discriminated union of all messages exchanged between the main thread
  * and the Worker. Main → Worker: `connect` | `disconnect`.
@@ -25,8 +23,6 @@ export type SSEWorkerTarget = {
   addEventListener(type: "message", listener: (e: MessageEvent<SSEWorkerMessage>) => void): void;
   removeEventListener(type: "message", listener: (e: MessageEvent<SSEWorkerMessage>) => void): void;
 };
-
-// ─── makeSSEWorker ────────────────────────────────────────────────────────────
 
 /**
  * Returns a `SSESourceFn` that tunnels EventSource connections through a Worker.

--- a/packages/sse/stories/sse.stories.tsx
+++ b/packages/sse/stories/sse.stories.tsx
@@ -21,8 +21,6 @@ import {
   StatRow,
 } from "../../../.storybook/ui/index.js";
 
-// ─── Mock SSE source factories (no server required) ───────────────────────────
-
 function buildHandle() {
   let rs: number = SSEReadyState.CONNECTING;
   const source = {
@@ -127,8 +125,6 @@ const makeFailingMock = (failAfterMs = 3000, msgCount = 2): SSESourceFn => {
   };
 };
 
-// ─── Meta ─────────────────────────────────────────────────────────────────────
-
 const meta = preview.meta({
   title: "Network/SSE",
   tags: ["autodocs"],
@@ -144,12 +140,8 @@ const meta = preview.meta({
 
 export default meta;
 
-// ─── Shared display helpers ───────────────────────────────────────────────────
-
 const STATE_LABEL = ["connecting", "open", "closed"] as const;
 const STATE_VARIANT = ["info", "success", "error"] as const;
-
-// ─── Stories ─────────────────────────────────────────────────────────────────
 
 export const StreamWithControlsStory = meta.story({
   name: "Reactive stream with state & controls",

--- a/packages/sse/test/index.test.ts
+++ b/packages/sse/test/index.test.ts
@@ -11,8 +11,6 @@ beforeEach(() => {
 });
 afterAll(() => vi.useRealTimers());
 
-// ── makeSSE ───────────────────────────────────────────────────────────────────
-
 describe("makeSSE", () => {
   it("creates an EventSource in CONNECTING state", () => {
     const [source, cleanup] = makeSSE("https://example.com/events");
@@ -68,8 +66,6 @@ describe("makeSSE", () => {
     expect(() => cleanup()).not.toThrow();
   });
 });
-
-// ── createSSE ─────────────────────────────────────────────────────────────────
 
 describe("createSSE", () => {
   it("starts in CONNECTING state", () =>
@@ -323,8 +319,6 @@ describe("createSSE", () => {
       }),
     ));
 });
-
-// ── createSSEStream ───────────────────────────────────────────────────────────
 
 describe("createSSEStream", () => {
   it("data throws NotReadyError before first message arrives", () =>

--- a/packages/sse/test/transform.test.ts
+++ b/packages/sse/test/transform.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { json, ndjson, lines, number, safe, pipe } from "../src/transform.js";
 
-// ── json ──────────────────────────────────────────────────────────────────────
-
 describe("json", () => {
   it("parses a JSON object", () => {
     expect(json('{"a":1}')).toEqual({ a: 1 });
@@ -24,8 +22,6 @@ describe("json", () => {
     expect(() => json("not json")).toThrow();
   });
 });
-
-// ── ndjson ────────────────────────────────────────────────────────────────────
 
 describe("ndjson", () => {
   it("parses each line as a JSON value", () => {
@@ -57,8 +53,6 @@ describe("ndjson", () => {
   });
 });
 
-// ── lines ─────────────────────────────────────────────────────────────────────
-
 describe("lines", () => {
   it("splits data into lines", () => {
     expect(lines("one\ntwo\nthree")).toEqual(["one", "two", "three"]);
@@ -81,8 +75,6 @@ describe("lines", () => {
   });
 });
 
-// ── number ────────────────────────────────────────────────────────────────────
-
 describe("number", () => {
   it("parses an integer string", () => {
     expect(number("42")).toBe(42);
@@ -104,8 +96,6 @@ describe("number", () => {
     expect(number("not a number")).toBeNaN();
   });
 });
-
-// ── safe ──────────────────────────────────────────────────────────────────────
 
 describe("safe", () => {
   it("returns the transform result when successful", () => {
@@ -143,8 +133,6 @@ describe("safe", () => {
     expect(result).toEqual({ a: 0 });
   });
 });
-
-// ── pipe ──────────────────────────────────────────────────────────────────────
 
 describe("pipe", () => {
   it("passes the string through both transforms in order", () => {

--- a/packages/sse/test/worker.test.ts
+++ b/packages/sse/test/worker.test.ts
@@ -4,8 +4,6 @@ import { createRoot, flush } from "solid-js";
 import { createSSE, SSEReadyState } from "../src/sse.js";
 import { makeSSEWorker, type SSEWorkerMessage, type SSEWorkerTarget } from "../src/worker.js";
 
-// ─── MockWorkerTarget ─────────────────────────────────────────────────────────
-
 /**
  * Minimal stub for a Worker / SharedWorker.port.
  * Records outgoing `postMessage` calls so tests can assert on them,
@@ -23,8 +21,6 @@ class MockWorkerTarget extends EventTarget implements SSEWorkerTarget {
     this.dispatchEvent(new MessageEvent("message", { data }));
   }
 }
-
-// ─── makeSSEWorker unit tests ─────────────────────────────────────────────────
 
 describe("makeSSEWorker", () => {
   it("returns a SSESourceFn (callable function)", () => {
@@ -201,8 +197,6 @@ describe("makeSSEWorker", () => {
     sourceB.close();
   });
 });
-
-// ─── createSSE + makeSSEWorker integration ────────────────────────────────────
 
 describe("createSSE with worker source", () => {
   beforeAll(() => vi.useFakeTimers());

--- a/packages/state-machine/stories/createMachine.stories.tsx
+++ b/packages/state-machine/stories/createMachine.stories.tsx
@@ -31,8 +31,6 @@ const meta = preview.meta({
 
 export default meta;
 
-// ── Story 1: Traffic Light ────────────────────────────────────────────────────
-
 const LIGHTS = [
   { key: "red" as const, color: "#ef4444" },
   { key: "yellow" as const, color: "#f59e0b" },
@@ -123,8 +121,6 @@ export const TrafficLight = meta.story({
   },
 });
 
-// ── Story 2: Lifecycle Counter ────────────────────────────────────────────────
-
 export const LifecycleCounter = meta.story({
   name: "Counter lifecycle",
   parameters: {
@@ -201,8 +197,6 @@ export const LifecycleCounter = meta.story({
     );
   },
 });
-
-// ── Story 3: JSX as State Value ───────────────────────────────────────────────
 
 export const InlineEdit = meta.story({
   name: "JSX as state value",

--- a/packages/state-machine/test/hydration.test.tsx
+++ b/packages/state-machine/test/hydration.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  renderHydrationRoundTrip,
+  type HydrationRoundTripResult,
+} from "../../../scripts/test-utils/hydration-harness.ts";
+
+// createMachine backs its return value with a render-body createMemo — the same class of
+// construct hope-ui's solid-primitives-eval.md flags as a hydration-id hazard. Renders through
+// the real, standard @solidjs/web renderToString + hydrate pipeline with the package resolved
+// from its published `dist` build.
+const APP_SOURCE = `
+import { createMachine } from "@solid-primitives/state-machine";
+
+export default function App() {
+  const state = createMachine({
+    initial: "idle",
+    states: {
+      idle: () => "foo",
+      loading: () => "bar",
+    },
+  });
+  return (
+    <div id="out">
+      <span id="type">{state().type}</span>
+      <span id="value">{state().value}</span>
+    </div>
+  );
+}
+`;
+
+describe("createMachine hydration round trip", () => {
+  let result: HydrationRoundTripResult | undefined;
+
+  afterEach(() => {
+    result?.cleanup();
+    result = undefined;
+  });
+
+  it("server-renders the initial state", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    expect(result.html).toContain("foo");
+  });
+
+  it("hydrates without any console error or warning", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    expect(result.consoleMessages).toEqual([]);
+  });
+
+  it("hydrates the DOM with the correct initial state", async () => {
+    result = await renderHydrationRoundTrip(APP_SOURCE, import.meta.dirname);
+    expect(result.container.querySelector("#type")?.textContent).toBe("idle");
+    expect(result.container.querySelector("#value")?.textContent).toBe("foo");
+  });
+});

--- a/packages/transition-group/stories/transition-group.stories.tsx
+++ b/packages/transition-group/stories/transition-group.stories.tsx
@@ -19,8 +19,6 @@ const meta = preview.meta({
 
 export default meta;
 
-// ─── createSwitchTransition ───────────────────────────────────────────────────
-
 export const SwitchFade = meta.story({
   name: "Fade between elements",
   parameters: {
@@ -203,8 +201,6 @@ export const SwitchModes = meta.story({
     );
   },
 });
-
-// ─── createListTransition ─────────────────────────────────────────────────────
 
 export const ListAddRemove = meta.story({
   name: "Add & remove items",

--- a/packages/upload/test/index.test.tsx
+++ b/packages/upload/test/index.test.tsx
@@ -11,8 +11,6 @@ import {
 import { transformFiles } from "../src/helpers.js";
 import type { UploadFile } from "../src/types.js";
 
-// ── jsdom polyfills ───────────────────────────────────────────────────────────
-
 beforeAll(() => {
   // jsdom does not implement createObjectURL
   vi.stubGlobal("URL", { createObjectURL: (f: File) => `blob:${f.name}` });
@@ -38,8 +36,6 @@ function dispatchChange(input: HTMLInputElement, files: FileList) {
   input.dispatchEvent(event);
 }
 
-// ── transformFiles ────────────────────────────────────────────────────────────
-
 describe("transformFiles", () => {
   it("returns empty array for null input", () => {
     expect(transformFiles(null)).toEqual([]);
@@ -61,8 +57,6 @@ describe("transformFiles", () => {
     expect(result.map(f => f.name)).toEqual(["a.png", "b.jpg"]);
   });
 });
-
-// ── createFilePicker ────────────────────────────────────────────────────────
 
 describe("createFilePicker", () => {
   it("initialises with empty file list, no error, and isLoading=false", () => {
@@ -256,8 +250,6 @@ describe("createFilePicker", () => {
   });
 });
 
-// ── createDropzone ────────────────────────────────────────────────────────────
-
 describe("createDropzone", () => {
   it("initialises with empty files, no error, isLoading=false, and isDragging=false", () => {
     const { files, error, isLoading, isDragging, dispose } = createRoot(dispose => ({
@@ -436,8 +428,6 @@ describe("createDropzone", () => {
   });
 });
 
-// ── dropzone ref callback factory ────────────────────────────────────────────
-
 describe("dropzone", () => {
   it("returns a callable ref with state properties attached", () => {
     const { dz, dispose } = createRoot(dispose => ({
@@ -485,8 +475,6 @@ describe("dropzone", () => {
     dispose();
   });
 });
-
-// ── fileUploader ref callback ─────────────────────────────────────────────────
 
 describe("fileUploader", () => {
   it("returns a function (ref callback)", () => {
@@ -562,8 +550,6 @@ describe("fileUploader", () => {
     dispose();
   });
 });
-
-// ── createFileUploader ──────────────────────────────────────────────────────────
 
 // Builds a minimal UploadFile without needing a real picker
 function makeUploadFile(name = "test.png"): UploadFile {
@@ -872,8 +858,6 @@ describe("createFileUploader", () => {
     dispose();
   });
 });
-
-// ── createFileUploader — XHR path ───────────────────────────────────────────────
 
 function makeMockXhr() {
   const uploadListeners: Record<string, (e: ProgressEvent) => void> = {};

--- a/packages/utils/src/colors/manipulation.ts
+++ b/packages/utils/src/colors/manipulation.ts
@@ -14,8 +14,6 @@ import { clamp } from "../index.ts";
 import { colorToOKLCH, normalizeHue, parseColor } from "./helpers.ts";
 import type { Color, ColorFormat } from "./types.ts";
 
-// ─── Safe parsing ─────────────────────────────────────────────────────────────
-
 /**
  * Like {@link parseColor} but returns `undefined` instead of throwing for invalid input.
  *
@@ -73,8 +71,6 @@ export function detectColorFormat(value: string): ColorFormat | undefined {
   if (/^hsba?\(/i.test(s)) return /^hsba\(/i.test(s) ? "hsba" : "hsb";
   return undefined;
 }
-
-// ─── Manipulation ─────────────────────────────────────────────────────────────
 
 /**
  * Returns a new color with lightness increased by `amount` (0–1 ratio = percentage points).
@@ -151,8 +147,6 @@ export function mix(a: Color, b: Color, ratio = 0.5): Color {
     .withChannelValue("alpha", lerp(ra.getChannelValue("alpha"), rb.getChannelValue("alpha")));
 }
 
-// ─── Accessibility ────────────────────────────────────────────────────────────
-
 /** WCAG 2.1 relative luminance. Alpha is ignored (assumes opaque rendering). */
 function relativeLuminance(color: Color): number {
   const rgb = color.toFormat("rgb");
@@ -211,8 +205,6 @@ export function isReadable(
   if (level === "AAA") return ratio >= (size === "large" ? 4.5 : 7);
   return ratio >= (size === "large" ? 3 : 4.5);
 }
-
-// ─── Color scales ─────────────────────────────────────────────────────────────
 
 /**
  * Returns an array of `steps` colors linearly interpolated in RGB space between

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -16,7 +16,6 @@ import {
   DEV,
 } from "solid-js";
 
-
 // isServer moved from solid-js/web (1.x) to @solidjs/web (2.x).
 // typeof window is a universal fallback compatible with both versions.
 const isServer: boolean = typeof window === "undefined";
@@ -398,8 +397,6 @@ export const afterPaint = (fn: () => void): void => {
   }
 };
 
-// ─── String transforms ────────────────────────────────────────────────────────
-
 /**
  * Parse a string as a single JSON value.
  *
@@ -484,8 +481,6 @@ export function pipe<A, B>(a: (raw: string) => A, b: (a: A) => B): (raw: string)
   return (raw: string): B => b(a(raw));
 }
 
-// ─── DOM helpers ─────────────────────────────────────────────────────────────
-
 /**
  * Check if a wrapper element contains a target element.
  * Portal-aware: follows SolidJS `_$host` links so elements rendered inside
@@ -501,6 +496,26 @@ export const contains = (wrapper: HTMLElement, target: HTMLElement): boolean => 
   }
   return false;
 };
+/**
+ * Returns a singleton value keyed by `key`, shared across every copy of the calling module that
+ * ends up loaded in the same JS realm (a `Symbol.for(key)` slot on `globalThis`, not a module-scope
+ * binding). Use this instead of a plain module-scope `let`/`const` for state that must stay
+ * consistent (ref-counts, active-instance stacks) even if the app's dependency graph ends up with
+ * more than one installed copy of the package — module-scope state would otherwise be split across
+ * copies and go out of sync (e.g. a "topmost instance" check disagreeing between copies).
+ *
+ * ```ts
+ * const registry = globalRegistry("@solid-primitives/my-package:my-state", () => ({
+ *   stack: createSignal<string[]>([], { ownedWrite: true }),
+ *   nextId: 0,
+ * }));
+ * ```
+ */
+export function globalRegistry<T>(key: string, init: () => T): T {
+  const g = globalThis as Record<symbol, T | undefined>;
+  return (g[Symbol.for(key)] ??= init());
+}
+
 /**
  * Wraps a setter function of any signal or store
  *

--- a/packages/utils/test/colors-manipulation.test.ts
+++ b/packages/utils/test/colors-manipulation.test.ts
@@ -16,8 +16,6 @@ import {
   perceptualColorScale,
 } from "../src/colors/manipulation.js";
 
-// ─── Safe parsing ─────────────────────────────────────────────────────────────
-
 describe("tryParseColor", () => {
   it("returns a Color for valid input", () => {
     const result = tryParseColor("#3264C8");
@@ -63,8 +61,6 @@ describe("detectColorFormat", () => {
     expect(detectColorFormat(input)).toBe(expected);
   });
 });
-
-// ─── Manipulation ─────────────────────────────────────────────────────────────
 
 describe("lighten", () => {
   it("increases lightness by amount × 100 percentage points", () => {
@@ -164,8 +160,6 @@ describe("mix", () => {
   });
 });
 
-// ─── Accessibility ────────────────────────────────────────────────────────────
-
 describe("contrastRatio", () => {
   it("black on white = 21", () => {
     expect(contrastRatio(parseColor("#000"), parseColor("#fff"))).toBeCloseTo(21, 0);
@@ -202,8 +196,6 @@ describe("isReadable", () => {
     expect(isReadable(fg, parseColor("#fff"), "AA", "large")).toBe(true);
   });
 });
-
-// ─── Color scales ─────────────────────────────────────────────────────────────
 
 describe("colorScale", () => {
   it("returns exactly `steps` colors", () => {

--- a/packages/utils/test/index.test.ts
+++ b/packages/utils/test/index.test.ts
@@ -1,6 +1,12 @@
 import { describe, test, expect, assert, vi } from "vitest";
 import { createSignal, createStore, flush } from "solid-js";
-import { handleDiffArray, arrayEquals, createHydratableSignal, wrapSetter } from "../src/index.js";
+import {
+  handleDiffArray,
+  arrayEquals,
+  createHydratableSignal,
+  wrapSetter,
+  globalRegistry,
+} from "../src/index.js";
 
 describe("handleDiffArray", () => {
   test("handleAdded called for new array", () => {
@@ -101,6 +107,34 @@ describe("createHydratableSignal", () => {
     const [state, setState] = createHydratableSignal("server", () => "client");
     expect(state()).toEqual("client");
     expect(setState).toBeInstanceOf(Function);
+  });
+});
+
+describe("globalRegistry", () => {
+  test("calls init exactly once and returns the same instance on subsequent calls", () => {
+    const init = vi.fn(() => ({ count: 0 }));
+    const key = `test:globalRegistry:${Math.random()}`;
+    const first = globalRegistry(key, init);
+    const second = globalRegistry(key, init);
+    expect(first).toBe(second);
+    expect(init).toHaveBeenCalledOnce();
+  });
+
+  test("survives a fresh call site sharing the same key — simulates duplicate installed copies", () => {
+    const key = `test:globalRegistry:duplicate-copy:${Math.random()}`;
+    // Simulates two separate module instances of the same package (e.g. a version-skewed
+    // duplicate dependency) each calling globalRegistry with the same key: both must observe
+    // the same mutations, matching real singleton semantics across copies.
+    const registryA = globalRegistry(key, () => ({ stack: [] as string[] }));
+    const registryB = globalRegistry(key, () => ({ stack: ["should never be used"] }));
+    registryA.stack.push("from-a");
+    expect(registryB.stack).toEqual(["from-a"]);
+  });
+
+  test("different keys get independent instances", () => {
+    const a = globalRegistry(`test:globalRegistry:a:${Math.random()}`, () => ({ value: 1 }));
+    const b = globalRegistry(`test:globalRegistry:b:${Math.random()}`, () => ({ value: 2 }));
+    expect(a).not.toBe(b);
   });
 });
 

--- a/packages/vibrate/src/index.ts
+++ b/packages/vibrate/src/index.ts
@@ -150,8 +150,6 @@ export function createVibrate(
   return { vibrating, start, stop, supported };
 }
 
-// ─── Pulse / frequency primitives ────────────────────────────────────────────
-
 // Duration of a single repeating chunk sent to navigator.vibrate.
 // The setInterval fires at the same cadence so patterns join seamlessly.
 const PULSE_CHUNK_MS = 1000;

--- a/packages/video/test/index.test.ts
+++ b/packages/video/test/index.test.ts
@@ -16,8 +16,6 @@ const testUrl = "https://example.com/clip.mp4";
 /** Yield to the microtask queue — used alongside flush() to drain Solid 2.0 effects. */
 const tick = () => Promise.resolve();
 
-// ── setVideoSrc ───────────────────────────────────────────────────────────────
-
 describe("setVideoSrc", () => {
   it("sets src and nulls srcObject when given a string", () => {
     const el = document.createElement("video") as HTMLVideoElement;
@@ -36,8 +34,6 @@ describe("setVideoSrc", () => {
     expect(el.src).not.toMatch(/clip\.mp4$/);
   });
 });
-
-// ── makeVideo ─────────────────────────────────────────────────────────────────
 
 describe("makeVideo", () => {
   it("returns a player and cleanup tuple", () => {
@@ -83,8 +79,6 @@ describe("makeVideo", () => {
     cleanup();
   });
 });
-
-// ── makeVideoPlayer ───────────────────────────────────────────────────────────
 
 describe("makeVideoPlayer", () => {
   it("returns controls and cleanup tuple", () => {
@@ -140,8 +134,6 @@ describe("makeVideoPlayer", () => {
     cleanup();
   });
 });
-
-// ── createVideo ───────────────────────────────────────────────────────────────
 
 describe("createVideo", () => {
   it("returns the expected shape", () =>
@@ -277,8 +269,6 @@ describe("createVideo", () => {
       expect(video.player._mock.paused).toBe(true);
     }));
 });
-
-// ── createVideoPlayer ───────────────────────────────────────────────────────
 
 describe("createVideoPlayer", () => {
   it("includes all VideoReturn fields plus controls fields", () =>
@@ -456,8 +446,6 @@ describe("createVideoPlayer", () => {
     }));
 });
 
-// ── makeVideoFrameCallback ──────────────────────────────────────────────────
-
 describe("makeVideoFrameCallback", () => {
   it("is not running until start is called", () => {
     const [player, cleanup] = makeVideo(testUrl);
@@ -533,8 +521,6 @@ describe("makeVideoFrameCallback", () => {
     }).not.toThrow();
   });
 });
-
-// ── createVideoFrameCallback ─────────────────────────────────────────────────
 
 describe("createVideoFrameCallback", () => {
   it("running is a reactive signal", () =>

--- a/packages/websocket/stories/websocket.stories.tsx
+++ b/packages/websocket/stories/websocket.stories.tsx
@@ -23,8 +23,6 @@ import {
   inputStyle,
 } from "../../../.storybook/ui/index.js";
 
-// ─── Simulated WebSocket ──────────────────────────────────────────────────────
-
 class SimulatedWS extends EventTarget {
   readyState: 0 | 1 | 2 | 3 = 0;
   binaryType: BinaryType = "blob";
@@ -91,8 +89,6 @@ function ts() {
 const STATE_LABELS = ["Connecting", "Open", "Closing", "Closed"] as const;
 const STATE_VARIANTS = ["warning", "success", "warning", "default"] as const;
 
-// ─── Meta ─────────────────────────────────────────────────────────────────────
-
 const meta = preview.meta({
   title: "Network/Websocket",
   tags: ["autodocs"],
@@ -107,8 +103,6 @@ const meta = preview.meta({
 });
 
 export default meta;
-
-// ─── createWSState ────────────────────────────────────────────────────────────
 
 export const WSStateStory = meta.story({
   name: "Reactive connection state",
@@ -183,8 +177,6 @@ export const WSStateStory = meta.story({
     );
   },
 });
-
-// ─── createWSMessage ──────────────────────────────────────────────────────────
 
 const DEMO_MESSAGES = [
   '{"type":"update","value":42}',
@@ -263,8 +255,6 @@ export const WSMessageStory = meta.story({
     );
   },
 });
-
-// ─── createWS ────────────────────────────────────────────────────────────────
 
 export const CreateWSStory = meta.story({
   name: "Buffered send queue",
@@ -400,8 +390,6 @@ export const CreateWSStory = meta.story({
   },
 });
 
-// ─── createReconnectingWS ─────────────────────────────────────────────────────
-
 export const ReconnectingWSStory = meta.story({
   name: "Auto-reconnect on drop",
   parameters: {
@@ -483,8 +471,6 @@ export const ReconnectingWSStory = meta.story({
     );
   },
 });
-
-// ─── makeHeartbeatWS ──────────────────────────────────────────────────────────
 
 export const HeartbeatWSStory = meta.story({
   name: "Heartbeat watchdog",

--- a/packages/workers/stories/workers.stories.tsx
+++ b/packages/workers/stories/workers.stories.tsx
@@ -20,7 +20,6 @@ import {
   radii,
 } from "../../../.storybook/ui/index.js";
 
-// ─── Shared self-contained worker functions ───────────────────────────────────
 // These are serialized via Function.prototype.toString — no closures or imports.
 
 async function isPrime(n: number): Promise<boolean> {
@@ -72,8 +71,6 @@ const meta = preview.meta({
 });
 
 export default meta;
-
-// ─── Story 1: Offloaded compute ──────────────────────────────────────────────
 
 export const OffloadedCompute = meta.story({
   name: "Offloaded compute",
@@ -152,8 +149,6 @@ export const OffloadedCompute = meta.story({
     );
   },
 });
-
-// ─── Story 2: Pool round-robin ───────────────────────────────────────────────
 
 type TaskState = { n: number; state: "idle" | "running" | "done"; prime?: boolean; ms?: number };
 
@@ -250,8 +245,6 @@ export const PoolRoundRobin = meta.story({
   },
 });
 
-// ─── Story 3: Auto-refreshing query ─────────────────────────────────────────
-
 export const AutoRefreshingQuery = meta.story({
   name: "Auto-refreshing query",
   parameters: {
@@ -332,8 +325,6 @@ export const AutoRefreshingQuery = meta.story({
   },
 });
 
-// ─── Story 4: Reactive store bridge ─────────────────────────────────────────
-
 export const ReactiveStoreBridge = meta.story({
   name: "Reactive store bridge",
   parameters: {
@@ -413,8 +404,6 @@ export const ReactiveStoreBridge = meta.story({
     );
   },
 });
-
-// ─── Story 5: Cancellable operation ─────────────────────────────────────────
 
 type Phase = "idle" | "running" | "done" | "cancelled";
 

--- a/packages/workers/test/index.test.ts
+++ b/packages/workers/test/index.test.ts
@@ -27,8 +27,6 @@ async function settle(cycles = 5) {
   }
 }
 
-// ─── createWorker ────────────────────────────────────────────────────────────
-
 describe("createWorker", () => {
   let mockWorker: { addEventListener: ReturnType<typeof vi.fn>; removeEventListener: ReturnType<typeof vi.fn>; postMessage: ReturnType<typeof vi.fn>; terminate: ReturnType<typeof vi.fn> };
 
@@ -114,8 +112,6 @@ describe("createWorker", () => {
   });
 });
 
-// ─── createWorkerPool ────────────────────────────────────────────────────────
-
 describe("createWorkerPool", () => {
   beforeEach(() => {
     vi.stubGlobal("Worker", vi.fn(() => ({
@@ -181,8 +177,6 @@ describe("createWorkerPool", () => {
   });
 });
 
-// ─── createWorkerQuery ───────────────────────────────────────────────────────
-
 describe("createWorkerQuery", () => {
   it("resolves the initial value", async () => {
     let result!: ReturnType<typeof createWorkerQuery<number>>;
@@ -223,8 +217,6 @@ describe("createWorkerQuery", () => {
   });
 
 });
-
-// ─── abort ───────────────────────────────────────────────────────────────────
 
 describe("abort", () => {
   let mockWorker: { addEventListener: ReturnType<typeof vi.fn>; removeEventListener: ReturnType<typeof vi.fn>; postMessage: ReturnType<typeof vi.fn>; terminate: ReturnType<typeof vi.fn> };
@@ -329,8 +321,6 @@ describe("createWorkerQuery abort", () => {
     expect(aborted).toContain("call-0");
   });
 });
-
-// ─── createReactiveWorker + workerScope ──────────────────────────────────────
 
 describe("createReactiveWorker + workerScope", () => {
   let channel: ReturnType<typeof makeChannel>;

--- a/scripts/test-utils/hydration-harness.ts
+++ b/scripts/test-utils/hydration-harness.ts
@@ -1,0 +1,205 @@
+/**
+ * Real server-render → client-hydrate round trip, for catching hydration hazards that
+ * per-package `test/server.test.ts` files structurally cannot: those run under this
+ * monorepo's `@solid-primitives/source` resolve condition, so every `@solid-primitives/*`
+ * import resolves to workspace `src` instead of the published `dist` build a real consumer
+ * gets from node_modules.
+ *
+ * The SERVER half genuinely closes that gap: it's rendered in a real `node` subprocess with no
+ * special resolve conditions, so `@solid-primitives/*` and `@solidjs/web` resolve exactly as
+ * they would for a real npm consumer (dist builds, the real "node" export condition).
+ *
+ * The CLIENT half does not close it the same way. `hydrate()` runs back in the calling Vitest
+ * worker, so the dom-compiled fixture's own `@solid-primitives/*` imports still resolve through
+ * Vite's module graph — this project's `@solid-primitives/source` condition is active there,
+ * i.e. workspace `src`, not `dist` (confirmed empirically: a marker export added only to a
+ * package's `src` was visible from inside the dynamically-imported dom module). For packages
+ * with no JSX of their own — the common case for `create*` primitives — this doesn't affect the
+ * property under test: Solid's owner-id allocation lives entirely in `@solidjs/signals`'s
+ * runtime and doesn't depend on whether the *calling* code was pre-compiled. It would matter for
+ * a package whose own public surface includes JSX.
+ *
+ * ⚠️ Because the server half resolves `dist` and the client half resolves `src`, a **stale**
+ * `dist` build (edited `src` without rebuilding) makes the two halves run genuinely different
+ * code — e.g. one side still has an old `createMemo` the other doesn't — which desyncs owner-id
+ * allocation for real and surfaces as a false-positive "unclaimed server-rendered node" warning
+ * that has nothing to do with the hazard under test. Rebuild (`pnpm -w build`, or scoped to the
+ * touched packages) after editing a package's `src` and before trusting a hydration test result.
+ *
+ * See the hope-ui solid-primitives-eval.md "transform-boundary hydration hazard": a
+ * render-body `createSignal(fn)`/`createMemo(fn)` living in an un-transformed dependency was
+ * reported to desync hydration ids between server and client. Whether that's a general
+ * solid-js limitation or specific to a non-standard SSR harness, this test proves (or
+ * disproves) it for each package using the real, standard `@solidjs/web` renderToString +
+ * hydrate pipeline — no custom harness of our own to second-guess.
+ */
+
+import { transformAsync } from "@babel/core";
+import babelTypescript from "@babel/preset-typescript";
+import babelSolid from "babel-preset-solid";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+async function compile(source: string, generate: "ssr" | "dom"): Promise<string> {
+  const result = await transformAsync(source, {
+    filename: "hydration-app.tsx",
+    // Presets apply last-to-first: typescript strips types before babel-preset-solid sees JSX.
+    presets: [
+      [
+        babelSolid,
+        {
+          moduleName: "@solidjs/web",
+          generate,
+          hydratable: true,
+          omitNestedClosingTags: false,
+        },
+      ],
+      [babelTypescript, { isTSX: true, allExtensions: true }],
+    ],
+    ast: false,
+    sourceMaps: false,
+    configFile: false,
+    babelrc: false,
+    parserOpts: { plugins: ["jsx", "typescript"] },
+  });
+  if (!result?.code) throw new Error("[hydration-harness] babel-preset-solid produced no output");
+  return result.code;
+}
+
+type PreparedFixture = { html: string; domFile: string };
+
+// Compiling + spawning the SSR subprocess is deterministic given (appSource, cwd), so it's
+// cached and reused across every `it()` block in a test file that shares the same fixture
+// source — each test still gets its own fresh container/hydrate() call, only the expensive
+// "produce the server HTML" step is shared. Temp files are cleaned up once, at process exit,
+// rather than per-call, since the cached domFile path is reused across calls.
+const fixtureCache = new Map<string, Promise<PreparedFixture>>();
+const tempDirsPendingCleanup = new Set<string>();
+let exitCleanupRegistered = false;
+
+function registerExitCleanup(): void {
+  if (exitCleanupRegistered) return;
+  exitCleanupRegistered = true;
+  process.once("exit", () => {
+    for (const dir of tempDirsPendingCleanup) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort — the process is exiting regardless
+      }
+    }
+  });
+}
+
+async function prepareFixture(appSource: string, cwd: string): Promise<PreparedFixture> {
+  const key = `${cwd}\0${appSource}`;
+  let entry = fixtureCache.get(key);
+  if (!entry) {
+    entry = (async () => {
+      const [ssrCode, domCode] = await Promise.all([
+        compile(appSource, "ssr"),
+        compile(appSource, "dom"),
+      ]);
+
+      const serverEntry = `${ssrCode}\nimport { renderToString } from "@solidjs/web";\nprocess.stdout.write(renderToString(() => App({})));\n`;
+
+      const html = execFileSync(process.execPath, ["--input-type=module"], {
+        cwd,
+        input: serverEntry,
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "inherit"],
+      });
+
+      const tmpDir = mkdtempSync(join(cwd, ".hydration-harness-"));
+      tempDirsPendingCleanup.add(tmpDir);
+      registerExitCleanup();
+      const domFile = join(tmpDir, "app.dom.mjs");
+      writeFileSync(domFile, domCode);
+
+      return { html, domFile };
+    })();
+    fixtureCache.set(key, entry);
+  }
+  return entry;
+}
+
+export type HydrationRoundTripResult = {
+  /** The HTML produced by the real `renderToString`, run in a real `node` subprocess. */
+  html: string;
+  /** `container` element the server HTML was hydrated into — still attached to `document.body`. */
+  container: HTMLElement;
+  /** Every `console.error`/`console.warn` message emitted while `hydrate()` ran. */
+  consoleMessages: string[];
+  /** Removes `container` from the document. Call in test cleanup. */
+  cleanup: () => void;
+};
+
+// The console.error/console.warn monkey-patch and the shared `globalThis._$HY` reset below are
+// not reentrant — serialize calls (across concurrent `it()`s/files sharing this module) through
+// one chain so a second call can't restore/reassign globals out from under a first call still
+// mid-hydrate.
+let runQueue: Promise<unknown> = Promise.resolve();
+
+async function runHydrationRoundTrip(appSource: string, cwd: string): Promise<HydrationRoundTripResult> {
+  const { html, domFile } = await prepareFixture(appSource, cwd);
+
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  document.body.appendChild(container);
+
+  const messages: string[] = [];
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  console.error = (...args: unknown[]) => {
+    messages.push(args.map(String).join(" "));
+  };
+  console.warn = (...args: unknown[]) => {
+    messages.push(args.map(String).join(" "));
+  };
+
+  try {
+    const { default: App } = await import(pathToFileURL(domFile).href);
+    const { hydrate } = await import("@solidjs/web");
+    // Equivalent of executing the inline <script> generateHydrationScript() embeds in real SSR
+    // HTML — jsdom doesn't run scripts assigned via .innerHTML, so this sets up the same global
+    // hydrate() otherwise expects to already be there.
+    (globalThis as any)._$HY = { events: [], completed: new WeakSet(), r: {}, fe() {} };
+    hydrate(() => App({}), container);
+    // Solid finalizes hydration (drainHydrationCallbacks) via a `setTimeout`, after any
+    // microtask-scheduled reactive updates have settled — wait for both ticks so a
+    // late-firing hydration-mismatch warning isn't missed by the console restore below.
+    await Promise.resolve();
+    await new Promise(resolve => setTimeout(resolve, 0));
+  } finally {
+    console.error = originalError;
+    console.warn = originalWarn;
+  }
+
+  return {
+    html,
+    container,
+    consoleMessages: messages,
+    cleanup: () => container.remove(),
+  };
+}
+
+/**
+ * `appSource` must be a self-contained `.tsx` module (no relative imports — only bare
+ * package specifiers) whose default export is a zero-prop Solid component.
+ *
+ * `cwd` should be the consuming package's directory (e.g. `import.meta.dirname` from a
+ * `test/*.test.tsx` file two levels under the package root) so that `node`'s bare-specifier
+ * resolution walks up to the workspace's real `node_modules`, exactly as it would for an
+ * installed consumer.
+ */
+export function renderHydrationRoundTrip(appSource: string, cwd: string): Promise<HydrationRoundTripResult> {
+  const run = runQueue.then(() => runHydrationRoundTrip(appSource, cwd));
+  // Keep the queue alive even if this run rejects, so a failing test doesn't wedge the ones after it.
+  runQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}


### PR DESCRIPTION
This PR is derived from some research and comments that came out of a HopeUI document I stumbled on: https://github.com/hope-ui/hope-ui/blob/main/docs/solid-primitives-eval.md. These were not reported but to be proactive in fixing details I've attempted exploring the issues and correcting them.

Responds to hope-ui's `solid-primitives-eval.md`, which flagged a suspected "transform-boundary hydration hazard" in `createSignal(fn)`/`createMemo`-backed primitives. Traced actual `solid-js@2.0.0-beta.20`/`@solidjs/signals` internals and built a real server-render→hydrate round-trip test harness (spawns a genuine `node` subprocess so the package under test resolves its published `dist` build, not workspace `src`) to prove/disprove it empirically rather than by inspection alone. Result: the pattern hydrates cleanly across `controlled-signal`, `a11y`, `pagination`, and `state-machine` — evidence points at hope-ui's own non-standard SSR harness, not a general solid-primitives/solid-js defect.

Along the way, found and fixed real bugs via an 8-angle self-review of the diff:

- **`interaction`**: opt-in `inert` option on `createHideOutside`/`ariaHideOutside`, ref-counted alongside `aria-hidden`. Fixed a bug where `inert` was applied even to nodes deliberately left alone because they already carry an author-managed `aria-hidden` — broke that "not ours to manage" invariant.
- **`focus`**: new standalone `createFocusRestore` primitive (restore focus without trapping, for non-modal Popover/Tooltip). Fixed a stale-closure race shared with `createFocusTrap` — a fast reactivate-before-restore-fires cycle could restore focus to the wrong element — via one shared `scheduleFocusRestore` helper instead of two copies of the same bug.
- **`scroll` + `interaction`**: module-scope ref-count/observer state hardened against duplicate installed package copies via a new shared `globalRegistry()` helper in `@solid-primitives/utils` (also fixed an instance-id collision the extraction would otherwise have introduced).
- **`a11y`**: `createFormControl`'s `dataset` converted from `createMemo` to a plain getter — removes a hydration-id-consuming call for a value cheap enough that memoizing it buys nothing.
- **Hydration harness**: dead import removed, console-patch timing fixed so it no longer misses async/deferred hydration-mismatch warnings (this surfaced a real stale-`dist`-build false positive during development, now documented as a known footgun), reentrancy guard, and caching so repeated fixtures don't re-spawn subprocesses.
- Removed a duplicate `contains()` helper in `scroll` in favor of the existing one in `@solid-primitives/utils`.

The only new public export across all of this is `globalRegistry` in `@solid-primitives/utils` — everything else is internal refactoring or bug fixes with no signature changes.

Some additional adjustments were added:

notification`**'s `createNotificationPermission.requestPermission` gained `affects(permission)` so `isPending(permission)` now works for callers who want the standard idiom, alongside the existing `pending` accessor (kept for backward compatibility — pure addition, no breaking change).

**`clipboard`** — I initially added the same pattern, but discovered through direct experimentation that `affects()` only holds its pending mark for a single flush cycle *unless it's called inside a real `action()` generator*. Clipboard's `write` is a plain async function, so the fix would have looked adopted but silently done nothing across the real async gap. I reverted it rather than ship something ineffective. This constraint isn't clearly documented anywhere, so I wrote it up in project memory.

controlled-props`**'s `BoolProp`/`NumberProp`/`RangeProp`/`StringProp` retyped from `Component<P>` to `VoidComponent<P>`, since none of them accept or render children.

All four packages pass their full test suites and typecheck cleanly, each fix verified by reverting it and confirming the corresponding test fails, then restoring.

Also a number of banner comments were removed