### PR TITLE
fix(upload/createDropzone): correct event handler for drags

### DIFF
--- a/.changeset/afraid-mails-cry.md
+++ b/.changeset/afraid-mails-cry.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/upload": minor
+---
+
+`createDropzone`: corrected `isDragging` signal & removed unnecessary props

--- a/packages/upload/src/createDropzone.ts
+++ b/packages/upload/src/createDropzone.ts
@@ -48,32 +48,23 @@ function createDropzone<T extends HTMLElement = HTMLElement>(
     ref = r;
   };
 
-  const onDragStart: JSX.EventHandler<T, DragEvent> = event => {
-    setIsDragging(true);
-    Promise.resolve(options?.onDragStart?.(transformFiles(event.dataTransfer?.files || null)));
-  };
-  const onDragEnd: JSX.EventHandler<T, DragEvent> = event => {
-    setIsDragging(false);
-    Promise.resolve(options?.onDragEnd?.(transformFiles(event.dataTransfer?.files || null)));
-  };
-
   const onDragEnter: JSX.EventHandler<T, DragEvent> = event => {
+    setIsDragging(true);
     Promise.resolve(options?.onDragEnter?.(transformFiles(event.dataTransfer?.files || null)));
   };
   const onDragLeave: JSX.EventHandler<T, DragEvent> = event => {
+    setIsDragging(false);
     Promise.resolve(options?.onDragLeave?.(transformFiles(event.dataTransfer?.files || null)));
   };
   const onDragOver: JSX.EventHandler<T, DragEvent> = event => {
     event.preventDefault();
     Promise.resolve(options?.onDragOver?.(transformFiles(event.dataTransfer?.files || null)));
   };
-  const onDrag: JSX.EventHandler<T, DragEvent> = event => {
-    Promise.resolve(options?.onDrag?.(transformFiles(event.dataTransfer?.files || null)));
-  };
 
   const onDrop: JSX.EventHandler<T, DragEvent> = event => {
     event.preventDefault();
 
+    setIsDragging(false)
     const parsedFiles = transformFiles(event.dataTransfer?.files || null);
     setFiles(parsedFiles);
 
@@ -84,21 +75,15 @@ function createDropzone<T extends HTMLElement = HTMLElement>(
     if (!ref) return;
 
     // TODO: Should event.stopPropagation() or event.preventDefault() in handlers below?
-    ref.addEventListener("dragstart", onDragStart as any);
     ref.addEventListener("dragenter", onDragEnter as any);
-    ref.addEventListener("dragend", onDragEnd as any);
     ref.addEventListener("dragleave", onDragLeave as any);
     ref.addEventListener("dragover", onDragOver as any);
-    ref.addEventListener("drag", onDrag as any);
     ref.addEventListener("drop", onDrop as any);
 
     onCleanup(() => {
-      ref?.removeEventListener("dragstart", onDragStart as any);
       ref?.removeEventListener("dragenter", onDragEnter as any);
-      ref?.removeEventListener("dragend", onDragEnd as any);
       ref?.removeEventListener("dragleave", onDragLeave as any);
       ref?.removeEventListener("dragover", onDragOver as any);
-      ref?.removeEventListener("drag", onDrag as any);
       ref?.removeEventListener("drop", onDrop as any);
     });
   });

--- a/packages/upload/src/types.ts
+++ b/packages/upload/src/types.ts
@@ -48,10 +48,7 @@ export interface Dropzone<T extends HTMLElement = HTMLElement> {
  */
 export interface DropzoneOptions {
   onDrop?: UserCallback;
-  onDragStart?: UserCallback;
   onDragEnter?: UserCallback;
-  onDragEnd?: UserCallback;
   onDragLeave?: UserCallback;
   onDragOver?: UserCallback;
-  onDrag?: UserCallback;
 }


### PR DESCRIPTION
This PR removes unnecessary events handler & corrects event handler / internal state of the `createDropzone` primitive.

I've noticed that when using the `createDropzone` hook, the hook misbehaves. After debugging for a while, I noticed that the hook actually binds to the wrong / unnecessary event for a usage of a "dropzone".

### Extra note

Please do sanity check me here as I'm actually kinda unsure :/
- `dragStart`, `drag` and `dragEnd` are events that are for when the Element itself is being dragged; not when something is being dragged onto it.
- Those events should not be relevant at all on a hook called `createDropzone` on the package `upload` and can be removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop state handling so visual dragging feedback starts and ends reliably when files enter, leave, or are dropped in the upload area.
  * Removed redundant drag event handling to provide more consistent dropzone behavior.

* **API Changes**
  * Removed support for the `onDragStart`, `onDragEnd`, and `onDrag` dropzone callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->