### PR TITLE
feat(tween): add createSpringTween and createVectorTween primitives

### DIFF
--- a/.changeset/tween-spring-vector.md
+++ b/.changeset/tween-spring-vector.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/tween": minor
+---
+
+Add `createSpringTween` for spring physics animations and `createVectorTween` for multi-property coordinate and vector tweening.

--- a/packages/tween/src/index.ts
+++ b/packages/tween/src/index.ts
@@ -1,6 +1,9 @@
 import { createSignal, createEffect, onCleanup, on } from "solid-js";
 import { isServer } from "solid-js/web";
 
+export * from "./spring.js";
+export * from "./vector.js";
+
 export type TweenProps = {
   duration?: number;
   ease?: (t: number) => number;

--- a/packages/tween/src/spring.ts
+++ b/packages/tween/src/spring.ts
@@ -1,0 +1,96 @@
+import { createSignal, createEffect, onCleanup, on, type Accessor } from "solid-js";
+import { isServer } from "solid-js/web";
+
+export interface SpringOptions {
+  /**
+   * Spring stiffness coefficient (0.01 - 1.0).
+   * @default 0.15
+   */
+  stiffness?: number;
+  /**
+   * Spring damping coefficient (0.1 - 1.0).
+   * @default 0.8
+   */
+  damping?: number;
+  /**
+   * Velocity threshold below which the spring settles and halts the RAF loop.
+   * @default 0.001
+   */
+  precision?: number;
+}
+
+/**
+ * Creates a reactive numeric spring physics animation accessor.
+ * Automatically halts the RAF loop when velocity and distance fall below precision threshold.
+ *
+ * @param target Accessor providing target numeric position.
+ * @param options Stiffness, damping, and precision configurations.
+ *
+ * @example
+ * ```ts
+ * const [x, setX] = createSignal(0);
+ * const springX = createSpringTween(x, { stiffness: 0.2, damping: 0.75 });
+ * ```
+ */
+export function createSpringTween(
+  target: Accessor<number>,
+  options: SpringOptions = {},
+): Accessor<number> {
+  if (isServer) {
+    return target;
+  }
+
+  const stiffness = options.stiffness ?? 0.15;
+  const damping = options.damping ?? 0.8;
+  const precision = options.precision ?? 0.001;
+
+  const [current, setCurrent] = createSignal(target());
+  let currentVal = target();
+  let velocity = 0;
+  let cancelId: number | null = null;
+
+  function tick() {
+    const dest = target();
+    const force = (dest - currentVal) * stiffness;
+    velocity = (velocity + force) * damping;
+    currentVal += velocity;
+
+    if (Math.abs(velocity) < precision && Math.abs(dest - currentVal) < precision) {
+      currentVal = dest;
+      velocity = 0;
+      setCurrent(dest);
+      cancelId = null;
+      return;
+    }
+
+    setCurrent(currentVal);
+    cancelId = requestAnimationFrame(tick);
+  }
+
+  createEffect(
+    on(
+      target,
+      () => {
+        if (cancelId === null) {
+          cancelId = requestAnimationFrame(tick);
+        }
+        onCleanup(() => {
+          if (cancelId !== null) {
+            cancelAnimationFrame(cancelId);
+            cancelId = null;
+          }
+        });
+      },
+      { defer: true },
+    ),
+  );
+
+  onCleanup(() => {
+    if (cancelId !== null) {
+      cancelAnimationFrame(cancelId);
+      cancelId = null;
+    }
+  });
+
+  return current;
+}

--- a/packages/tween/src/vector.ts
+++ b/packages/tween/src/vector.ts
@@ -1,0 +1,88 @@
+import { createSignal, createEffect, onCleanup, on, type Accessor } from "solid-js";
+import { isServer } from "solid-js/web";
+
+export type VectorRecord = Record<string, number>;
+
+export interface VectorTweenProps {
+  duration?: number;
+  ease?: (t: number) => number;
+}
+
+/**
+ * Creates a multi-property vector / object tween method for animating 2D/3D coordinates or multi-property states.
+ *
+ * @param target Accessor returning an object with numeric properties (e.g. { x: 10, y: 20 }).
+ * @param options Duration and easing curve function.
+ *
+ * @example
+ * ```ts
+ * const [coords, setCoords] = createSignal({ x: 0, y: 0 });
+ * const tweened = createVectorTween(coords, { duration: 300 });
+ * ```
+ */
+export function createVectorTween<T extends VectorRecord>(
+  target: Accessor<T>,
+  { ease = (t: number) => t, duration = 100 }: VectorTweenProps = {},
+): Accessor<T> {
+  if (isServer) {
+    return target;
+  }
+
+  const initial = target();
+  const [current, setCurrent] = createSignal<T>({ ...initial });
+
+  let start: number;
+  let startValues: T;
+  let cancelId: number | null = null;
+
+  function tick(t: number) {
+    const elapsed = t - start;
+    const progress = Math.min(elapsed / duration, 1);
+    const easedProgress = ease(progress);
+
+    const dest = target();
+    const next = {} as T;
+
+    for (const key of Object.keys(dest) as (keyof T)[]) {
+      const s = startValues[key] ?? 0;
+      const d = dest[key] ?? 0;
+      next[key] = (s + (d - s) * easedProgress) as T[keyof T];
+    }
+
+    setCurrent(next);
+
+    if (progress < 1) {
+      cancelId = requestAnimationFrame(tick);
+    } else {
+      cancelId = null;
+    }
+  }
+
+  createEffect(
+    on(
+      target,
+      () => {
+        start = performance.now();
+        startValues = { ...current() };
+        if (cancelId !== null) cancelAnimationFrame(cancelId);
+        cancelId = requestAnimationFrame(tick);
+        onCleanup(() => {
+          if (cancelId !== null) {
+            cancelAnimationFrame(cancelId);
+            cancelId = null;
+          }
+        });
+      },
+      { defer: true },
+    ),
+  );
+
+  onCleanup(() => {
+    if (cancelId !== null) {
+      cancelAnimationFrame(cancelId);
+      cancelId = null;
+    }
+  });
+
+  return current;
+}

--- a/packages/tween/test/vector.test.ts
+++ b/packages/tween/test/vector.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { createRoot, createSignal } from "solid-js";
+import { createVectorTween } from "../src/vector";
+
+describe("createVectorTween", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("initializes with target vector coordinates", () => {
+    createRoot(dispose => {
+      const [pos] = createSignal({ x: 10, y: 20 });
+      const tweened = createVectorTween(pos, { duration: 200 });
+      expect(tweened()).toEqual({ x: 10, y: 20 });
+      dispose();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This PR extends `@solid-primitives/tween` with two animation primitives:

1. **`createSpringTween(target, options)`**: Reactive spring physics animation engine (`stiffness`, `damping`, `precision`). Automatically halts the RAF loop when velocity and distance fall below threshold.
2. **`createVectorTween(target, options)`**: Multi-property object and coordinate vector tweening (e.g. `{ x: number, y: number, ... }` or multi-property records) with customizable easing curves and durations.

## Changes
- `packages/tween/src/spring.ts`: Spring physics solver.
- `packages/tween/src/vector.ts`: Multi-property vector interpolation engine.
- `packages/tween/src/index.ts`: Re-export spring & vector tween functions alongside default scalar tween.
- `packages/tween/test/vector.test.ts`: Vitest test suite.
- `.changeset/tween-spring-vector.md`: Minor changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added spring-based numeric animations with configurable stiffness, damping, and precision.
  * Added vector animations for smoothly interpolating multiple numeric properties.
  * Both animation utilities support customizable timing and easing options where applicable.

* **Tests**
  * Added coverage verifying vector animations initialize with the target coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->