### PR TITLE
feat(signal-builders): add createDoubleBuffer for zero-allocation high-frequency array streaming

### DIFF
--- a/.changeset/signal-builders-double-buffer.md
+++ b/.changeset/signal-builders-double-buffer.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/signal-builders": minor
+---
+
+Add `createDoubleBuffer` for zero-allocation TypedArray / Array buffer swapping in high-frequency 60fps streams (WebGL, WebGPU, WebAudio, Canvas).

--- a/packages/signal-builders/src/buffer.ts
+++ b/packages/signal-builders/src/buffer.ts
@@ -1,0 +1,63 @@
+import { type Accessor, createSignal } from "solid-js";
+
+export type TypedOrPlainArray =
+  | Uint8Array
+  | Uint16Array
+  | Uint32Array
+  | Int8Array
+  | Int16Array
+  | Int32Array
+  | Float32Array
+  | Float64Array
+  | any[];
+
+/**
+ * Creates a zero-allocation double-buffered signal optimized for high-frequency (e.g. 60-120fps) streams such as WebGL, WebGPU, WebAudio, or canvas render loops.
+ *
+ * Rather than allocating a new array/buffer on every update, it maintains two pre-allocated buffers (front and back).
+ * The `update` function writes directly into the back buffer and then atomically swaps pointers while notifying subscribers via an internal version tick.
+ *
+ * @param bufferFactory Factory function returning a pre-allocated array or TypedArray buffer.
+ * @returns Tuple of [read: Accessor<T>, update: (writer: (back: T) => void) => void, peek: () => T]
+ *
+ * @example
+ * ```ts
+ * const [spectrum, updateSpectrum] = createDoubleBuffer(() => new Float32Array(512));
+ *
+ * // In animation frame loop - Zero GC allocation
+ * updateSpectrum((backBuffer) => {
+ *   analyser.getFloatFrequencyData(backBuffer);
+ * });
+ * ```
+ */
+export function createDoubleBuffer<T extends TypedOrPlainArray>(
+  bufferFactory: () => T,
+): [
+  read: Accessor<T>,
+  update: (writer: (backBuffer: T) => void) => void,
+  peek: () => T,
+] {
+  let front = bufferFactory();
+  let back = bufferFactory();
+
+  const [version, setVersion] = createSignal(0, { equals: false });
+
+  const read: Accessor<T> = () => {
+    version();
+    return front;
+  };
+
+  const peek = (): T => front;
+
+  const update = (writer: (backBuffer: T) => void): void => {
+    writer(back);
+    // Swap pointers
+    const temp = front;
+    front = back;
+    back = temp;
+
+    setVersion(v => v + 1);
+  };
+
+  return [read, update, peek];
+}

--- a/packages/signal-builders/src/index.ts
+++ b/packages/signal-builders/src/index.ts
@@ -2,7 +2,6 @@
 export * from "./convert.js";
 
 // STRING
-
 export * from "./string.js";
 
 // NUMBER
@@ -14,3 +13,6 @@ export * from "./array.js";
 // OBJECT
 export * from "./object.js";
 export * from "./update.js";
+
+// BUFFER
+export * from "./buffer.js";

--- a/packages/signal-builders/test/buffer.test.ts
+++ b/packages/signal-builders/test/buffer.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import { createEffect, createRoot } from "solid-js";
+import { createDoubleBuffer } from "../src/buffer";
+
+describe("createDoubleBuffer", () => {
+  it("initializes with bufferFactory data", () => {
+    createRoot(dispose => {
+      const [buffer] = createDoubleBuffer(() => new Float32Array([1, 2, 3]));
+      expect(buffer()).toEqual(new Float32Array([1, 2, 3]));
+      dispose();
+    });
+  });
+
+  it("updates buffer values without allocating new instances", () => {
+    createRoot(dispose => {
+      let allocationCount = 0;
+      const [buffer, updateBuffer] = createDoubleBuffer(() => {
+        allocationCount++;
+        return new Float32Array(3);
+      });
+
+      expect(allocationCount).toBe(2); // front and back
+
+      updateBuffer(back => {
+        back[0] = 10;
+        back[1] = 20;
+        back[2] = 30;
+      });
+
+      expect(buffer()).toEqual(new Float32Array([10, 20, 30]));
+      expect(allocationCount).toBe(2); // No new allocations during update
+
+      dispose();
+    });
+  });
+
+  it("triggers reactive effects on buffer swap", () => {
+    createRoot(dispose => {
+      const [buffer, updateBuffer] = createDoubleBuffer(() => new Uint8Array(2));
+      const effectFn = vi.fn();
+
+      createEffect(() => {
+        const current = buffer();
+        effectFn(current[0]);
+      });
+
+      expect(effectFn).toHaveBeenCalledWith(0);
+
+      updateBuffer(back => {
+        back[0] = 42;
+      });
+
+      expect(effectFn).toHaveBeenCalledWith(42);
+      expect(effectFn).toHaveBeenCalledTimes(2);
+
+      dispose();
+    });
+  });
+
+  it("supports peek() for reading current buffer untracked", () => {
+    createRoot(dispose => {
+      const [, updateBuffer, peek] = createDoubleBuffer(() => new Float32Array([5, 6]));
+
+      expect(peek()).toEqual(new Float32Array([5, 6]));
+
+      updateBuffer(back => {
+        back[0] = 99;
+      });
+
+      expect(peek()[0]).toBe(99);
+      dispose();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds `createDoubleBuffer` to `@solid-primitives/signal-builders`:

- **Zero-GC High-Frequency Stream Updates**: Designed for 60-120fps streaming sources (WebGL vertex updates, WebGPU compute buffers, WebAudio FFT analysers, Canvas 2D render loops, and sensor telemetry).
- **Pointer Swapping Architecture**: Maintains two pre-allocated buffers (front and back). The `update` function writes into the back buffer and swaps pointers atomically while triggering reactive subscribers via an internal non-allocating version signal.
- **Full Array & TypedArray Support**: Works seamlessly with `Float32Array`, `Uint8Array`, `Int32Array`, and standard JS arrays.

## Changes
- `packages/signal-builders/src/buffer.ts`: `createDoubleBuffer` implementation.
- `packages/signal-builders/src/index.ts`: Re-export `createDoubleBuffer` and `TypedOrPlainArray`.
- `packages/signal-builders/test/buffer.test.ts`: Vitest test suite.
- `.changeset/signal-builders-double-buffer.md`: Minor changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a double-buffer utility for efficient, reactive updates to typed or plain arrays.
  * Supports in-place updates, buffer swapping, reactive reads, and non-reactive peeking.
* **Documentation**
  * Added release notes for the new double-buffer API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->