### PR TITLE
feat(upload/transformFiles): remove unnecessary validation

### DIFF
--- a/.changeset/fine-kids-grin.md
+++ b/.changeset/fine-kids-grin.md
@@ -1,0 +1,5 @@
+---
+"@solid-primitives/upload": patch
+---
+
+`helper`: rework `transformFiles` internal function to remove unneeded checks

--- a/packages/upload/src/helpers.ts
+++ b/packages/upload/src/helpers.ts
@@ -14,29 +14,20 @@ export function createInputComponent({ multiple = false, accept = "" }: FileUplo
 }
 
 export function transformFiles(files: FileList | null): UploadFile[] {
-  const parsedFiles: UploadFile[] = [];
+  if (!files) return [];
 
-  if (!files) return parsedFiles;
-
-  for (const index in files) {
-    const fileIndex = +index;
-    if (isNaN(+fileIndex)) {
-      continue;
-    }
-
-    const file = files[fileIndex];
-    if (!file) {
-      continue;
-    }
-
-    const parsedFile: UploadFile = {
+  const parsed: UploadFile[] = []
+  for (const idx in files) {
+    // SAFETY: w3c File API defines FileList item access to be valid from index 0 to `files.length - 1`
+    // https://w3c.github.io/FileAPI/#filelist-methods-params: "Supported property indices are the numbers in the range zero to one less than the number of File objects represented by the FileList object."
+    const file = files[Number(idx)]!
+    parsed.push({
       source: URL.createObjectURL(file),
       name: file.name,
       size: file.size,
       file,
-    };
-    parsedFiles.push(parsedFile);
+    });
   }
 
-  return parsedFiles;
+  return parsed;
 }


### PR DESCRIPTION
The current `transformFiles` function does an unnecessary check for a valid file index number / file existing in an index. This PR removes it.

I've consulted [the W3C reference](https://w3c.github.io/FileAPI/#filelist-section):
- Indices of `FileList` "are the numbers in the range zero to one less than the number of [File](https://w3c.github.io/FileAPI/#dfn-file) objects"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop state tracking so the dragging indicator updates correctly when entering, leaving, or dropping files.
  * Improved file processing for dropped or selected files, including safer handling of empty input.
* **API Changes**
  * Removed the `onDragStart`, `onDragEnd`, and `onDrag` dropzone callbacks.
  * Continued support for `onDragEnter`, `onDragLeave`, and `onDragOver` callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->