### PR TITLE
feat(devices): add createWakeLock, createVibration, and createScreenOrientation primitives

### DIFF
--- a/.changeset/devices-wakelock-vibration-orientation.md
+++ b/.changeset/devices-wakelock-vibration-orientation.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/devices": minor
+---
+
+Add Screen Wake Lock (`createWakeLock`), Haptics / Vibration (`createVibration`), and Screen Orientation (`createScreenOrientation`) reactive primitives.

--- a/packages/devices/src/index.ts
+++ b/packages/devices/src/index.ts
@@ -2,6 +2,10 @@ import { createMemo, createSignal, getOwner, onCleanup } from "solid-js";
 import { isServer } from "solid-js/web";
 import { createStore } from "solid-js/store";
 
+export * from "./wakelock.js";
+export * from "./vibration.js";
+export * from "./orientation.js";
+
 /**
  * Creates a list of all media devices
  *

--- a/packages/devices/src/orientation.ts
+++ b/packages/devices/src/orientation.ts
@@ -1,0 +1,64 @@
+import { createSignal, onCleanup, type Accessor } from "solid-js";
+import { isServer } from "solid-js/web";
+
+export interface ScreenOrientationState {
+  angle: number;
+  type: OrientationType;
+}
+
+export interface ScreenOrientationReturn {
+  isSupported: boolean;
+  orientation: Accessor<ScreenOrientationState>;
+  lock: (orientation: OrientationLockType) => Promise<void>;
+  unlock: () => void;
+}
+
+/**
+ * Reactive Screen Orientation API wrapper.
+ * Observes device orientation state (`portrait-primary`, `landscape-primary`, angle) and provides programmatic orientation locking.
+ *
+ * @example
+ * ```ts
+ * const { orientation, lock, unlock } = createScreenOrientation();
+ * console.log(orientation().type);
+ * ```
+ */
+export function createScreenOrientation(): ScreenOrientationReturn {
+  if (isServer || typeof screen === "undefined" || !("orientation" in screen)) {
+    const fallback: Accessor<ScreenOrientationState> = () => ({
+      angle: 0,
+      type: "portrait-primary",
+    });
+    return {
+      isSupported: false,
+      orientation: fallback,
+      lock: async () => {},
+      unlock: () => {},
+    };
+  }
+
+  const screenOrientation = screen.orientation;
+  const [orientation, setOrientation] = createSignal<ScreenOrientationState>({
+    angle: screenOrientation.angle,
+    type: screenOrientation.type,
+  });
+
+  const update = () => {
+    setOrientation({
+      angle: screenOrientation.angle,
+      type: screenOrientation.type,
+    });
+  };
+
+  screenOrientation.addEventListener("change", update);
+  onCleanup(() => {
+    screenOrientation.removeEventListener("change", update);
+  });
+
+  return {
+    isSupported: true,
+    orientation,
+    lock: (lockType: OrientationLockType) => screenOrientation.lock(lockType),
+    unlock: () => screenOrientation.unlock(),
+  };
+}

--- a/packages/devices/src/vibration.ts
+++ b/packages/devices/src/vibration.ts
@@ -1,0 +1,50 @@
+import { isServer } from "solid-js/web";
+
+export type VibrationPattern = number | number[];
+
+export interface VibrationReturn {
+  isSupported: boolean;
+  vibrate: (pattern: VibrationPattern) => boolean;
+  stop: () => boolean;
+}
+
+/**
+ * Reactive Vibration / Haptics API wrapper.
+ * Provides tactile pulse feedback for mobile buttons, toggles, success/error confirmations, and game interactions.
+ *
+ * @example
+ * ```ts
+ * const { isSupported, vibrate, stop } = createVibration();
+ * vibrate(100); // 100ms pulse
+ * vibrate([100, 50, 100]); // double pulse
+ * ```
+ */
+export function createVibration(): VibrationReturn {
+  if (isServer || typeof navigator === "undefined" || !("vibrate" in navigator)) {
+    return {
+      isSupported: false,
+      vibrate: () => false,
+      stop: () => false,
+    };
+  }
+
+  return {
+    isSupported: true,
+    vibrate: (pattern: VibrationPattern) => {
+      try {
+        return navigator.vibrate(pattern);
+      }
+      catch {
+        return false;
+      }
+    },
+    stop: () => {
+      try {
+        return navigator.vibrate(0);
+      }
+      catch {
+        return false;
+      }
+    },
+  };
+}

--- a/packages/devices/src/wakelock.ts
+++ b/packages/devices/src/wakelock.ts
@@ -1,0 +1,82 @@
+import { createSignal, onCleanup, type Accessor } from "solid-js";
+import { isServer } from "solid-js/web";
+
+export interface WakeLockReturn {
+  isSupported: boolean;
+  isActive: Accessor<boolean>;
+  request: () => Promise<boolean>;
+  release: () => Promise<void>;
+}
+
+/**
+ * Reactive Screen Wake Lock API wrapper.
+ * Prevents device screens from dimming or locking during active workflows (e.g. video playback, timers, workouts, kiosks).
+ * Automatically releases lock on component cleanup and re-acquires on document visibility recovery.
+ *
+ * @example
+ * ```ts
+ * const { isSupported, isActive, request, release } = createWakeLock();
+ * ```
+ */
+export function createWakeLock(): WakeLockReturn {
+  if (isServer || typeof navigator === "undefined" || !("wakeLock" in navigator)) {
+    return {
+      isSupported: false,
+      isActive: () => false,
+      request: async () => false,
+      release: async () => {},
+    };
+  }
+
+  const [isActive, setIsActive] = createSignal(false);
+  let sentinel: WakeLockSentinel | null = null;
+  let requested = false;
+
+  const request = async (): Promise<boolean> => {
+    requested = true;
+    try {
+      if (sentinel && !sentinel.released) {
+        setIsActive(true);
+        return true;
+      }
+      sentinel = await navigator.wakeLock.request("screen");
+      sentinel.addEventListener("release", () => {
+        setIsActive(false);
+      });
+      setIsActive(true);
+      return true;
+    } catch {
+      setIsActive(false);
+      return false;
+    }
+  };
+
+  const release = async (): Promise<void> => {
+    requested = false;
+    if (sentinel && !sentinel.released) {
+      await sentinel.release();
+    }
+    sentinel = null;
+    setIsActive(false);
+  };
+
+  const onVisibilityChange = () => {
+    if (document.visibilityState === "visible" && requested) {
+      void request();
+    }
+  };
+
+  document.addEventListener("visibilitychange", onVisibilityChange);
+
+  onCleanup(() => {
+    document.removeEventListener("visibilitychange", onVisibilityChange);
+    void release();
+  });
+
+  return {
+    isSupported: true,
+    isActive,
+    request,
+    release,
+  };
+}

--- a/packages/devices/test/devices-extras.test.ts
+++ b/packages/devices/test/devices-extras.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { createVibration } from "../src/vibration";
+import { createWakeLock } from "../src/wakelock";
+import { createScreenOrientation } from "../src/orientation";
+
+describe("createVibration", () => {
+  it("returns safe fallback in non-supported environments", () => {
+    const { isSupported, vibrate, stop } = createVibration();
+    expect(typeof isSupported).toBe("boolean");
+    expect(typeof vibrate).toBe("function");
+    expect(typeof stop).toBe("function");
+  });
+});
+
+describe("createWakeLock", () => {
+  it("returns safe fallback in non-supported environments", () => {
+    const { isSupported, isActive, request, release } = createWakeLock();
+    expect(typeof isSupported).toBe("boolean");
+    expect(typeof isActive).toBe("function");
+    expect(typeof request).toBe("function");
+    expect(typeof release).toBe("function");
+  });
+});
+
+describe("createScreenOrientation", () => {
+  it("returns safe fallback in non-supported environments", () => {
+    const { isSupported, orientation, lock, unlock } = createScreenOrientation();
+    expect(typeof isSupported).toBe("boolean");
+    expect(typeof orientation).toBe("function");
+    expect(typeof lock).toBe("function");
+    expect(typeof unlock).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

This PR expands `@solid-primitives/devices` with 3 mobile & kiosk hardware primitives:

1. **`createWakeLock()`**: Screen Wake Lock API wrapper preventing screen dimming/locking during active presentations, timers, audio/video playback, and kiosk check-ins. Auto-releases on cleanup and re-acquires upon visibility recovery.
2. **`createVibration()`**: Tactile Vibration & Haptics API wrapper for mobile buttons, toggles, success/error confirmations, and game interactions.
3. **`createScreenOrientation()`**: Reactive Screen Orientation API wrapper observing orientation changes (`portrait-primary`, `landscape-primary`, angle) with programmatic `lock()` and `unlock()` capabilities.

## Changes
- `packages/devices/src/wakelock.ts`: Wake lock implementation.
- `packages/devices/src/vibration.ts`: Vibration / haptics implementation.
- `packages/devices/src/orientation.ts`: Screen orientation implementation.
- `packages/devices/src/index.ts`: Re-exported new primitives.
- `packages/devices/test/devices-extras.test.ts`: Vitest test suite.
- `.changeset/devices-wakelock-vibration-orientation.md`: Minor changeset.