### PR TITLE
feat(audio): add reactive WebAudio API primitives (createAudioContext, createAudioParam, createAudioAnalyser)

### DIFF
--- a/.changeset/webaudio-primitives.md
+++ b/.changeset/webaudio-primitives.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/audio": minor
+---
+
+Add WebAudio API reactive primitives: `createAudioContext`, `createAudioParam`, and `createAudioAnalyser` with zero-allocation buffers and owner-scoped teardown.

--- a/packages/audio/src/index.ts
+++ b/packages/audio/src/index.ts
@@ -3,6 +3,8 @@ import { isServer } from "solid-js/web";
 import { access, noop } from "@solid-primitives/utils";
 import { createStaticStore } from "@solid-primitives/static-store";
 
+export * from "./webaudio.js";
+
 // Set of control enums
 export enum AudioState {
   LOADING = "loading",

--- a/packages/audio/src/webaudio.ts
+++ b/packages/audio/src/webaudio.ts
@@ -1,0 +1,221 @@
+import {
+  type Accessor,
+  createEffect,
+  createSignal,
+  onCleanup,
+  onMount,
+} from "solid-js";
+import { isServer } from "solid-js/web";
+import { access, type MaybeAccessor } from "@solid-primitives/utils";
+
+export interface AudioContextOptions extends AudioContextOptions {
+  /**
+   * Automatically suspend AudioContext when document is hidden (background tab) to save CPU/battery.
+   * @default true
+   */
+  autoSuspendOnHidden?: boolean;
+}
+
+/**
+ * Creates and manages a lifecycle-bound WebAudio `AudioContext`.
+ * Automatically closes context on component cleanup and handles tab visibility suspensions.
+ *
+ * @param options WebAudio AudioContext configuration options.
+ * @returns AudioContext instance with reactive state accessor.
+ *
+ * @example
+ * ```ts
+ * const [ctx, { state, resume, suspend }] = createAudioContext();
+ * ```
+ */
+export function createAudioContext(
+  options: AudioContextOptions = {},
+): [
+  AudioContext | null,
+  {
+    state: Accessor<AudioContextState>;
+    resume: () => Promise<void>;
+    suspend: () => Promise<void>;
+    close: () => Promise<void>;
+  },
+] {
+  if (isServer || typeof window === "undefined" || !("AudioContext" in window || "webkitAudioContext" in window)) {
+    const noopState: Accessor<AudioContextState> = () => "suspended";
+    return [
+      null,
+      {
+        state: noopState,
+        resume: async () => {},
+        suspend: async () => {},
+        close: async () => {},
+      },
+    ];
+  }
+
+  const AudioCtxConstructor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+  const ctx = new AudioCtxConstructor(options);
+  const [state, setState] = createSignal<AudioContextState>(ctx.state);
+
+  const updateState = () => setState(ctx.state);
+
+  ctx.addEventListener("statechange", updateState);
+
+  if (options.autoSuspendOnHidden ?? true) {
+    const onVisibilityChange = () => {
+      if (document.hidden) {
+        if (ctx.state === "running") {
+          void ctx.suspend();
+        }
+      } else {
+        if (ctx.state === "suspended") {
+          void ctx.resume();
+        }
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    onCleanup(() => {
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    });
+  }
+
+  onCleanup(() => {
+    ctx.removeEventListener("statechange", updateState);
+    if (ctx.state !== "closed") {
+      void ctx.close();
+    }
+  });
+
+  return [
+    ctx,
+    {
+      state,
+      resume: () => ctx.resume().then(updateState),
+      suspend: () => ctx.suspend().then(updateState),
+      close: () => ctx.close().then(updateState),
+    },
+  ];
+}
+
+export type RampMode = "instant" | "linear" | "exponential";
+
+export interface AudioParamOptions {
+  /**
+   * Ramp transition curve to apply when signal updates.
+   * @default "linear"
+   */
+  ramp?: RampMode;
+  /**
+   * Time duration in seconds for ramp transitions.
+   * @default 0.05 (50ms)
+   */
+  timeConstant?: number;
+}
+
+/**
+ * Reactively binds a SolidJS numeric accessor to a WebAudio `AudioParam` (e.g. GainNode.gain, BiquadFilterNode.frequency).
+ * Schedules ramp transitions smoothly on the AudioContext clock with zero GC allocations.
+ *
+ * @param param The WebAudio AudioParam node to automate.
+ * @param value Signal or accessor providing target values.
+ * @param options Transition curve and time constants.
+ *
+ * @example
+ * ```ts
+ * const [gain, setGain] = createSignal(0.8);
+ * createAudioParam(gainNode.gain, gain, { ramp: 'exponential', timeConstant: 0.03 });
+ * ```
+ */
+export function createAudioParam(
+  param: AudioParam,
+  value: MaybeAccessor<number>,
+  options: AudioParamOptions = {},
+): void {
+  if (isServer) return;
+
+  const ramp = options.ramp ?? "linear";
+  const timeConstant = options.timeConstant ?? 0.05;
+
+  createEffect(() => {
+    const target = access(value);
+    if (typeof target !== "number" || isNaN(target)) return;
+
+    const now = param.context.currentTime;
+
+    if (ramp === "instant" || timeConstant <= 0) {
+      param.setValueAtTime(target, now);
+    } else if (ramp === "exponential") {
+      const safeTarget = Math.max(target, 0.00001);
+      param.cancelScheduledValues(now);
+      param.setValueAtTime(Math.max(param.value, 0.00001), now);
+      param.exponentialRampToValueAtTime(safeTarget, now + timeConstant);
+    } else {
+      param.cancelScheduledValues(now);
+      param.setValueAtTime(param.value, now);
+      param.linearRampToValueAtTime(target, now + timeConstant);
+    }
+  });
+}
+
+export interface AnalyserOptions {
+  fftSize?: number;
+  smoothingTimeConstant?: number;
+  minDecibels?: number;
+  maxDecibels?: number;
+}
+
+/**
+ * Creates a zero-allocation WebAudio AnalyserNode with persistent Float32/Uint8 frequency & time buffers.
+ *
+ * @param ctx AudioContext instance.
+ * @param source Source AudioNode to connect from.
+ * @param options Analyser FFT configuration.
+ */
+export function createAudioAnalyser(
+  ctx: AudioContext,
+  source: AudioNode,
+  options: AnalyserOptions = {},
+): {
+  analyser: AnalyserNode;
+  getByteFrequencyData: () => Uint8Array;
+  getFloatFrequencyData: () => Float32Array;
+  getByteTimeDomainData: () => Uint8Array;
+  getFloatTimeDomainData: () => Float32Array;
+} {
+  const analyser = ctx.createAnalyser();
+  if (options.fftSize) analyser.fftSize = options.fftSize;
+  if (options.smoothingTimeConstant !== undefined) analyser.smoothingTimeConstant = options.smoothingTimeConstant;
+  if (options.minDecibels !== undefined) analyser.minDecibels = options.minDecibels;
+  if (options.maxDecibels !== undefined) analyser.maxDecibels = options.maxDecibels;
+
+  source.connect(analyser);
+
+  const binCount = analyser.frequencyBinCount;
+  const byteFreqBuffer = new Uint8Array(binCount);
+  const floatFreqBuffer = new Float32Array(binCount);
+  const byteTimeBuffer = new Uint8Array(binCount);
+  const floatTimeBuffer = new Float32Array(binCount);
+
+  onCleanup(() => {
+    source.disconnect(analyser);
+  });
+
+  return {
+    analyser,
+    getByteFrequencyData: () => {
+      analyser.getByteFrequencyData(byteFreqBuffer);
+      return byteFreqBuffer;
+    },
+    getFloatFrequencyData: () => {
+      analyser.getFloatFrequencyData(floatFreqBuffer);
+      return floatFreqBuffer;
+    },
+    getByteTimeDomainData: () => {
+      analyser.getByteTimeDomainData(byteTimeBuffer);
+      return byteTimeBuffer;
+    },
+    getFloatTimeDomainData: () => {
+      analyser.getFloatTimeDomainData(floatTimeBuffer);
+      return floatTimeBuffer;
+    },
+  };
+}

--- a/packages/audio/test/webaudio.test.ts
+++ b/packages/audio/test/webaudio.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createRoot, createSignal } from "solid-js";
+import { createAudioParam } from "../src/webaudio";
+
+describe("createAudioParam", () => {
+  it("schedules parameter value updates on signal transition", () => {
+    createRoot(dispose => {
+      const [gain, setGain] = createSignal(0.5);
+
+      const mockParam = {
+        value: 0.5,
+        context: { currentTime: 1.0 },
+        setValueAtTime: vi.fn(),
+        linearRampToValueAtTime: vi.fn(),
+        exponentialRampToValueAtTime: vi.fn(),
+        cancelScheduledValues: vi.fn(),
+      } as unknown as AudioParam;
+
+      createAudioParam(mockParam, gain, { ramp: "linear", timeConstant: 0.05 });
+
+      expect(mockParam.setValueAtTime).toHaveBeenCalledWith(0.5, 1.0);
+
+      setGain(0.8);
+      expect(mockParam.cancelScheduledValues).toHaveBeenCalledWith(1.0);
+      expect(mockParam.linearRampToValueAtTime).toHaveBeenCalledWith(0.8, 1.05);
+
+      dispose();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR extends `@solid-primitives/audio` with reactive WebAudio API primitives:

1. **`createAudioContext(options)`**: Lifecycle-bound `AudioContext` with auto-suspend when the document/tab is hidden (`visibilitychange`) and automatic `ctx.close()` on component unmount.
2. **`createAudioParam(param, signal, options)`**: Directly connects a SolidJS signal/accessor to a WebAudio `AudioParam` (`GainNode.gain`, `BiquadFilterNode.frequency`, etc.) using hardware-accurate `linearRampToValueAtTime` or `exponentialRampToValueAtTime` curves aligned with `ctx.currentTime` without GC allocation.
3. **`createAudioAnalyser(ctx, sourceNode, options)`**: Zero-allocation WebAudio FFT Analyser providing pre-allocated `Float32Array` and `Uint8Array` views for high-framerate visualizers.

## Changes
- `packages/audio/src/webaudio.ts`: Core WebAudio primitives implementation.
- `packages/audio/src/index.ts`: Re-export WebAudio APIs alongside existing HTMLAudio primitives.
- `packages/audio/test/webaudio.test.ts`: Vitest test suite.
- `.changeset/webaudio-primitives.md`: Minor changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SolidJS-integrated Web Audio utilities for creating and managing audio contexts.
  - Audio contexts can automatically suspend when the page is hidden and safely support server-rendered environments.
  - Added reactive `AudioParam` controls with instant, linear, and exponential automation.
  - Added analyser support with reusable frequency- and time-domain data buffers.
  - Resources are cleaned up automatically with their associated SolidJS owner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->