### PR TITLE
patch: fix createUndoHistory and align to Solid2 API

### DIFF
--- a/.changeset/history-undo-multi-source-fix.md
+++ b/.changeset/history-undo-multi-source-fix.md
@@ -2,9 +2,11 @@
 "@solid-primitives/history": patch
 ---
 
-Fix `createUndoHistory` misfiring restores when tracking multiple sources and one of them pauses (returns a falsy value) while another stays active.
+Fix two independent bugs in `createUndoHistory` that could each cause `undo`/`redo` to misfire — the second affects single-source usage too, not just multiple sources.
 
-Previously each history entry stored a compacted array of setters, dropping any paused source — so entries on either side of a pause/resume boundary could end up with different lengths, causing `undo`/`redo` to compare setters by the wrong array index and either restore the wrong source or spuriously re-fire one that hadn't actually changed. Entries now keep a fixed-length slot per source (`undefined` when paused), so index alignment is stable across every recorded entry.
+**Microtask race on the internal "ignore" flag.** The previous implementation suppressed re-recording a history entry during `undo`/`redo` with a flag (`ignoreNext`) reset via a separately-scheduled microtask (`createMicrotask`). Since Solid 2.0 batches signal writes into their own microtask-scheduled flush, the flag's reset microtask could resolve *before* the write's own flush — so the restore triggered by `undo`/`redo` got recorded as a brand-new history entry instead of being suppressed, corrupting `canRedo`/`canUndo` bookkeeping. This reproduces with a single source and no multi-source setup at all. The rewrite replaces the flag with `createOptimistic`, whose revert is coordinated by Solid's own flush (it runs after the same flush's pending recomputes, not via an independent competing microtask), which structurally removes this race.
+
+**Misaligned/spurious restores with multiple sources.** Separately, each history entry stored a compacted array of setters, dropping any paused source — so entries on either side of a pause/resume boundary could end up with different lengths, causing `undo`/`redo` to compare setters by the wrong array index and either restore the wrong source or spuriously re-fire one that hadn't actually changed. Entries now keep a fixed-length slot per source (`undefined` when paused), so index alignment is stable across every recorded entry.
 
 Also fixes the `limit` option: the default silently became unbounded and `limit: 0` no longer meant zero retention. Restored the documented default of `100` and made trimming unconditional so `limit: 0` correctly retains no undo history.
 

--- a/.changeset/history-undo-multi-source-fix.md
+++ b/.changeset/history-undo-multi-source-fix.md
@@ -1,0 +1,9 @@
+---
+"@solid-primitives/history": patch
+---
+
+Fix `createUndoHistory` misfiring restores when tracking multiple sources and one of them pauses (returns a falsy value) while another stays active.
+
+Previously each history entry stored a compacted array of setters, dropping any paused source — so entries on either side of a pause/resume boundary could end up with different lengths, causing `undo`/`redo` to compare setters by the wrong array index and either restore the wrong source or spuriously re-fire one that hadn't actually changed. Entries now keep a fixed-length slot per source (`undefined` when paused), so index alignment is stable across every recorded entry.
+
+Also fixes the `limit` option: the default silently became unbounded and `limit: 0` no longer meant zero retention. Restored the documented default of `100` and made trimming unconditional so `limit: 0` correctly retains no undo history.

--- a/.changeset/history-undo-multi-source-fix.md
+++ b/.changeset/history-undo-multi-source-fix.md
@@ -7,3 +7,5 @@ Fix `createUndoHistory` misfiring restores when tracking multiple sources and on
 Previously each history entry stored a compacted array of setters, dropping any paused source — so entries on either side of a pause/resume boundary could end up with different lengths, causing `undo`/`redo` to compare setters by the wrong array index and either restore the wrong source or spuriously re-fire one that hadn't actually changed. Entries now keep a fixed-length slot per source (`undefined` when paused), so index alignment is stable across every recorded entry.
 
 Also fixes the `limit` option: the default silently became unbounded and `limit: 0` no longer meant zero retention. Restored the documented default of `100` and made trimming unconditional so `limit: 0` correctly retains no undo history.
+
+Credit to @mesram, whose `createStore`/`createOptimistic`-based rewrite is the basis for this fix.

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -1,12 +1,5 @@
-import { type Many, createMicrotask, falseFn, noop } from "@solid-primitives/utils";
-import {
-  type Accessor,
-  type Signal,
-  type SignalOptions,
-  createMemo,
-  createSignal,
-  untrack,
-} from "solid-js";
+import { type Many, falseFn, noop } from "@solid-primitives/utils";
+import { type Accessor, createMemo, createOptimistic, createStore, untrack } from "solid-js";
 import { isServer } from "@solidjs/web";
 
 /**
@@ -50,7 +43,13 @@ export type UndoHistoryReturn = {
   redo: VoidFunction;
 };
 
-type HistoryState = { count: Signal<number>; list: VoidFunction[][] };
+// One slot per source, always the same length as `sources` — even when a
+// source is paused (returns falsy) it keeps its `undefined` slot instead of
+// being dropped, so entries never end up with mismatched lengths and index i
+// always refers to the same source across every recorded entry.
+type Setters = (VoidFunction | undefined)[];
+
+type HistoryState = { offset: number; items: Setters[] };
 
 /**
  * Creates an undo history from a reactive source for going back and forth between state snapshots.
@@ -92,68 +91,63 @@ export function createUndoHistory(
     };
   }
 
-  let ignoreNext = false;
-
   const limit = options?.limit ?? 100,
-    sources = Array.isArray(source) ? source.map(s => createMemo(s)) : [source],
-    clearIgnore = createMicrotask(() => (ignoreNext = false)),
-    // Initial state lives outside the memo so Solid undefined-prev first-call is handled
-    initialCount = createSignal<number>(0, { ownedWrite: true } as SignalOptions<number>),
-    initialState: HistoryState = { list: [], count: initialCount },
-    history = createMemo<HistoryState>(p => {
-      const prev = p ?? initialState;
+    // Each source gets its own memo so an unrelated source's recompute
+    // doesn't produce a fresh (reference-unequal) closure for this one —
+    // that reference stability is what lets `jump` skip no-op restores.
+    sources = (Array.isArray(source) ? source : [source]).map(s => createMemo(s)),
+    [disableTracking, setDisableTracking] = createOptimistic(false),
+    [store, setStore] = createStore<HistoryState>(
+      draft => {
+        const setters: Setters = sources.map(s => s() || undefined);
+        if (untrack(disableTracking) || setters.every(s => s === undefined)) return;
 
-      // always track the sources
-      const setters: VoidFunction[] = [];
-      for (const s of sources) {
-        const setter = s();
-        if (setter) setters.push(setter);
-      }
-
-      if (ignoreNext || !setters.length) {
-        ignoreNext = false;
-        return prev;
-      }
-
-      const count = untrack(prev.count[0]),
-        newLength = prev.list.length - count,
-        newHistory = prev.list.slice(Math.max(0, newLength - limit), newLength);
-      newHistory.push(setters);
-
-      return {
-        count: count
-          ? createSignal<number>(0, { ownedWrite: true } as SignalOptions<number>)
-          : prev.count,
-        list: newHistory,
-      };
-    }),
-    canUndo = createMemo(() => {
-      const h = history();
-      return h.list.length - h.count[0]() > 1;
-    }),
-    canRedo = createMemo(() => history().count[0]() > 0),
-    move = (n: -1 | 1) => {
-      ignoreNext = true;
-      clearIgnore();
-      const h = history(),
-        newCount = h.count[1](p => p + n),
-        newIndex = h.list.length - newCount - 1,
-        prevSetters = h.list[newIndex + n]!,
-        setters = h.list[newIndex]!;
-      for (let i = 0; i < setters.length; i++) {
-        // only call the setter if the current value is different
-        if (setters[i] !== prevSetters[i]) setters[i]!();
-      }
+        // drop any redo-only tail (entries beyond the current position),
+        // insert the new entry, then trim to at most `limit` past entries.
+        draft.items.splice(draft.items.length - draft.offset, draft.offset, setters);
+        draft.items.splice(0, draft.items.length - (limit + 1));
+        draft.offset = 0;
+      },
+      { offset: 0, items: [] },
+    ),
+    getTargetIndex = (state: HistoryState, amount: number) => {
+      const target = state.items.length - 1 - (state.offset - amount);
+      return target >= 0 && target < state.items.length ? target : null;
+    },
+    jump = (amount: -1 | 1) => {
+      setDisableTracking(true);
+      let toEntry: Setters | undefined, fromEntry: Setters | undefined;
+      setStore(draft => {
+        const targetIndex = getTargetIndex(draft, amount);
+        if (targetIndex === null) return;
+        toEntry = draft.items[targetIndex];
+        fromEntry = draft.items[targetIndex - amount];
+        draft.offset -= amount;
+      });
+      if (!toEntry || !fromEntry) return;
+      const setters = toEntry,
+        prevSetters = fromEntry;
+      untrack(() => {
+        for (let i = 0; i < setters.length; i++) {
+          // only call the setter if it was active on both sides of the move
+          // and the value actually differs — if a source was paused on
+          // either side we have no tracked value to compare against, so
+          // skip it rather than firing a spurious restore
+          const setter = setters[i],
+            prevSetter = prevSetters[i];
+          if (setter !== undefined && prevSetter !== undefined && setter !== prevSetter) setter();
+        }
+      });
     };
 
   return {
-    canUndo,
-    canRedo,
+    canUndo: () => getTargetIndex(store, -1) !== null,
+    canRedo: () => getTargetIndex(store, 1) !== null,
     undo() {
-      untrack(() => canUndo() && move(1));
+      jump(-1);
     },
     redo() {
-      untrack(() => canRedo() && move(-1));
+      jump(1);
     },
   };
 }

--- a/packages/history/test/index.test.ts
+++ b/packages/history/test/index.test.ts
@@ -383,6 +383,53 @@ describe("createUndoHistory", () => {
     dispose();
   });
 
+  test("undo/redo don't record a bogus entry under natural (non-flushed) microtask timing", async () => {
+    // Regression test: the internal "ignore recording during undo/redo" flag
+    // must not depend on a separately-scheduled microtask racing against
+    // Solid's own auto-batched write flush — a single explicit flush() call
+    // right after undo()/redo() can mask that race, so this deliberately
+    // awaits real microtask ticks instead.
+    const tick = async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    };
+
+    const [a, setA] = createSignal(0);
+    const { history, dispose } = createRoot(dispose => ({
+      history: createUndoHistory(() => {
+        const v = a();
+        return () => setA(v);
+      }),
+      dispose,
+    }));
+
+    setA(1);
+    await tick();
+    setA(2);
+    await tick();
+
+    history.undo();
+    await tick();
+    expect(a()).toBe(1);
+    expect(history.canRedo()).toBe(true); // must not have recorded the undo's own restore as a new entry
+
+    history.undo();
+    await tick();
+    expect(a()).toBe(0);
+    expect(history.canUndo()).toBe(false);
+    expect(history.canRedo()).toBe(true);
+
+    history.redo();
+    await tick();
+    history.redo();
+    await tick();
+    expect(a()).toBe(2);
+    expect(history.canRedo()).toBe(false);
+
+    dispose();
+  });
+
   test("default limit is bounded to 100 undo steps", () => {
     const [a, setA] = createSignal(0);
     const { history, dispose } = createRoot(dispose => ({

--- a/packages/history/test/index.test.ts
+++ b/packages/history/test/index.test.ts
@@ -321,4 +321,111 @@ describe("createUndoHistory", () => {
 
     dispose();
   });
+
+  test("multiple sources, one intermittently paused - no spurious/misaligned restores", () => {
+    const [a, setA] = createSignal(0);
+    const [b, setB] = createSignal(0);
+    const [trackB, setTrackB] = createSignal(true);
+    let bCalls = 0;
+
+    const { history, dispose } = createRoot(dispose => ({
+      history: createUndoHistory([
+        () => {
+          const v = a();
+          return () => setA(v);
+        },
+        () => {
+          if (!trackB()) return undefined;
+          const v = b();
+          return () => {
+            bCalls++;
+            setB(v);
+          };
+        },
+      ]),
+      dispose,
+    }));
+
+    // recorded entries: E0(a0,b0) E1(a1,b0) E2(a1,-b paused-) E3(a2,-b paused-)
+    setA(1);
+    flush();
+    setTrackB(false);
+    flush();
+    setA(2);
+    flush();
+
+    history.undo(); // E3 -> E2
+    flush();
+    expect(a()).toBe(1);
+    expect(bCalls).toBe(0); // b never changed, must not fire
+
+    history.undo(); // E2 -> E1 (crosses the pause boundary)
+    flush();
+    expect(a()).toBe(1); // a is legitimately unchanged between E1/E2 — not a bug
+    expect(bCalls).toBe(0); // must not spuriously re-fire b just because array shapes differ across the boundary
+
+    history.undo(); // E1 -> E0
+    flush();
+    expect(a()).toBe(0);
+    expect(bCalls).toBe(0);
+    expect(history.canUndo()).toBe(false);
+
+    history.redo(); // E0 -> E1
+    flush();
+    history.redo(); // E1 -> E2 (crosses the pause boundary going forward)
+    flush();
+    expect(bCalls).toBe(0);
+    history.redo(); // E2 -> E3
+    flush();
+    expect(a()).toBe(2);
+    expect(bCalls).toBe(0);
+
+    dispose();
+  });
+
+  test("default limit is bounded to 100 undo steps", () => {
+    const [a, setA] = createSignal(0);
+    const { history, dispose } = createRoot(dispose => ({
+      history: createUndoHistory(() => {
+        const v = a();
+        return () => setA(v);
+      }),
+      dispose,
+    }));
+
+    for (let i = 1; i <= 500; i++) {
+      setA(i);
+      flush();
+    }
+
+    let steps = 0;
+    while (history.canUndo() && steps < 1000) {
+      history.undo();
+      flush();
+      steps++;
+    }
+    expect(steps).toBe(100);
+
+    dispose();
+  });
+
+  test("limit: 0 means zero retention", () => {
+    const [a, setA] = createSignal(0);
+    const { history, dispose } = createRoot(dispose => ({
+      history: createUndoHistory(
+        () => {
+          const v = a();
+          return () => setA(v);
+        },
+        { limit: 0 },
+      ),
+      dispose,
+    }));
+
+    setA(1);
+    flush();
+    expect(history.canUndo()).toBe(false);
+
+    dispose();
+  });
 });


### PR DESCRIPTION
The previous implementation suppressed re-recording a history entry during `undo`/`redo` with a flag (`ignoreNext`) reset via a separately-scheduled microtask (`createMicrotask`). Since Solid 2.0 batches signal writes into their own microtask-scheduled flush, the flag's reset microtask could resolve **before** the write's own flush — so the restore triggered by `undo`/`redo` got recorded as a brand-new history entry instead of being suppressed, corrupting `canRedo`/`canUndo` bookkeeping.

This reproduces with a single source and no multi-source setup at all — calling `flush()` immediately after `undo()`/`redo()` happens to mask it (it forces synchronous processing ahead of the real microtask queue), which is why it wasn't caught by the existing tests.

The rewrite replaces the flag with `createOptimistic`, whose revert is coordinated by Solid's own flush (it runs after that same flush's pending recomputes, not via an independent competing microtask), which structurally removes this race.

Separately, each history entry stored a *compacted* array of setters, dropping any paused source — so entries on either side of a pause/resume boundary could end up with different lengths. `undo`/`redo` diff two adjacent entries by raw array index, so crossing that boundary compared the wrong slots against each other — firing a setter that hadn't actually changed, or potentially restoring the wrong source with more sources/patterns.

Entries now keep a **fixed-length slot per source** (`undefined` when paused), so index `i` always refers to the same source across every recorded entry. The restore comparison also requires *both* sides of a move to be defined before treating them as "different."

Thank you @mesram for the original idea and suggestion (https://playground.solidjs.com/anonymous/ee90e2bd-ebd4-48fd-8fa4-67df5d81b9fd).

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved undo and redo behavior when tracking multiple sources that are intermittently paused.
  * Prevented paused sources from being incorrectly restored or invoked during history navigation.
  * Restored the default retention of 100 undo steps.
  * Ensured setting the history limit to 0 retains no history.
  * Redo entries are now discarded when new changes are recorded after undoing.