### PR TITLE
fix: Guard against unresolved catalog:/workspace: protocols

### DIFF
--- a/.changeset/fix-catalog-protocol-republish.md
+++ b/.changeset/fix-catalog-protocol-republish.md
@@ -1,0 +1,6 @@
+---
+"@solid-primitives/event-listener": patch
+"@solid-primitives/pagination": patch
+---
+
+Republish only, no functional changes. `event-listener@3.0.0-next.4` and `pagination@1.0.0-next.7` were accidentally published to npm with an unresolved pnpm workspace-catalog protocol string (`"catalog:peer"`) left in `peerDependencies`, instead of a resolved semver range. npm and yarn have no concept of the `catalog:` protocol, so installing either of those exact versions fails with `EUNSUPPORTEDPROTOCOL`. This release republishes both packages with `peerDependencies` correctly resolved (e.g. `"solid-js": "^2.0.0-rc.0"`). If you're on `event-listener@3.0.0-next.4` or `pagination@1.0.0-next.7`, upgrade to this version or later.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Build all packages
         run: pnpm build
 
+      - name: Verify no unresolved workspace protocols in packed manifests
+        run: pnpm run verify:manifests
+
       - name: Lint
         # Will run the step even if build step failed
         if: success() || failure()

--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "jsr:sync-versions:check": "node --import=@nothing-but/node-resolve-ts --experimental-transform-types ./scripts/sync-jsr-versions.ts --check",
     "update-readme": "node --import=@nothing-but/node-resolve-ts --experimental-transform-types ./scripts/update-readme.ts",
     "measure": "node --import=@nothing-but/node-resolve-ts --experimental-transform-types ./scripts/measure.ts",
+    "verify:manifests": "node --import=@nothing-but/node-resolve-ts --experimental-transform-types ./scripts/verify-published-manifests.ts",
     "version": "changeset version && pnpm jsr:sync-versions && pnpm i --no-frozen-lockfile && git add .",
-    "release": "pnpm build && changeset publish",
-    "release-tagged": "pnpm build && if [ -f .changeset/pre.json ]; then changeset publish; else changeset publish --tag \"$BRANCH_NAME\"; fi"
+    "release": "pnpm build && pnpm run verify:manifests && changeset publish",
+    "release-tagged": "pnpm build && pnpm run verify:manifests && if [ -f .changeset/pre.json ]; then changeset publish; else changeset publish --tag \"$BRANCH_NAME\"; fi"
   },
   "devDependencies": {
     "@babel/core": "catalog:",

--- a/scripts/verify-published-manifests.ts
+++ b/scripts/verify-published-manifests.ts
@@ -1,0 +1,72 @@
+// Guards against unresolved pnpm workspace-protocol strings (`catalog:`,
+// `catalog:<name>`, `workspace:`) making it into a package's PUBLISHED
+// manifest. Source package.json files are expected to contain these
+// protocols — pnpm resolves them at pack/publish time. This script actually
+// packs every package (via `pnpm pack`, the same manifest-resolution path
+// `pnpm publish` uses) and inspects the packed package/package.json, not the
+// source file, so it only fails on a genuine resolution failure.
+//
+// Background: @solid-primitives/event-listener@3.0.0-next.4 and
+// @solid-primitives/pagination@1.0.0-next.7 were published to npm with
+// literal "catalog:peer" strings left in peerDependencies, which breaks
+// plain npm/yarn installs (EUNSUPPORTEDPROTOCOL). See
+// https://github.com/solidjs-community/solid-primitives/issues/1052.
+//
+// Usage: pnpm run verify:manifests
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const DEP_FIELDS = ["dependencies", "devDependencies", "peerDependencies", "optionalDependencies"] as const;
+const BAD_PROTOCOLS = ["catalog:", "workspace:"];
+
+type PackedPackage = { name: string; version: string; filename: string };
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "verify-manifests-"));
+
+let packed: PackedPackage[];
+try {
+  const output = execFileSync(
+    "pnpm",
+    ["pack", "--recursive", "--json", "--pack-destination", tmpDir],
+    { cwd: repoRoot, encoding: "utf8", maxBuffer: 1024 * 1024 * 64 },
+  );
+  packed = JSON.parse(output);
+} catch (err) {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  throw err;
+}
+
+const failures: string[] = [];
+
+for (const pkg of packed) {
+  const manifestText = execFileSync("tar", ["-xzO", "-f", pkg.filename, "package/package.json"], {
+    encoding: "utf8",
+  });
+  const manifest = JSON.parse(manifestText);
+
+  for (const field of DEP_FIELDS) {
+    const deps = manifest[field];
+    if (!deps) continue;
+    for (const [dep, range] of Object.entries(deps)) {
+      if (typeof range === "string" && BAD_PROTOCOLS.some(p => range.startsWith(p))) {
+        failures.push(`${pkg.name}@${pkg.version} ${field}.${dep} = "${range}"`);
+      }
+    }
+  }
+}
+
+fs.rmSync(tmpDir, { recursive: true, force: true });
+
+if (failures.length > 0) {
+  console.error("Unresolved workspace-protocol strings found in packed manifests:\n");
+  for (const f of failures) console.error(`  - ${f}`);
+  console.error(
+    "\nThese packages would be published to npm broken (npm/yarn can't resolve `catalog:`/`workspace:`). Aborting release.",
+  );
+  process.exit(1);
+}
+
+console.log(`Verified ${packed.length} packed manifests: no unresolved workspace protocols.`);


### PR DESCRIPTION
Before writing a fix I checked the actual scope and cause directly against the npm registry, rather than assuming this affects every package that uses the `catalog:peer` pattern (it doesn't — ~97 packages use that pattern in source, but most haven't been re-published since the catalog migration and were never at risk):

- **Confirmed exactly two published versions are broken**: `event-listener@3.0.0-next.4` and `pagination@1.0.0-next.7`, both bumped in the same "Version Packages" commit — the most recent one on `next`. Nothing else has published since.
- **Reproduced the exact same tooling locally** (pnpm `11.9.0`, pinned via `packageManager`, unchanged since that commit) — both `pnpm pack` and `pnpm publish --dry-run` correctly resolve `catalog:peer` → `^2.0.0-rc.0` today, from the exact same source files. This isn't a currently-reproducible bug in the repo's config.
- **Ruled out the obvious CI suspect**: a `npm install -g npm@latest` step (for npm OIDC trusted publishing) sitting right before the publish step. Confirmed via git history that this step didn't exist yet at the commit that produced the broken publish — it postdates the incident, so it can't be the cause.
- **Conclusion**: root cause isn't conclusively provable after the fact — this looks like a one-off CI/environment flake in that specific run. Rather than chase an unprovable cause further, the fix targets the failure mode itself: an unresolved protocol string reaching a published manifest, regardless of why.

### Fix

1. **`scripts/verify-published-manifests.ts`** (new) — packs the entire workspace in one call (`pnpm pack -r --json`), reads every packed `package/package.json` (the manifest exactly as it would land on npm, not the source file), and fails with a precise `package@version field.dep = "value"` message if any dependency field still contains an unresolved `catalog:`/`workspace:` string.
2. Wired into `pnpm run release` / `release-tagged` (right after `pnpm build`, before `changeset publish`) — fails closed, so a bad manifest never reaches `npm publish`.
3. Also added to `tests.yml` so this is checked on every PR, not just at release time (this PR itself exercises it in CI).
4. Changeset republishes `event-listener` (`next.4` → `next.5`) and `pagination` (`next.7` → `next.8`) with `peerDependencies` correctly resolved. No functional changes in either package.

### Testing

- Ran the script against the real current workspace (102 packages): passes clean, 0 unresolved protocol strings.
- Tested the detection logic in isolation against a synthetic manifest matching the exact broken shape from this issue — correctly flags it — and against a correctly-resolved manifest — no false positive.
- Could not force a live repro of the original failure (pnpm resolves correctly for me locally with matching tooling), so verification is necessarily "the guard is correct and fires on the known-bad shape," not "reproduced and fixed the exact original trigger."

### Notes

- The npm OIDC step mentioned above is unrelated to this fix (confirmed to postdate the incident) — not touched here, and shouldn't be read as related if it comes up in review.
- Once merged, the changeset triggers the normal "Version Packages (next)" PR; merging *that* runs `release-tagged.yml` with the new guard in place. If resolution behaves as it does locally, it publishes cleanly; if not, the job fails before `changeset publish` ever runs, with an exact error instead of silently shipping broken again.

Closes #1052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Republished `@solid-primitives/event-listener` and `@solid-primitives/pagination` with corrected dependency metadata.
  - Fixed installation failures in npm and Yarn caused by unresolved workspace protocol references.
  - No functional behavior changes are included in these releases.

- **Chores**
  - Added automated checks to prevent unresolved dependency protocols from being included in future published packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->