### PR TITLE
fix: resolve lint:packages warnings blocking CI (--max-warnings 0)

### DIFF
--- a/packages/memo/src/index.ts
+++ b/packages/memo/src/index.ts
@@ -504,7 +504,7 @@ export function createRcMemo<T>(
             return {
               memo: createMemo(
                 prev => {
-                  let result = calc(prev);
+                  const result = calc(prev);
                   lastSeenValue = result;
                   return result;
                 },
@@ -519,7 +519,7 @@ export function createRcMemo<T>(
       } else {
         existing.refCount++;
       }
-      let existing2 = existing!;
+      const existing2 = existing!;
       onCleanup(() => {
         existing2.refCount--;
         if (existing2.refCount === 0) {

--- a/packages/websocket/src/index.ts
+++ b/packages/websocket/src/index.ts
@@ -103,6 +103,7 @@ export const makeReconnectingWS = (
   };
   let events: Parameters<WebSocket["addEventListener"]>[] = [["close", onClose]];
   const getWS = () => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- ws is undefined on the first call, TS just doesn't reflect that in its declared type
     ws?.removeEventListener("close", onClose);
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (ws && ws.readyState < 2) ws.close();


### PR DESCRIPTION
- memo: two `let` bindings that are never reassigned (prefer-const)
- websocket: ws?.removeEventListener flagged as an unnecessary optional chain by @typescript-eslint/no-unnecessary-condition — this is a false positive, ws is genuinely undefined on the first getWS() call (declared without an initializer), TS's declared type just doesn't reflect that. Suppressed with the same eslint-disable pattern already used one line below for the identical false positive, rather than removing the `?.` (which would throw on first connect).

No behavior change; verified via full memo/websocket test suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code clarity and linting documentation without changing observable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->